### PR TITLE
docs: add lowercase guideline for PR name ✏️

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,9 @@ Some things to keep in mind when making a pull request:
     - `docs`: A change only to in-code or markdown documentation.
     - `test`: A change that adds missing tests.
     - `chore`: A change that is likely none of the above.
-  - Be present tense (ie: "Fix", not "Fixed").
-  - Start with a verb (ie: "Fix ....", "Add ...", "Implement ...").
+  - Be in all lowercase.
+  - Be present tense (ie: "fix", not "fixed").
+  - Start with a verb (ie: "add ...", "implement ...", "update ...").
   - Have an emoji at the end of it (we like color around here). 🔥
 - Each PR should be attached to an issue, so be sure to add this to the PR
   description:


### PR DESCRIPTION
## Description ✏️

Adds a guideline to contributing PR, which is to make the PR name all lowercase.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [x] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
