### PR TITLE
refactor: update colors in tailwind config 💨

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 import { Application, ApplicationStatus } from '@oyster/types';
 import {
-  Color,
+  AccentColor,
   Dashboard,
   Dropdown,
   Pagination,
@@ -161,9 +161,9 @@ function ApplicationsTable() {
     {
       displayName: 'Status',
       render: (application) => {
-        const StatusColor: Record<ApplicationStatus, Color> = {
+        const StatusColor: Record<ApplicationStatus, AccentColor> = {
           accepted: 'lime-100',
-          pending: 'gold-100',
+          pending: 'amber-100',
           rejected: 'red-100',
         };
 

--- a/apps/admin-dashboard/app/tailwind.css
+++ b/apps/admin-dashboard/app/tailwind.css
@@ -11,7 +11,7 @@ select {
 
 a:focus-visible,
 button:focus-visible {
-  outline-color: var(--color-primary);
+  outline-color: theme('colors.primary');
   outline-offset: 1px;
   outline-style: solid;
   outline-width: 1px;

--- a/apps/member-profile/app/routes/_profile.home.tsx
+++ b/apps/member-profile/app/routes/_profile.home.tsx
@@ -257,7 +257,7 @@ export default function HomeLayout() {
 
       {(showOnboardingCard || showSwagCard) && (
         <>
-          <div className="@[1500px]:grid-cols-3 @[1000px]:grid-cols-2 grid grid-cols-1 items-start gap-4">
+          <div className="grid grid-cols-1 items-start gap-4 @[1000px]:grid-cols-2 @[1500px]:grid-cols-3">
             {showSwagCard && <ClaimSwagPackCard />}
             {showOnboardingCard && <OnboardingSessionCard />}
           </div>
@@ -266,12 +266,12 @@ export default function HomeLayout() {
         </>
       )}
 
-      <div className="@[1500px]:grid-cols-3 @[900px]:grid-cols-2 grid grid-cols-1 items-start gap-4">
+      <div className="grid grid-cols-1 items-start gap-4 @[900px]:grid-cols-2 @[1500px]:grid-cols-3">
         <Home.Column>
           <ActiveStatusCard />
 
-          <div className="@container gap-[inherit]">
-            <div className="@[420px]:grid-cols-2 grid grid-cols-1 gap-[inherit]">
+          <div className="gap-[inherit] @container">
+            <div className="grid grid-cols-1 gap-[inherit] @[420px]:grid-cols-2">
               <MemberNumberCard />
               <TotalCommunityMemberCard />
               <EventsAttendedCard />
@@ -284,7 +284,7 @@ export default function HomeLayout() {
           <LeaderboardCard className="@[1500px]:hidden" />
         </Home.Column>
 
-        <Home.Column className="@[1500px]:flex hidden">
+        <Home.Column className="hidden @[1500px]:flex">
           <LeaderboardCard />
         </Home.Column>
 
@@ -328,9 +328,7 @@ function ActiveStatusCard() {
             <span
               className={cx(
                 'inline-block h-2 w-2 rounded-full align-middle',
-                thisWeekActiveStatus === 'active'
-                  ? 'bg-[var(--color-success)]'
-                  : 'bg-[var(--color-error)]'
+                thisWeekActiveStatus === 'active' ? 'bg-success' : 'bg-error'
               )}
             />{' '}
             {toTitleCase(thisWeekActiveStatus)}
@@ -345,8 +343,8 @@ function ActiveStatusCard() {
           <div className="grid w-fit grid-cols-8 gap-2">
             {statuses.map((status) => {
               const className = match(status.status)
-                .with('active', () => 'bg-[var(--color-success)]')
-                .with('inactive', () => 'bg-[var(--color-error)]')
+                .with('active', () => 'bg-success')
+                .with('inactive', () => 'bg-error')
                 .with(undefined, () => 'bg-gray-200')
                 .exhaustive();
 
@@ -715,7 +713,7 @@ function SocialItem({
   return (
     <li>
       <a href={href} target="_blank">
-        <Icon color="var(--color-primary)" size={28} />
+        <Icon className="text-primary" size={28} />
       </a>
     </li>
   );

--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -71,20 +71,14 @@ function EmailAddressSection() {
             <li
               className={cx(
                 'flex items-center justify-between rounded-lg border border-solid p-2',
-
-                email.primary
-                  ? 'border-[var(--color-gold)] bg-[var(--color-gold-100)]'
-                  : 'border-gray-200'
+                email.primary ? 'border-gold bg-gold-100' : 'border-gray-200'
               )}
               key={email.email}
             >
               <Text>{email.email}</Text>
 
               {email.primary && (
-                <Text
-                  className="font-medium uppercase text-[var(--color-gold)]"
-                  variant="sm"
-                >
+                <Text className="text-gold font-medium uppercase" variant="sm">
                   Primary
                 </Text>
               )}

--- a/apps/member-profile/app/tailwind.css
+++ b/apps/member-profile/app/tailwind.css
@@ -11,7 +11,7 @@ select {
 
 a:focus-visible,
 button:focus-visible {
-  outline-color: var(--color-primary);
+  outline-color: theme('colors.primary');
   outline-offset: 1px;
   outline-style: solid;
   outline-width: 1px;

--- a/config/tailwind/tailwind.config.js
+++ b/config/tailwind/tailwind.config.js
@@ -1,3 +1,5 @@
+import colors from 'tailwindcss/colors';
+
 /** @type {import('tailwindcss').Config} */
 export const tailwindConfig = {
   content: [
@@ -8,7 +10,12 @@ export const tailwindConfig = {
   theme: {
     extend: {
       colors: {
-        primary: 'var(--color-primary)',
+        error: colors.red[600],
+        gold: '#fdb532',
+        'gold-100': '#fff7ea',
+        primary: '#348e87',
+        success: colors.green[600],
+        warning: colors.yellow[400],
       },
       keyframes: {
         'modal-animation': {

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,7 +1,8 @@
 import React, { PropsWithChildren } from 'react';
 import { Check as CheckIcon } from 'react-feather';
+import { match } from 'ts-pattern';
 
-import { ACCENT_COLORS, Color, ColorVariable } from '../utils/constants';
+import { ACCENT_COLORS, AccentColor } from '../utils/constants';
 import { cx } from '../utils/cx';
 
 type CheckboxProps = Pick<
@@ -15,7 +16,7 @@ type CheckboxProps = Pick<
   | 'required'
   | 'value'
 > & {
-  color?: Color;
+  color?: AccentColor;
 };
 
 export const Checkbox = ({
@@ -25,10 +26,6 @@ export const Checkbox = ({
   readOnly,
   ...rest
 }: CheckboxProps) => {
-  const labelStyle = {
-    '--color': ColorVariable[color as Color],
-  } as React.CSSProperties;
-
   return (
     <div className="flex items-center">
       <input
@@ -47,8 +44,8 @@ export const Checkbox = ({
           'flex h-4 w-4 items-center justify-center rounded-[0.25rem] border-2 border-gray-300',
           'peer-hover:border-primary',
           'peer-focus:border-primary',
-          'peer-checked:bg-primary peer-checked:border-primary',
-          'peer-checked:disabled:bg-gray-500 peer-checked:disabled:border-gray-500'
+          'peer-checked:border-primary peer-checked:bg-primary',
+          'peer-checked:disabled:border-gray-500 peer-checked:disabled:bg-gray-500'
         )}
       >
         <CheckIcon className="h-4 w-4 text-white" />
@@ -57,10 +54,22 @@ export const Checkbox = ({
       <label
         className={cx(
           'ml-2 cursor-pointer text-sm',
-          color && 'rounded-full bg-[var(--color)] px-2'
+          color && 'rounded-full px-2',
+
+          match(color)
+            .with('amber-100', () => 'bg-amber-100')
+            .with('blue-100', () => 'bg-blue-100')
+            .with('cyan-100', () => 'bg-cyan-100')
+            .with('green-100', () => 'bg-green-100')
+            .with('lime-100', () => 'bg-lime-100')
+            .with('orange-100', () => 'bg-orange-100')
+            .with('pink-100', () => 'bg-pink-100')
+            .with('purple-100', () => 'bg-purple-100')
+            .with('red-100', () => 'bg-red-100')
+            .with(undefined, () => undefined)
+            .exhaustive()
         )}
         htmlFor={id}
-        style={labelStyle}
       >
         {label}
       </label>

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -16,7 +16,7 @@ type CheckboxProps = Pick<
   | 'required'
   | 'value'
 > & {
-  color?: AccentColor;
+  color?: AccentColor | 'gold-100';
 };
 
 export const Checkbox = ({
@@ -60,6 +60,7 @@ export const Checkbox = ({
             .with('amber-100', () => 'bg-amber-100')
             .with('blue-100', () => 'bg-blue-100')
             .with('cyan-100', () => 'bg-cyan-100')
+            .with('gold-100', () => 'bg-gold-100')
             .with('green-100', () => 'bg-green-100')
             .with('lime-100', () => 'bg-lime-100')
             .with('orange-100', () => 'bg-orange-100')

--- a/packages/ui/src/components/pill.tsx
+++ b/packages/ui/src/components/pill.tsx
@@ -38,7 +38,7 @@ export const Pill = ({ children, color, onCloseHref }: PillProps) => {
 
 export function getPillCn({ color, onCloseHref }: Omit<PillProps, 'children'>) {
   return cx(
-    'w-max rounded-full bg-[var(--background-color)] px-2 text-sm',
+    'w-max rounded-full px-2 text-sm',
 
     onCloseHref && 'flex items-center gap-1',
 
@@ -46,7 +46,7 @@ export function getPillCn({ color, onCloseHref }: Omit<PillProps, 'children'>) {
       .with('amber-100', () => 'bg-amber-100')
       .with('blue-100', () => 'bg-blue-100')
       .with('cyan-100', () => 'bg-cyan-100')
-      .with('gold-100', () => 'bg-[var(--color-gold-100)]')
+      .with('gold-100', () => 'bg-gold-100')
       .with('gray-100', () => 'bg-gray-100')
       .with('green-100', () => 'bg-green-100')
       .with('lime-100', () => 'bg-lime-100')

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
+import { match } from 'ts-pattern';
 
-import { ACCENT_COLORS, Color, ColorVariable } from '../utils/constants';
+import { ACCENT_COLORS, AccentColor } from '../utils/constants';
 import { cx } from '../utils/cx';
 
 type RadioProps = Pick<
@@ -14,7 +15,7 @@ type RadioProps = Pick<
   | 'required'
   | 'value'
 > & {
-  color?: Color;
+  color?: AccentColor | 'primary';
 };
 
 export const Radio = ({
@@ -24,10 +25,6 @@ export const Radio = ({
   readOnly,
   ...rest
 }: RadioProps) => {
-  const style = {
-    '--color': ColorVariable[color],
-  } as React.CSSProperties;
-
   return (
     <div className="flex items-center">
       <input
@@ -46,7 +43,7 @@ export const Radio = ({
         className={cx(
           'flex h-4 w-4 items-center justify-center rounded-full border-2 border-gray-300 bg-inherit',
           'peer-hover:border-primary peer-focus:border-primary',
-          'peer-checked:bg-white peer-checked:border-primary',
+          'peer-checked:border-primary peer-checked:bg-white',
           'peer-checked:*:bg-primary'
         )}
       >
@@ -54,9 +51,23 @@ export const Radio = ({
       </div>
 
       <label
-        className="ml-2 cursor-pointer rounded-full bg-[var(--color)] px-2 text-sm"
+        className={cx(
+          'ml-2 cursor-pointer rounded-full bg-[var(--color)] px-2 text-sm',
+
+          match(color)
+            .with('amber-100', () => 'bg-amber-100')
+            .with('blue-100', () => 'bg-blue-100')
+            .with('cyan-100', () => 'bg-cyan-100')
+            .with('green-100', () => 'bg-green-100')
+            .with('lime-100', () => 'bg-lime-100')
+            .with('orange-100', () => 'bg-orange-100')
+            .with('pink-100', () => 'bg-pink-100')
+            .with('purple-100', () => 'bg-purple-100')
+            .with('red-100', () => 'bg-red-100')
+            .with('primary', () => 'bg-primary')
+            .exhaustive()
+        )}
         htmlFor={id}
-        style={style}
       >
         {label}
       </label>

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -52,7 +52,7 @@ export const Radio = ({
 
       <label
         className={cx(
-          'ml-2 cursor-pointer rounded-full bg-[var(--color)] px-2 text-sm',
+          'ml-2 cursor-pointer rounded-full px-2 text-sm',
 
           match(color)
             .with('amber-100', () => 'bg-amber-100')

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,10 +1,9 @@
 import { match } from 'ts-pattern';
 
-import { Color } from '../utils/constants';
 import { cx } from '../utils/cx';
 
 type SpinnerProps = {
-  color?: Extract<Color, 'error' | 'primary' | 'success'>;
+  color?: 'error' | 'primary' | 'success';
 };
 
 export function Spinner({ color = 'primary' }: SpinnerProps) {

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -60,12 +60,12 @@ export function Toast({ message, type }: ToastProps): JSX.Element | null {
     >
       <div
         className={cx(
-          'relative box-border flex items-center justify-center rounded bg-[var(--background-color)] p-1',
+          'relative box-border flex items-center justify-center rounded p-1',
 
           match(type)
-            .with('error', () => 'bg-red-600')
-            .with('success', () => 'bg-green-600')
-            .with('warning', () => 'bg-yellow-400')
+            .with('error', () => 'bg-error')
+            .with('success', () => 'bg-success')
+            .with('warning', () => 'bg-warning')
             .exhaustive()
         )}
       >

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1,43 +1,3 @@
-:root {
-  --color-amber-100: #fef3c7;
-  --color-black: #000;
-  --color-blue-50: #eff6ff;
-  --color-blue-100: #dbeafe;
-  --color-cyan-100: #cffafe;
-  --color-error: #dc2626;
-  --color-gold: #fdb532;
-  --color-gold-100: #fff7ea;
-  --color-gold-500: #fdb532;
-  --color-gray-50: #f9fafb;
-  --color-gray-100: #f9fafb;
-  --color-gray-200: #e5e7eb;
-  --color-gray-300: #d1d5db;
-  --color-gray-400: #9ca3af;
-  --color-gray-500: #6b7280;
-  --color-gray-700: #374151;
-  --color-gray-900: #111827;
-  --color-green-100: #dcfce7;
-  --color-lime-50: #f7fee7;
-  --color-lime-100: #ecfccb;
-  --color-orange-100: #ffedd5;
-  --color-pink-100: #fce7f3;
-  --color-purple-100: #f3e8ff;
-  --color-red-50: #fef2f2;
-  --color-red-100: #fee2e2;
-  --color-teal: #348e87;
-  --color-slate: #091024;
-  --color-success: #16a34a;
-  --color-warning: #ffcc00;
-  --color-white: #fff;
-}
-
-:root {
-  --color-disabled: var(--color-gray-500);
-  --color-pill-default: var(--color-pink-100);
-  --color-placeholder: var(--color-gray-400);
-  --color-primary: var(--color-teal);
-}
-
 /* Elements */
 
 button,
@@ -63,7 +23,7 @@ select {
 
 .dropdown-item :is(a, button):only-child:hover,
 .dropdown-item :is(a, button):only-child:focus-within {
-  background-color: var(--color-gray-100);
+  background-color: theme('colors.gray.100');
 }
 
 .dropdown-item :is(a, button):only-child > svg {
@@ -82,7 +42,7 @@ select {
 }
 
 .link {
-  color: var(--color-primary);
+  color: theme('colors.primary');
   text-decoration: underline;
 }
 
@@ -93,16 +53,16 @@ select {
 }
 
 .scrollbar::-webkit-scrollbar-thumb {
-  background-color: var(--color-gray-300);
+  background-color: theme('colors.gray.300');
   border-radius: 1rem;
 }
 
 .scrollbar::-webkit-scrollbar-thumb:active {
-  background-color: var(--color-gray-500);
+  background-color: theme('colors.gray.500');
 }
 
 .scrollbar::-webkit-scrollbar-track {
-  background-color: var(--color-gray-100);
+  background-color: theme('colors.gray.100');
   border-radius: 0.5rem;
   display: block;
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,5 +50,5 @@ export { useHydrated } from './hooks/use-hydrated';
 export { useOnClickOutside } from './hooks/use-on-click-outside';
 export { useSearchParams } from './hooks/use-search-params';
 export { ACCENT_COLORS } from './utils/constants';
-export type { Color } from './utils/constants';
+export type { AccentColor } from './utils/constants';
 export { cx } from './utils/cx';

--- a/packages/ui/src/utils/constants.ts
+++ b/packages/ui/src/utils/constants.ts
@@ -1,77 +1,15 @@
-import { ExtractValue } from '@oyster/types';
-
-export type Color =
+export type AccentColor =
   | 'amber-100'
-  | 'black'
-  | 'blue-50'
   | 'blue-100'
   | 'cyan-100'
-  | 'error'
-  | 'gold'
-  | 'gold-100'
-  | 'gold-500'
-  | 'gray-50'
-  | 'gray-100'
-  | 'gray-200'
-  | 'gray-300'
-  | 'gray-500'
-  | 'gray-700'
-  | 'gray-900'
   | 'green-100'
-  | 'lime-50'
   | 'lime-100'
   | 'orange-100'
   | 'pink-100'
-  | 'primary'
   | 'purple-100'
-  | 'red-50'
-  | 'red-100'
-  | 'teal'
-  | 'slate'
-  | 'success'
-  | 'warning'
-  | 'white';
+  | 'red-100';
 
-type ColorVariableRecord = {
-  [Key in Color]: `var(--color-${Key})`;
-};
-
-export const ColorVariable: ColorVariableRecord = {
-  'amber-100': 'var(--color-amber-100)',
-  black: 'var(--color-black)',
-  'blue-50': 'var(--color-blue-50)',
-  'blue-100': 'var(--color-blue-100)',
-  'cyan-100': 'var(--color-cyan-100)',
-  error: 'var(--color-error)',
-  gold: 'var(--color-gold)',
-  'gold-100': 'var(--color-gold-100)',
-  'gold-500': 'var(--color-gold-500)',
-  'gray-50': 'var(--color-gray-50)',
-  'gray-100': 'var(--color-gray-100)',
-  'gray-200': 'var(--color-gray-200)',
-  'gray-300': 'var(--color-gray-300)',
-  'gray-500': 'var(--color-gray-500)',
-  'gray-700': 'var(--color-gray-700)',
-  'gray-900': 'var(--color-gray-900)',
-  'green-100': 'var(--color-green-100)',
-  'lime-50': 'var(--color-lime-50)',
-  'lime-100': 'var(--color-lime-100)',
-  'orange-100': 'var(--color-orange-100)',
-  'pink-100': 'var(--color-pink-100)',
-  primary: 'var(--color-primary)',
-  'purple-100': 'var(--color-purple-100)',
-  'red-50': 'var(--color-red-50)',
-  'red-100': 'var(--color-red-100)',
-  slate: 'var(--color-slate)',
-  success: 'var(--color-success)',
-  teal: 'var(--color-teal)',
-  warning: 'var(--color-warning)',
-  white: 'var(--color-white)',
-} as const;
-
-export type ColorVariable = ExtractValue<typeof ColorVariable>;
-
-export const ACCENT_COLORS: Color[] = [
+export const ACCENT_COLORS: AccentColor[] = [
   'red-100',
   'orange-100',
   'lime-100',


### PR DESCRIPTION
## Description ✏️

This PR does the folllowing:
- Removes all CSS color variables and uses Tailwind's functionality instead.
- Removes the `Color` type and replaces it with the `AccentColor`.
- Uses Tailwind's `theme()` function in CSS files to reference colors.
- Adds more colors to the base Tailwind config (ie: `error`, `success`, `gold`).

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
