### PR TITLE
refactor: remove `export *` from barrel files 🛢️

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,12 +1,56 @@
-export * from './domain/application';
-export * from './domain/email-marketing';
-export * from './domain/event';
-export * from './domain/gamification';
+export { Application, ApplicationStatus } from './domain/application';
+export {
+  EmailCampaign,
+  EmailCampaignClick,
+  EmailCampaignLink,
+  EmailCampaignOpen,
+  EmailList,
+  EmailMarketingPlatform,
+} from './domain/email-marketing';
+export {
+  Event,
+  EventAttendee,
+  EventRegistration,
+  EventType,
+} from './domain/event';
+export {
+  Activity,
+  ActivityPeriod,
+  ActivityType,
+  CompletedActivity,
+} from './domain/gamification';
+export type { GetActivityType } from './domain/gamification';
 export { ProfileView } from './domain/profile-view';
-export * from './domain/program';
-export * from './domain/resource';
-export * from './domain/scholarship';
-export * from './domain/student';
-export * from './domain/types';
-export * from './shared/types';
-export * from './shared/zod';
+export { Program, ProgramParticipant } from './domain/program';
+export { Resource, ResourceStatus, ResourceUser } from './domain/resource';
+export { ScholarshipRecipient, ScholarshipType } from './domain/scholarship';
+export {
+  ActivationRequirement,
+  MemberEthnicity,
+  Student,
+  StudentActiveStatus,
+  StudentEmail,
+} from './domain/student';
+export {
+  Address,
+  Demographic,
+  EducationLevel,
+  Email,
+  Entity,
+  FORMATTED_DEMOGRAPHICS,
+  FORMATTED_GENDER,
+  FORMATTED_OTHER_DEMOGRAPHICS,
+  FORMATTED_RACE,
+  Gender,
+  Major,
+  OtherDemographic,
+  Race,
+  SwagPackType,
+} from './domain/types';
+export type { ExtractValue } from './shared/types';
+export {
+  ISO8601Date,
+  NullishString,
+  Timezone,
+  nullableField,
+} from './shared/zod';

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -4,7 +4,7 @@ import { match } from 'ts-pattern';
 import { cx } from '../utils/cx';
 import { Spinner } from './spinner';
 
-export type ButtonProps = Pick<
+type ButtonProps = Pick<
   React.HTMLProps<HTMLButtonElement>,
   'children' | 'disabled' | 'name' | 'onClick' | 'type' | 'value'
 > & {

--- a/packages/ui/src/components/date-picker.tsx
+++ b/packages/ui/src/components/date-picker.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { cx } from '../utils/cx';
 import { getInputCn } from './input';
 
-export type DatePickerProps = Pick<
+type DatePickerProps = Pick<
   React.HTMLProps<HTMLInputElement>,
   'defaultValue' | 'id' | 'name' | 'onBlur' | 'placeholder' | 'required'
 > & {

--- a/packages/ui/src/hooks/use-on-click-outside.ts
+++ b/packages/ui/src/hooks/use-on-click-outside.ts
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-export type OnClickOutsideRef<T> = React.MutableRefObject<T | null>;
+type OnClickOutsideRef<T> = React.MutableRefObject<T | null>;
 
 /**
  * Hook that detects whether or not there was a click on an element outside

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,17 +1,24 @@
 export { Address } from './components/address';
-export * from './components/button';
+export { Button, getButtonCn } from './components/button';
 export { Checkbox } from './components/checkbox';
 export { Combobox, ComboboxInput, ComboboxItem } from './components/combobox';
 export type { ComboboxProps } from './components/combobox';
 export { ComboboxPopover } from './components/combobox-popover';
 export { Dashboard } from './components/dashboard';
-export * from './components/date-picker';
-export * from './components/divider';
+export { DatePicker } from './components/date-picker';
+export { Divider } from './components/divider';
 export { Dropdown } from './components/dropdown';
-export * from './components/form';
-export * from './components/icon-button';
-export * from './components/input';
-export * from './components/link';
+export {
+  Form,
+  InputField,
+  getActionErrors,
+  validateForm,
+} from './components/form';
+export type { FieldProps } from './components/form';
+export { IconButton, getIconButtonCn } from './components/icon-button';
+export { Input, getInputCn } from './components/input';
+export type { InputProps } from './components/input';
+export { Link } from './components/link';
 export { Login } from './components/login';
 export { Modal } from './components/modal';
 export {
@@ -22,22 +29,26 @@ export {
   MultiComboboxValues,
 } from './components/multi-combobox';
 export type { MultiComboboxProps } from './components/multi-combobox';
-export * from './components/pagination';
-export * from './components/pill';
+export { Pagination } from './components/pagination';
+export { Pill } from './components/pill';
+export type { PillProps } from './components/pill';
 export { ProfilePicture } from './components/profile-picture';
 export { Public } from './components/public';
 export { Radio } from './components/radio';
-export * from './components/search-bar';
+export { SearchBar } from './components/search-bar';
 export { Select } from './components/select';
-export * from './components/spinner';
-export * from './components/table';
-export * from './components/text';
-export * from './components/textarea';
+export { Spinner } from './components/spinner';
+export { Table } from './components/table';
+export type { TableColumnProps } from './components/table';
+export { Text } from './components/text';
+export type { TextProps } from './components/text';
+export { Textarea } from './components/textarea';
 export { Toast } from './components/toast';
 export type { ToastProps } from './components/toast';
-export * from './hooks/use-delayed-value';
-export * from './hooks/use-hydrated';
-export * from './hooks/use-on-click-outside';
+export { useDelayedValue } from './hooks/use-delayed-value';
+export { useHydrated } from './hooks/use-hydrated';
+export { useOnClickOutside } from './hooks/use-on-click-outside';
 export { useSearchParams } from './hooks/use-search-params';
-export * from './utils/constants';
-export * from './utils/cx';
+export { ACCENT_COLORS } from './utils/constants';
+export type { Color } from './utils/constants';
+export { cx } from './utils/cx';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,8 +1,8 @@
-export * from './get-cookie';
-export * from './id';
-export * from './iife';
-export * from './order';
-export * from './pick';
-export * from './sleep';
-export * from './to-escaped-string';
-export * from './to-title-case';
+export { getCookie } from './get-cookie';
+export { id } from './id';
+export { iife } from './iife';
+export { order } from './order';
+export { pick } from './pick';
+export { sleep } from './sleep';
+export { toEscapedString } from './to-escaped-string';
+export { toTitleCase } from './to-title-case';


### PR DESCRIPTION
## Description ✏️

This PR removes all instances of `export *` from all barrel files in our packages. That was a lazy way of exporting, not being mindful of everything we were exporting. With this change, we are intentional about everything that we're exporting.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
