### PR TITLE
fix:  add host to psql connection in `db:setup` script 🔨

### DIFF
--- a/packages/core/src/infrastructure/database/scripts/setup.ts
+++ b/packages/core/src/infrastructure/database/scripts/setup.ts
@@ -14,19 +14,20 @@ const __dirname = path.dirname(__filename);
 // This is the full path to the `setup.sql` file.
 const pathToInitFile = path.join(__dirname, 'setup.sql');
 
-const dbUser = 'postgres';
-const dbName = 'postgres';
+exec(
+  `psql -U postgres -d postgres -f ${pathToInitFile}`,
+  (error, stdout, stderr) => {
+    if (stdout) {
+      console.log(stdout);
+    }
 
-const psqlCommand = `psql -U ${dbUser} -d ${dbName} -f ${pathToInitFile}`;
+    if (stderr) {
+      // Log but don't throw for notices/warnings.
+      console.warn(stderr);
+    }
 
-exec(psqlCommand, (error, stdout, stderr) => {
-  console.log(stdout); // Log standard output
-  if (stderr) {
-    console.warn(stderr); // Log but don't throw for notices/warnings
+    if (error) {
+      throw new Error(`psql exited with error: ${error}`);
+    }
   }
-  if (error) {
-    // Check for actual error
-    console.error(`exec error: ${error}`);
-    throw new Error(`psql exited with error: ${error}`);
-  }
-});
+);

--- a/packages/core/src/infrastructure/database/scripts/setup.ts
+++ b/packages/core/src/infrastructure/database/scripts/setup.ts
@@ -14,8 +14,19 @@ const __dirname = path.dirname(__filename);
 // This is the full path to the `setup.sql` file.
 const pathToInitFile = path.join(__dirname, 'setup.sql');
 
-exec(`psql -f ${pathToInitFile}`, (_, stdout, stderror) => {
-  if (stderror) {
-    throw new Error(stderror);
+const dbUser = 'postgres';
+const dbName = 'postgres';
+
+const psqlCommand = `psql -U ${dbUser} -d ${dbName} -f ${pathToInitFile}`;
+
+exec(psqlCommand, (error, stdout, stderr) => {
+  console.log(stdout); // Log standard output
+  if (stderr) {
+    console.warn(stderr); // Log but don't throw for notices/warnings
+  }
+  if (error) {
+    // Check for actual error
+    console.error(`exec error: ${error}`);
+    throw new Error(`psql exited with error: ${error}`);
   }
 });

--- a/packages/core/src/infrastructure/database/scripts/setup.ts
+++ b/packages/core/src/infrastructure/database/scripts/setup.ts
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 const pathToInitFile = path.join(__dirname, 'setup.sql');
 
 exec(
-  `psql -U postgres -d postgres -f ${pathToInitFile}`,
+  `psql -U postgres -h localhost -d postgres -f ${pathToInitFile}`,
   (error, stdout, stderr) => {
     if (stdout) {
       console.log(stdout);


### PR DESCRIPTION
## Description ✏️
The latest commit specifies the host (localhost) to be able to run psql using peer authentication (the default authentication method in Unix based postgresql installations)

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
