### PR TITLE
feat: update census response to `json` column 📀

### DIFF
--- a/packages/db/src/migrations/20240416173934_census_json.ts
+++ b/packages/db/src/migrations/20240416173934_census_json.ts
@@ -1,0 +1,19 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('census_responses')
+    .alterColumn('json', (column) => {
+      return column.setDataType('json');
+    })
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('census_responses')
+    .alterColumn('json', (column) => {
+      return column.setDataType('jsonb');
+    })
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

Closes #70.

This PR updates the `json` column to be of type `json` instead of `jsonb`, which is needed because Metabase doesn't unfold `jsonb` columns.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
