### PR TITLE
fix: save company in census submission 💼

### DIFF
--- a/packages/core/src/modules/census/use-cases/submit-census-response.ts
+++ b/packages/core/src/modules/census/use-cases/submit-census-response.ts
@@ -5,6 +5,7 @@ import { MemberType } from '@oyster/types';
 
 import { job } from '@/infrastructure/bull/use-cases/job';
 import { type SubmitCensusResponseData } from '@/modules/census/census.types';
+import { saveCompanyIfNecessary } from '@/modules/employment/use-cases/save-company-if-necessary';
 
 export async function submitCensusResponse(
   memberId: string,
@@ -13,6 +14,10 @@ export async function submitCensusResponse(
   const year = new Date().getFullYear();
 
   await db.transaction().execute(async (trx) => {
+    if (data.companyId) {
+      await saveCompanyIfNecessary(trx, data.companyId);
+    }
+
     await trx
       .updateTable('students')
       .set({ type: data.hasGraduated ? MemberType.ALUMNI : MemberType.STUDENT })


### PR DESCRIPTION
## Description ✏️

When submitting a census response and selecting a company for an internship/full-time position, we're not actually saving that company if it doesn't already exist in our database. This results in us not being able to populate the name of the company when creating Metabase analytics.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
