### PR TITLE
fix: remove career coaching resource from home page🧋

### DIFF
--- a/apps/member-profile/app/routes/_profile.home.tsx
+++ b/apps/member-profile/app/routes/_profile.home.tsx
@@ -639,13 +639,6 @@ function ImportantResourcesCard() {
         </ResourceItem>
 
         <ResourceItem
-          description="A space for 1:1 coaching. Ask any career questions from resume help to negotiating your offer."
-          href="https://calendly.com/catalystcreation/color-stack-decoded-1-1-coaching-sessions-"
-        >
-          Career Coaching w/ Cataliña
-        </ResourceItem>
-
-        <ResourceItem
           description="A collection of our past event recordings. Don't miss a beat!"
           href="https://youtube.com/@colorstackinc.2266"
         >


### PR DESCRIPTION
## Description ✏️

Closes #146 

- Removes the career coaching piece from `ImportantResourcesCard` from the home page

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
