### PR TITLE
chore(db): re-add `postinstall` script ⚡️

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,11 +95,6 @@ Please ensure that you have the following software on your machine:
    ```
    git checkout -b YOUR_BRANCH_NAME
    ```
-4. Install all project dependencies.
-
-   ```sh
-   yarn
-   ```
 
 ### Syncing a Forked Repository
 
@@ -125,6 +120,14 @@ Postmark for sending emails and Google for authentication. If you would like to
 enable these integrations in development, please see the
 [How to Enable Integrations](./docs/how-to-enable-integrations.md)
 documentation.
+
+### Install Dependencies
+
+To install all project dependencies, run:
+
+```sh
+yarn
+```
 
 ### Database Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ enable these integrations in development, please see the
 [How to Enable Integrations](./docs/how-to-enable-integrations.md)
 documentation.
 
-### Install Dependencies
+### Project Dependencies
 
 To install all project dependencies, run:
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix",
     "migrate": "tsx ./src/scripts/migrate.ts && yarn types",
     "migrate:down": "tsx ./src/scripts/migrate.ts --down && yarn types",
+    "postinstall": "yarn run types",
     "seed": "tsx ./src/scripts/seed.ts && yarn types",
     "setup": "tsx ./src/scripts/setup.ts",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## Description ✏️

This PR has the same objective as what's described in #25. We had to revert that PR in #44 mainly because it broke the `CONTRIBUTION.md` onboarding steps. After further consideration, those benefits described in #25 made sense, we just had to repurpose it.

This PR:
- Adds the `postinstall` to the `db` package instead of the monorepo root. This ensures that anytime the `node_modules` within the db package changes, it'll run.
- Updates the documentation to move the `yarn` installation step after setting up environment variables, which is necessary because `kysely-codegen` is in the `postinstall` and requires the `DATABASE_URL` to be set in the environment.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [x] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
