### PR TITLE
fix: remove need for transpilation in `db:seed` 🌱

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ Now that we have some tables, we're ready to add some seed data in our database,
 which will enable you to log into the Admin Dashboard and Member Profile. Run:
 
 ```sh
-yarn workspace @colorstack/core db:seed
+yarn db:seed
 ```
 
 Follow the prompt to add your email, and you will now be able to log into both

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build --cache-dir=.turbo",
     "db:migrate": "yarn workspace @colorstack/core db:migrate",
+    "db:seed": "yarn workspace @colorstack/core db:seed",
     "dev": "turbo run dev --cache-dir=.turbo",
     "dev:apps": "yarn dev --filter='./apps/*'",
     "lint": "turbo run lint --cache-dir=.turbo",

--- a/packages/core/src/infrastructure/database/scripts/seed.ts
+++ b/packages/core/src/infrastructure/database/scripts/seed.ts
@@ -1,9 +1,6 @@
 import { sql } from 'kysely';
 import readline from 'readline';
 
-import { EducationLevel, Email, Major } from '@colorstack/types';
-import { id } from '@colorstack/utils';
-
 import { ENV } from '@/shared/env';
 import { createDatabaseConnection } from '../shared/create-database-connection';
 import { migrate } from '../shared/migrate';
@@ -114,14 +111,14 @@ async function seed() {
           acceptedAt: new Date(),
           currentLocation: 'New York, NY',
           currentLocationCoordinates: sql`point(-73.935242, 40.73061)`,
-          educationLevel: EducationLevel.UNDERGRADUATE,
+          educationLevel: 'undergraduate',
           email,
           firstName: 'First',
           gender: '',
           graduationYear: new Date().getFullYear().toString(),
           id: memberId,
           lastName: 'Last',
-          major: Major.COMPUTER_SCIENCE,
+          major: 'computer_science',
           otherDemographics: [],
           race: [],
           schoolId: schoolId1,
@@ -138,18 +135,10 @@ async function seed() {
 }
 
 async function setEmailFromCommandLine() {
-  const answer = await question(
+  email = await question(
     'In order to log into the Member Profile and Admin Dashboard, you will need both a member record and an admin record. Please provide an email so we can create those for you.\n' +
       'Email: '
   );
-
-  const result = Email.safeParse(answer);
-
-  if (!result.success) {
-    throw new Error('The email you provided was invalid.');
-  }
-
-  email = result.data;
 }
 
 async function question(prompt: string) {
@@ -164,6 +153,13 @@ async function question(prompt: string) {
       cli.close();
     });
   });
+}
+
+let idCounter = 0;
+
+function id() {
+  idCounter++;
+  return idCounter.toString();
 }
 
 main();

--- a/packages/core/src/infrastructure/database/scripts/seed.ts
+++ b/packages/core/src/infrastructure/database/scripts/seed.ts
@@ -1,5 +1,6 @@
 import { sql } from 'kysely';
 import readline from 'readline';
+import { z } from 'zod';
 
 import { ENV } from '@/shared/env';
 import { createDatabaseConnection } from '../shared/create-database-connection';
@@ -135,10 +136,26 @@ async function seed() {
 }
 
 async function setEmailFromCommandLine() {
-  email = await question(
+  const answer = await question(
     'In order to log into the Member Profile and Admin Dashboard, you will need both a member record and an admin record. Please provide an email so we can create those for you.\n' +
       'Email: '
   );
+
+  const result = z
+    .string()
+    .trim()
+    .min(1)
+    .email()
+    .transform((value) => {
+      return value.toLowerCase();
+    })
+    .safeParse(answer);
+
+  if (!result.success) {
+    throw new Error('The email you provided was invalid.');
+  }
+
+  email = result.data;
 }
 
 async function question(prompt: string) {

--- a/packages/core/src/infrastructure/database/scripts/seed.ts
+++ b/packages/core/src/infrastructure/database/scripts/seed.ts
@@ -155,11 +155,11 @@ async function question(prompt: string) {
   });
 }
 
-let idCounter = 0;
+let counter = 0;
 
 function id() {
-  idCounter++;
-  return idCounter.toString();
+  counter++;
+  return counter.toString();
 }
 
 main();


### PR DESCRIPTION
## Description ✏️

**Note: This PR does not solve the root issue and we need to figure out a more sustainable way to support transpilation in our non-Vite parts of the codebase.**

This PR does the following:
- Removes references to `@colorstack/types` and `@colorstack/utils` in the `seed` script.
- Adds the top-level `db:seed` command, which references the `core` package command.
- Updates the documentation for seeding according to the above.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
