### PR TITLE
fix: past events spacing 🪐

### DIFF
--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -153,7 +153,7 @@ function PastEventItem({ event }: PastEventItemProps) {
             getButtonCn({ fill: true, size: 'small', variant: 'secondary' }),
             !event.recordingLink && 'invisible'
           )}
-          href={event.recordingLink}
+          href={event.recordingLink || undefined}
           target="_blank"
         >
           View Recording <Video />

--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -151,7 +151,6 @@ function PastEventItem({ event }: PastEventItemProps) {
         <a
           className={cx(
             getButtonCn({ fill: true, size: 'small', variant: 'secondary' }),
-            'mt-2',
             !event.recordingLink && 'invisible'
           )}
           href={event.recordingLink}

--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -148,18 +148,17 @@ function PastEventItem({ event }: PastEventItemProps) {
           />
         )}
 
-        {!!event.recordingLink && (
-          <a
-            className={cx(
-              getButtonCn({ fill: true, size: 'small', variant: 'secondary' }),
-              'mt-2'
-            )}
-            href={event.recordingLink}
-            target="_blank"
-          >
-            View Recording <Video />
-          </a>
-        )}
+        <a
+          className={cx(
+            getButtonCn({ fill: true, size: 'small', variant: 'secondary' }),
+            'mt-2',
+            !event.recordingLink && 'invisible'
+          )}
+          href={event.recordingLink}
+          target="_blank"
+        >
+          View Recording <Video />
+        </a>
       </div>
     </li>
   );


### PR DESCRIPTION
## Description ✏️

This PR fixes the spacing of past events. The issue was that not all past events have event recordings, so the alignment of the different cards looked awkward.

### Before / After
![Screenshot 2024-04-22 at 9 10 47 PM](https://github.com/colorstackorg/oyster/assets/38056800/44eef2ec-5bb9-4dbb-a3d0-ee766e8c3e0b)

![Screenshot 2024-04-22 at 9 10 17 PM](https://github.com/colorstackorg/oyster/assets/38056800/755f696d-3e71-4323-9918-6a77380c2f4c)

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
