### PR TITLE
feat: add `postinstall` script to monorepo root 🌴

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "turbo run dev --cache-dir=.turbo",
     "dev:apps": "yarn dev --filter='./apps/*'",
     "lint": "turbo run lint --cache-dir=.turbo",
+    "postinstall": "yarn workspace @oyster/core db:types",
     "test": "turbo run test --cache-dir=.turbo",
     "start": "turbo run start --cache-dir=.turbo"
   },


### PR DESCRIPTION
## Description ✏️

It's a bit unintuitive, but after you install a new package, the auto-generated types that `kysely-codegen` generates are wiped out, and it will make the build fail if you try to build. If you recognize the issue, you'll simply run `yarn db:migrate` and everything will work again, but that is an extra step that is a bit cumbersome.

Instead, with this PR, after installation, we will automatically regenerate any types.

```json
"postinstall": "yarn workspace @oyster/core db:types"
```

Note that in the case of our CI workflow, the database will be empty at the time that the `postinstall` script runs, which causes no harm (nor does it add any benefit). This is mainly a development workflow optimization.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
