### PR TITLE
chore: add `type-check` command 🧽

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  build:
-    name: Lint, Build and Test
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -67,6 +67,9 @@ jobs:
 
       - name: Lint
         run: yarn lint
+
+      - name: Check types
+        run: yarn type-check
 
       - name: Build all packages and applications
         run: yarn build

--- a/apps/admin-dashboard/package.json
+++ b/apps/admin-dashboard/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "build": "remix vite:build",
     "dev": "remix vite:dev",
-    "lint": "tsc --noEmit",
-    "start": "remix-serve ./build/server/index.js"
+    "start": "remix-serve ./build/server/index.js",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@oyster/core": "*",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,8 +5,9 @@
   "license": "MIT",
   "scripts": {
     "dev": "tsx watch ./src/main.ts",
-    "lint": "eslint 'src/**' && tsc --noEmit",
-    "start": "tsx ./src/main.ts"
+    "lint": "eslint 'src/**'",
+    "start": "tsx ./src/main.ts",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@oyster/core": "*",

--- a/apps/member-profile/package.json
+++ b/apps/member-profile/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "build": "remix vite:build",
     "dev": "remix vite:dev",
-    "lint": "tsc --noEmit",
-    "start": "remix-serve ./build/server/index.js"
+    "start": "remix-serve ./build/server/index.js",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@oyster/core": "*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dev:apps": "yarn dev --filter='./apps/*'",
     "lint": "turbo run lint --cache-dir=.turbo",
     "test": "turbo run test --cache-dir=.turbo",
-    "start": "turbo run start --cache-dir=.turbo"
+    "start": "turbo run start --cache-dir=.turbo",
+    "type-check": "turbo run type-check --cache-dir=.turbo"
   },
   "devDependencies": {
     "prettier": "^3.2.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,8 +21,8 @@
     "db:seed": "tsx ./src/infrastructure/database/scripts/seed.ts && yarn db:types",
     "db:setup": "tsx ./src/infrastructure/database/scripts/setup.ts",
     "db:types": "kysely-codegen --dialect=postgres --camel-case",
-    "lint": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@mailchimp/mailchimp_marketing": "^3.0.78",

--- a/packages/email-templates/package.json
+++ b/packages/email-templates/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "dev": "email dev --port=3010",
-    "lint": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@react-email/button": "^0.0.6",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "./src/index.ts",
   "scripts": {
-    "lint": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "devDependencies": {
     "zod": "^3.20.2"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "lint": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "devDependencies": {
     "@oyster/tsconfig": "*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "main": "./src/index.ts",
   "scripts": {
-    "lint": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "type-check": "tsc --noEmit"
   },
   "devDependencies": {
     "nanoid": "^3.0.0",

--- a/turbo.json
+++ b/turbo.json
@@ -3,19 +3,22 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["build/**", "dist/**"]
     },
     "dev": {
       "cache": false,
       "dependsOn": ["^build"],
       "persistent": true
     },
-    "start": {
-      "cache": false
-    },
     "lint": {
       "dependsOn": ["^build"]
     },
-    "test": {}
+    "start": {
+      "cache": false
+    },
+    "test": {},
+    "type-check": {
+      "dependsOn": ["^build"]
+    }
   }
 }


### PR DESCRIPTION
## Description ✏️

Closes #74.

This PR does the following:
- Runs `yarn type-check` in the CI workflow.
- Moves `tsc --noEmit` to `type-check`.
- Adds `type-check` command to Turbo config.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [x] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
