### PR TITLE
feat: see events recordings in the member profile  👀

### DIFF
--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -136,7 +136,7 @@ function PastEventItem({ event }: PastEventItemProps) {
     <li className="flex flex-col rounded-3xl border border-gray-200">
       <div className="h-24 w-full rounded-[inherit] bg-[url(/images/colorstack-background.png)] bg-contain" />
 
-      <div className="flex flex-1 flex-col gap-4 p-4">
+      <div className="flex flex-1 flex-col gap-3 p-4">
         <EventName name={event.name} />
         <EventDate date={event.date} />
 

--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -45,6 +45,7 @@ async function getPastEvents({ timezone }: GetPastEventsInput) {
       'id',
       'name',
       'startTime',
+      'recordingLink',
       (eb) => {
         return eb
           .selectFrom(
@@ -144,6 +145,12 @@ function PastEventItem({ event }: PastEventItemProps) {
             id={event.id}
             profilePictures={event.profilePictures}
           />
+        )}
+
+        {!!event.recordingLink && (
+          <a className="link" href={event.recordingLink} target="_blank">
+            View Recorded Event
+          </a>
         )}
       </div>
     </li>

--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -5,9 +5,10 @@ import {
 } from '@remix-run/node';
 import { generatePath, Link, Outlet, useLoaderData } from '@remix-run/react';
 import { sql } from 'kysely';
+import { Video } from 'react-feather';
 
 import { EventType } from '@oyster/types';
-import { ProfilePicture } from '@oyster/ui';
+import { cx, getButtonCn, ProfilePicture } from '@oyster/ui';
 
 import {
   EventDate,
@@ -44,8 +45,8 @@ async function getPastEvents({ timezone }: GetPastEventsInput) {
       'endTime',
       'id',
       'name',
-      'startTime',
       'recordingLink',
+      'startTime',
       (eb) => {
         return eb
           .selectFrom(
@@ -135,7 +136,7 @@ function PastEventItem({ event }: PastEventItemProps) {
     <li className="flex flex-col rounded-3xl border border-gray-200">
       <div className="h-24 w-full rounded-[inherit] bg-[url(/images/colorstack-background.png)] bg-contain" />
 
-      <div className="flex flex-1 flex-col gap-3 p-4">
+      <div className="flex flex-1 flex-col gap-4 p-4">
         <EventName name={event.name} />
         <EventDate date={event.date} />
 
@@ -148,8 +149,15 @@ function PastEventItem({ event }: PastEventItemProps) {
         )}
 
         {!!event.recordingLink && (
-          <a className="link" href={event.recordingLink} target="_blank">
-            View Recorded Event
+          <a
+            className={cx(
+              getButtonCn({ fill: true, size: 'small', variant: 'secondary' }),
+              'mt-2'
+            )}
+            href={event.recordingLink}
+            target="_blank"
+          >
+            View Recording <Video />
           </a>
         )}
       </div>


### PR DESCRIPTION
## Description ✏️

Closes #69 

A member can use the events panel in the Member Profile to:

- Go to the "past events" page.
- For an individual event, a member can click a "View Event Recording" button, just below the attendee list/count. This should open the link in a new tab.

![localhost_3000_events_past](https://github.com/colorstackorg/oyster/assets/121850312/ea5f53ae-5388-49f8-b283-9181bfccf997)


## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
