### PR TITLE
fix: migrations on windows machines 🪟

### DIFF
--- a/packages/db/src/use-cases/migrate.ts
+++ b/packages/db/src/use-cases/migrate.ts
@@ -1,6 +1,12 @@
 import { promises as fs } from 'fs';
-import { FileMigrationProvider, Kysely, Migrator } from 'kysely';
-import { DB } from 'kysely-codegen/dist/db';
+import {
+  Migrator,
+  type Kysely,
+  type Migration,
+  type MigrationProvider,
+} from 'kysely';
+import { type DB } from 'kysely-codegen/dist/db';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -33,16 +39,9 @@ export async function migrate(options: MigrateOptions = defaultOptions) {
 
   const db = options.db || createDatabaseConnection();
 
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = path.dirname(__filename);
-
   const migrator = new Migrator({
     db,
-    provider: new FileMigrationProvider({
-      fs,
-      path,
-      migrationFolder: path.join(__dirname, '../migrations'),
-    }),
+    provider: new FileMigrationProvider(),
     migrationTableName: 'kysely_migrations',
     migrationLockTableName: 'kysely_migrations_lock',
   });
@@ -81,5 +80,49 @@ export async function migrate(options: MigrateOptions = defaultOptions) {
   // destroying it to the caller. Otherwise, we'll destroy it here.
   if (!options.db) {
     await db.destroy();
+  }
+}
+
+// NOTE: Kysely's built-in `FileMigrationProvider` does not work on Windows,
+// due to Windows not supporting `import()` of absolute URLs which are not
+// file URLs. Kysely has decided not to fix this issue since they don't want
+// to have any platform-specific code in their library, so we have to fix it
+// ourselves. You can reference the original implementation here:
+// https://github.com/kysely-org/kysely/blob/0.27.2/src/migration/file-migration-provider.ts
+
+class FileMigrationProvider implements MigrationProvider {
+  async getMigrations() {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+
+    // This is the absolute path to the "migrations" directory.
+    const directoryPath = path.join(__dirname, '../migrations');
+
+    // This is a list of file names in the "migrations" directory.
+    const files = await fs.readdir(directoryPath);
+
+    const migrations: Record<string, Migration> = {};
+
+    for (const file of files) {
+      const pathParts = [directoryPath, file];
+
+      // This is the main addition we're making to the original code from
+      // Kysely. On Windows, we need all absolute URLs to be "file URLs", so
+      // we add this prefix.
+      if (os.platform() === 'win32') {
+        pathParts.unshift('file://');
+      }
+
+      const absolutePathToMigration = path.join(...pathParts);
+
+      const migration = await import(absolutePathToMigration);
+
+      // We remove the extension form the file name to get the migration key.
+      const migrationKey = file.substring(0, file.lastIndexOf('.'));
+
+      migrations[migrationKey] = migration;
+    }
+
+    return migrations;
   }
 }


### PR DESCRIPTION
## Description ✏️

This PR:
- Copies the original implementation of `FileMigrationProvider` from Kysely and modifies it to support Windows. I specifically needed to the `file://` prefix when building the absolute URL to a migration file.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
