### PR TITLE
fix: use react key to redisplay toast message 🍞

### DIFF
--- a/apps/admin-dashboard/app/root.tsx
+++ b/apps/admin-dashboard/app/root.tsx
@@ -66,7 +66,10 @@ function App() {
 
       <body>
         <Outlet />
-        {toast && <Toast message={toast.message} type={toast.type} />}
+
+        {toast && (
+          <Toast key={toast.id} message={toast.message} type={toast.type} />
+        )}
 
         <script
           // https://remix.run/docs/en/v1/guides/envvars#browser-environment-variables

--- a/apps/admin-dashboard/app/shared/session.server.ts
+++ b/apps/admin-dashboard/app/shared/session.server.ts
@@ -1,6 +1,7 @@
 import { createCookieSessionStorage, redirect, Session } from '@remix-run/node';
 
 import { ToastProps } from '@oyster/ui';
+import { id } from '@oyster/utils';
 
 import { Route } from './constants';
 import { ENV } from './constants.server';
@@ -82,6 +83,7 @@ export function isAmbassador(session: Session) {
 
 export function toast(session: Session, toast: ToastProps) {
   session.flash(SESSION.TOAST, {
+    id: id(),
     message: toast.message,
     type: toast.type,
   });

--- a/apps/member-profile/app/root.tsx
+++ b/apps/member-profile/app/root.tsx
@@ -72,7 +72,10 @@ function App() {
 
       <body>
         <Outlet />
-        {toast && <Toast message={toast.message} type={toast.type} />}
+
+        {toast && (
+          <Toast key={toast.id} message={toast.message} type={toast.type} />
+        )}
 
         <script
           // https://remix.run/docs/en/v1/guides/envvars#browser-environment-variables

--- a/apps/member-profile/app/shared/session.server.ts
+++ b/apps/member-profile/app/shared/session.server.ts
@@ -1,6 +1,7 @@
 import { createCookieSessionStorage, redirect, Session } from '@remix-run/node';
 
 import { ToastProps } from '@oyster/ui';
+import { id } from '@oyster/utils';
 
 import { Route } from './constants';
 import { ENV } from './constants.server';
@@ -64,6 +65,7 @@ export function user(session: Session): string {
 
 export function toast(session: Session, toast: ToastProps): void {
   session.flash(SESSION.TOAST, {
+    id: id(),
     message: toast.message,
     type: toast.type,
   });

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -27,8 +27,6 @@ export function Toast({ message, type }: ToastProps): JSX.Element | null {
   const hydrated = useHydrated();
 
   useEffect(() => {
-    // NOTE: If this value changes, be sure to update it in the CSS file
-    // for the icon shader as well.
     const timeout = setTimeout(() => {
       setShow(false);
     }, 7000);


### PR DESCRIPTION
## Description ✏️

Closes #81.

This PR:
- Adds an `id` to the toast message.
- Passes that `id` as a React `key` to the `Toast` component.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
