### PR TITLE
fix: allow emails to be sent in dev environment ✉️

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,12 +187,6 @@ yarn build
 
 ### Running the Applications
 
-To run all of our _packages and applications_, you can run:
-
-```sh
-yarn dev
-```
-
 To run all of our _applications_, you can run:
 
 ```sh
@@ -205,6 +199,18 @@ this:
 ```sh
 yarn dev --filter=api
 ```
+
+### Logging Into Applications
+
+You can log into the Member Profile and Admin Dashboard by sending a one-time
+code to your email OR by using your Google login.
+
+- [Recommended] To log in by sending a one-time code to your email, you'll first
+  need to enable the **Postmark** integration. See instructions on how to do so
+  [here](./docs/how-to-enable-integrations.md#postmark).
+- To log in via Google, you'll first need to enable the **Google** integration.
+  See instructions on how to do so
+  [here](./docs/how-to-enable-integrations.md#google).
 
 ### Editor Setup
 

--- a/packages/core/src/modules/notification/use-cases/send-email.ts
+++ b/packages/core/src/modules/notification/use-cases/send-email.ts
@@ -13,7 +13,7 @@ import {
   StudentRemovedEmail,
 } from '@oyster/email-templates';
 
-import { ENV, IS_PRODUCTION, IS_TEST } from '@/shared/env';
+import { ENV, IS_TEST } from '@/shared/env';
 import { Environment } from '@/shared/types';
 import { getPostmarkInstance } from '../shared/email.utils';
 
@@ -53,7 +53,7 @@ const Template: Record<EmailTemplate['name'], (...args: any) => JSX.Element> = {
 // Instances
 
 export async function sendEmail(input: EmailTemplate) {
-  if (!shouldSendEmail(input.to)) {
+  if (IS_TEST) {
     return;
   }
 
@@ -118,29 +118,4 @@ function getSubject(input: EmailTemplate): string {
     .exhaustive();
 
   return subjectWithEnvironment;
-}
-
-/**
- * Returns `true` if the email should be allowed to be sent.
- *
- * The email should be sent if one of the following is true:
- * - It is the `production` environment.
- * - The `to` address is whitelisted.
- *
- * @param to - Email address to send email to.
- */
-function shouldSendEmail(to: string): boolean {
-  if (IS_TEST) {
-    return false;
-  }
-
-  if (IS_PRODUCTION) {
-    return true;
-  }
-
-  if (to.endsWith('@colorstack.org')) {
-    return true;
-  }
-
-  return false;
 }


### PR DESCRIPTION
## Description ✏️

This PR:
- Removes the `shouldSendEmail` function, which previously didn't allow emails to be sent to non-`@colorstack.org` emails in development.
- Adds documentation on logging into applications, and setting up the relevant integrations.

We can still probably prevent accidental emails from being sent in the dev environment, but we'll need to think through that a little bit more.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
