### PR TITLE
fix: expose redis container on port `6380` 📦

### DIFF
--- a/apps/admin-dashboard/.env.example
+++ b/apps/admin-dashboard/.env.example
@@ -5,7 +5,7 @@ API_URL=http://localhost:8080
 DATABASE_URL=postgresql://oyster:oyster@localhost:5433/oyster
 ENVIRONMENT=development
 JWT_SECRET=_
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 SESSION_SECRET=_
 
 # Optional for development, but won't be able to run certain features...

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,7 +4,7 @@ API_URL=http://localhost:8080
 DATABASE_URL=postgresql://oyster:oyster@localhost:5433/oyster
 ENVIRONMENT=development
 JWT_SECRET=_
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 PORT=8080
 STUDENT_PROFILE_URL=http://localhost:3000
 

--- a/apps/member-profile/.env.example
+++ b/apps/member-profile/.env.example
@@ -4,7 +4,7 @@ API_URL=http://localhost:8080
 DATABASE_URL=postgresql://oyster:oyster@localhost:5433/oyster
 ENVIRONMENT=development
 JWT_SECRET=_
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 SESSION_SECRET=_
 STUDENT_PROFILE_URL=http://localhost:3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     container_name: oyster-redis
     image: redis:latest
     ports:
-      - 6379:6379
+      - 6380:6379
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
## Description ✏️

This PR updates moves the exposed Redis port from it's default `6379` to `6380`. This avoids any potential clashes if the user is already running a Redis service on port `6379`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
