### PR TITLE
chore: enable the `sort-imports` lint rule 🧼

### DIFF
--- a/apps/admin-dashboard/app/entry.client.tsx
+++ b/apps/admin-dashboard/app/entry.client.tsx
@@ -1,6 +1,6 @@
 import { RemixBrowser, useLocation, useMatches } from '@remix-run/react';
 import * as Sentry from '@sentry/remix';
-import { StrictMode, startTransition, useEffect } from 'react';
+import { startTransition, StrictMode, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({

--- a/apps/member-profile/app/entry.client.tsx
+++ b/apps/member-profile/app/entry.client.tsx
@@ -1,6 +1,6 @@
 import { RemixBrowser, useLocation, useMatches } from '@remix-run/react';
 import * as Sentry from '@sentry/remix';
-import { StrictMode, startTransition, useEffect } from 'react';
+import { startTransition, StrictMode, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({

--- a/apps/member-profile/app/routes/_profile.home.tsx
+++ b/apps/member-profile/app/routes/_profile.home.tsx
@@ -9,11 +9,11 @@ import { type PropsWithChildren, type PropsWithoutRef } from 'react';
 import {
   CheckCircle,
   ExternalLink,
+  GitHub,
   type Icon,
   Instagram,
   Linkedin,
   Twitter,
-  GitHub,
   XCircle,
   Youtube,
 } from 'react-feather';

--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -1,7 +1,7 @@
 import {
   type ActionFunctionArgs,
-  type LoaderFunctionArgs,
   json,
+  type LoaderFunctionArgs,
 } from '@remix-run/node';
 import {
   Outlet,
@@ -17,10 +17,10 @@ import { z } from 'zod';
 import {
   Button,
   Checkbox,
-  Form,
-  Text,
   cx,
+  Form,
   getActionErrors,
+  Text,
   validateForm,
 } from '@oyster/ui';
 

--- a/config/eslint/base.js
+++ b/config/eslint/base.js
@@ -74,6 +74,13 @@ module.exports = {
       { blankLine: 'always', prev: '*', next: 'function' },
       { blankLine: 'always', prev: 'function', next: '*' },
     ],
+    'sort-imports': [
+      'error',
+      {
+        ignoreCase: true,
+        ignoreDeclarationSort: true,
+      },
+    ],
   },
   settings: {
     'import/internal-regex': '^@oyster/',

--- a/packages/core/src/modules/education/queries/list-schools.ts
+++ b/packages/core/src/modules/education/queries/list-schools.ts
@@ -1,4 +1,4 @@
-import { sql, type SelectExpression } from 'kysely';
+import { type SelectExpression, sql } from 'kysely';
 
 import { type DB } from '@oyster/db';
 

--- a/packages/core/src/modules/member/use-cases/update-member.ts
+++ b/packages/core/src/modules/member/use-cases/update-member.ts
@@ -1,6 +1,6 @@
 import { type Transaction, type UpdateObject } from 'kysely';
 
-import { db, point, type DB } from '@oyster/db';
+import { type DB, db, point } from '@oyster/db';
 import { type Student } from '@oyster/types';
 
 type UpdateMemberOptions = {

--- a/packages/db/src/scripts/seed.ts
+++ b/packages/db/src/scripts/seed.ts
@@ -1,4 +1,4 @@
-import { type Transaction, sql } from 'kysely';
+import { sql, type Transaction } from 'kysely';
 import readline from 'readline';
 import { z } from 'zod';
 

--- a/packages/db/src/shared/utils.ts
+++ b/packages/db/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import { sql, type RawBuilder } from 'kysely';
+import { type RawBuilder, sql } from 'kysely';
 
 type Point = {
   x: number;

--- a/packages/db/src/use-cases/migrate.ts
+++ b/packages/db/src/use-cases/migrate.ts
@@ -1,9 +1,9 @@
 import { promises as fs } from 'fs';
 import {
-  Migrator,
   type Kysely,
   type Migration,
   type MigrationProvider,
+  Migrator,
 } from 'kysely';
 import os from 'os';
 import path from 'path';

--- a/packages/db/src/use-cases/truncate.ts
+++ b/packages/db/src/use-cases/truncate.ts
@@ -1,4 +1,4 @@
-import { type Transaction, sql } from 'kysely';
+import { sql, type Transaction } from 'kysely';
 
 import { IS_PRODUCTION } from '../shared/env';
 import { type DB } from '../shared/types';


### PR DESCRIPTION
## Description ✏️

This PR enables the [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) rule. We ensure that it doesn't clash with [`import/order`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) by specifying:

```js
ignoreDeclarationSort: true
```

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [x] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
