### PR TITLE
refactor: remove airtable npm library 🌭

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,6 @@
     "@oyster/utils": "*",
     "@react-email/render": "^0.0.6",
     "@slack/web-api": "^6.7.2",
-    "airtable": "^0.11.6",
     "bullmq": "^4.12.2",
     "dayjs": "^1.11.5",
     "dedent": "^0.7.0",

--- a/packages/core/src/modules/airtable/airtable.shared.ts
+++ b/packages/core/src/modules/airtable/airtable.shared.ts
@@ -1,11 +1,13 @@
-import Airtable from 'airtable';
-
 import { RateLimiter } from '@/shared/utils/rate-limiter';
 
 // Environment Variables
 
-const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY as string;
-const AIRTABLE_FAMILY_BASE_ID = process.env.AIRTABLE_FAMILY_BASE_ID as string;
+export const { AIRTABLE_API_KEY, AIRTABLE_FAMILY_BASE_ID } = process.env;
+
+// Constants
+
+export const AIRTABLE_API_URI = 'https://api.airtable.com/v0';
+export const AIRTABLE_MEMBERS_TABLE = 'Members';
 
 // Rate Limiter
 
@@ -16,41 +18,3 @@ export const airtableRateLimiter = new RateLimiter('airtable:connections', {
   rateLimit: 5,
   rateLimitWindow: 1,
 });
-
-// Helpers
-
-export async function getAirtableRecord(email: string) {
-  const table = getMembersAirtable();
-
-  await airtableRateLimiter.process();
-
-  const [record] = await table
-    .select({
-      fields: [],
-      filterByFormula: `({Email} = "${email}")`,
-      maxRecords: 1,
-    })
-    .firstPage();
-
-  return record;
-}
-
-export function getMembersAirtable() {
-  const airtable = getAirtableInstance();
-  const base = airtable.base(AIRTABLE_FAMILY_BASE_ID);
-  const table = base('Members');
-
-  return table;
-}
-
-export function getAirtableInstance() {
-  if (!AIRTABLE_API_KEY) {
-    throw new Error(
-      '"AIRTABLE_API_KEY" is not set, so Airtable integration is disabled.'
-    );
-  }
-
-  return new Airtable({
-    apiKey: AIRTABLE_API_KEY,
-  });
-}

--- a/packages/core/src/modules/airtable/airtable.shared.ts
+++ b/packages/core/src/modules/airtable/airtable.shared.ts
@@ -9,6 +9,7 @@ const { AIRTABLE_API_KEY } = process.env;
 
 export const AIRTABLE_API_URI = 'https://api.airtable.com/v0';
 export const AIRTABLE_MEMBERS_TABLE = 'Members';
+export const AIRTABLE_MEMBERS_URI = `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}`;
 
 // Rate Limiter
 

--- a/packages/core/src/modules/airtable/airtable.shared.ts
+++ b/packages/core/src/modules/airtable/airtable.shared.ts
@@ -2,8 +2,9 @@ import { RateLimiter } from '@/shared/utils/rate-limiter';
 
 // Environment Variables
 
-export const { AIRTABLE_FAMILY_BASE_ID } = process.env;
-const { AIRTABLE_API_KEY } = process.env;
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
+
+export const AIRTABLE_FAMILY_BASE_ID = process.env.AIRTABLE_FAMILY_BASE_ID;
 
 // Constants
 

--- a/packages/core/src/modules/airtable/airtable.shared.ts
+++ b/packages/core/src/modules/airtable/airtable.shared.ts
@@ -2,7 +2,8 @@ import { RateLimiter } from '@/shared/utils/rate-limiter';
 
 // Environment Variables
 
-export const { AIRTABLE_API_KEY, AIRTABLE_FAMILY_BASE_ID } = process.env;
+export const { AIRTABLE_FAMILY_BASE_ID } = process.env;
+const { AIRTABLE_API_KEY } = process.env;
 
 // Constants
 
@@ -18,3 +19,16 @@ export const airtableRateLimiter = new RateLimiter('airtable:connections', {
   rateLimit: 5,
   rateLimitWindow: 1,
 });
+
+// Functions
+
+export function getAirtableHeaders(
+  options: { includeContentType: boolean } = { includeContentType: false }
+) {
+  return {
+    Authorization: `Bearer ${AIRTABLE_API_KEY}`,
+    ...(options.includeContentType && {
+      'Content-Type': 'application/json',
+    }),
+  };
+}

--- a/packages/core/src/modules/airtable/queries/get-airtable-record.ts
+++ b/packages/core/src/modules/airtable/queries/get-airtable-record.ts
@@ -7,6 +7,9 @@ import {
   AIRTABLE_MEMBERS_TABLE,
 } from '@/modules/airtable/airtable.shared';
 
+/**
+ * @see https://airtable.com/developers/web/api/list-records
+ */
 export async function getAirtableRecord(email: string) {
   const url = new URL(
     `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}`

--- a/packages/core/src/modules/airtable/queries/get-airtable-record.ts
+++ b/packages/core/src/modules/airtable/queries/get-airtable-record.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import {
+  AIRTABLE_API_KEY,
+  AIRTABLE_API_URI,
+  AIRTABLE_FAMILY_BASE_ID,
+  AIRTABLE_MEMBERS_TABLE,
+} from '@/modules/airtable/airtable.shared';
+
+export async function getAirtableRecord(email: string) {
+  const url = new URL(
+    `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}`
+  );
+
+  url.searchParams.set('fields', '[]');
+  url.searchParams.set('filterByFormula', `({Email} = "${email}")`);
+  url.searchParams.set('maxRecords', '1');
+
+  const response = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+    method: 'get',
+  });
+
+  const json = await response.json();
+
+  const [record] = z
+    .object({ id: z.string().min(1) })
+    .array()
+    .parse(json.records);
+
+  return record;
+}

--- a/packages/core/src/modules/airtable/queries/get-airtable-record.ts
+++ b/packages/core/src/modules/airtable/queries/get-airtable-record.ts
@@ -1,9 +1,7 @@
 import { z } from 'zod';
 
 import {
-  AIRTABLE_API_URI,
-  AIRTABLE_FAMILY_BASE_ID,
-  AIRTABLE_MEMBERS_TABLE,
+  AIRTABLE_MEMBERS_URI,
   getAirtableHeaders,
 } from '@/modules/airtable/airtable.shared';
 
@@ -11,9 +9,7 @@ import {
  * @see https://airtable.com/developers/web/api/list-records
  */
 export async function getAirtableRecord(email: string) {
-  const url = new URL(
-    `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}`
-  );
+  const url = new URL(AIRTABLE_MEMBERS_URI);
 
   url.searchParams.set('fields', '[]');
   url.searchParams.set('filterByFormula', `({Email} = "${email}")`);

--- a/packages/core/src/modules/airtable/queries/get-airtable-record.ts
+++ b/packages/core/src/modules/airtable/queries/get-airtable-record.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
 import {
-  AIRTABLE_API_KEY,
   AIRTABLE_API_URI,
   AIRTABLE_FAMILY_BASE_ID,
   AIRTABLE_MEMBERS_TABLE,
+  getAirtableHeaders,
 } from '@/modules/airtable/airtable.shared';
 
 /**
@@ -20,7 +20,7 @@ export async function getAirtableRecord(email: string) {
   url.searchParams.set('maxRecords', '1');
 
   const response = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+    headers: getAirtableHeaders(),
     method: 'get',
   });
 

--- a/packages/core/src/modules/airtable/queries/get-airtable-record.ts
+++ b/packages/core/src/modules/airtable/queries/get-airtable-record.ts
@@ -11,7 +11,6 @@ import {
 export async function getAirtableRecord(email: string) {
   const url = new URL(AIRTABLE_MEMBERS_URI);
 
-  url.searchParams.set('fields', '[]');
   url.searchParams.set('filterByFormula', `({Email} = "${email}")`);
   url.searchParams.set('maxRecords', '1');
 

--- a/packages/core/src/modules/airtable/use-cases/create-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/create-airtable-record.ts
@@ -1,9 +1,9 @@
 import { type GetBullJobData } from '@/infrastructure/bull/bull.types';
 import { IS_PRODUCTION } from '@/shared/env';
 import {
-  AIRTABLE_API_KEY,
   AIRTABLE_API_URI,
   airtableRateLimiter,
+  getAirtableHeaders,
 } from '../airtable.shared';
 
 /**
@@ -29,10 +29,7 @@ export async function createAirtableRecord({
       // create that value instead of failing.
       typecast: true,
     }),
-    headers: {
-      Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
+    headers: getAirtableHeaders({ includeContentType: true }),
     method: 'post',
   });
 

--- a/packages/core/src/modules/airtable/use-cases/create-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/create-airtable-record.ts
@@ -6,6 +6,9 @@ import {
   airtableRateLimiter,
 } from '../airtable.shared';
 
+/**
+ * @see https://airtable.com/developers/web/api/create-records
+ */
 export async function createAirtableRecord({
   baseId,
   data,

--- a/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
@@ -3,9 +3,7 @@ import { getAirtableRecord } from '@/modules/airtable/queries/get-airtable-recor
 import { IS_PRODUCTION } from '@/shared/env';
 import { NotFoundError } from '@/shared/errors';
 import {
-  AIRTABLE_API_URI,
-  AIRTABLE_FAMILY_BASE_ID,
-  AIRTABLE_MEMBERS_TABLE,
+  AIRTABLE_MEMBERS_URI,
   airtableRateLimiter,
   getAirtableHeaders,
 } from '../airtable.shared';
@@ -30,13 +28,10 @@ export async function deleteAirtableRecord({
 
   await airtableRateLimiter.process();
 
-  await fetch(
-    `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}/${record.id}`,
-    {
-      headers: getAirtableHeaders(),
-      method: 'delete',
-    }
-  );
+  await fetch(`${AIRTABLE_MEMBERS_URI}/${record.id}`, {
+    headers: getAirtableHeaders(),
+    method: 'delete',
+  });
 
   console.log({
     code: 'airtable_record_deleted',

--- a/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
@@ -1,10 +1,13 @@
 import { type GetBullJobData } from '@/infrastructure/bull/bull.types';
+import { getAirtableRecord } from '@/modules/airtable/queries/get-airtable-record';
 import { IS_PRODUCTION } from '@/shared/env';
 import { NotFoundError } from '@/shared/errors';
 import {
+  AIRTABLE_API_KEY,
+  AIRTABLE_API_URI,
+  AIRTABLE_FAMILY_BASE_ID,
+  AIRTABLE_MEMBERS_TABLE,
   airtableRateLimiter,
-  getAirtableRecord,
-  getMembersAirtable,
 } from '../airtable.shared';
 
 export async function deleteAirtableRecord({
@@ -22,11 +25,15 @@ export async function deleteAirtableRecord({
     });
   }
 
-  const table = getMembersAirtable();
-
   await airtableRateLimiter.process();
 
-  await table.destroy(record.id);
+  await fetch(
+    `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}/${record.id}`,
+    {
+      headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+      method: 'delete',
+    }
+  );
 
   console.log({
     code: 'airtable_record_deleted',

--- a/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
@@ -10,6 +10,9 @@ import {
   airtableRateLimiter,
 } from '../airtable.shared';
 
+/**
+ * @see https://airtable.com/developers/web/api/delete-record
+ */
 export async function deleteAirtableRecord({
   email,
 }: GetBullJobData<'airtable.record.delete'>) {

--- a/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/delete-airtable-record.ts
@@ -3,11 +3,11 @@ import { getAirtableRecord } from '@/modules/airtable/queries/get-airtable-recor
 import { IS_PRODUCTION } from '@/shared/env';
 import { NotFoundError } from '@/shared/errors';
 import {
-  AIRTABLE_API_KEY,
   AIRTABLE_API_URI,
   AIRTABLE_FAMILY_BASE_ID,
   AIRTABLE_MEMBERS_TABLE,
   airtableRateLimiter,
+  getAirtableHeaders,
 } from '../airtable.shared';
 
 /**
@@ -33,7 +33,7 @@ export async function deleteAirtableRecord({
   await fetch(
     `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}/${record.id}`,
     {
-      headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+      headers: getAirtableHeaders(),
       method: 'delete',
     }
   );

--- a/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
@@ -30,7 +30,9 @@ export async function updateAirtableRecord({
   await airtableRateLimiter.process();
 
   await fetch(`${AIRTABLE_MEMBERS_URI}/${record.id}`, {
-    body: JSON.stringify({ Email: newEmail }),
+    body: JSON.stringify({
+      fields: { Email: newEmail },
+    }),
     headers: getAirtableHeaders({ includeContentType: true }),
     method: 'patch',
   });

--- a/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
@@ -3,9 +3,7 @@ import { getAirtableRecord } from '@/modules/airtable/queries/get-airtable-recor
 import { IS_PRODUCTION } from '@/shared/env';
 import { NotFoundError } from '@/shared/errors';
 import {
-  AIRTABLE_API_URI,
-  AIRTABLE_FAMILY_BASE_ID,
-  AIRTABLE_MEMBERS_TABLE,
+  AIRTABLE_MEMBERS_URI,
   airtableRateLimiter,
   getAirtableHeaders,
 } from '../airtable.shared';
@@ -31,14 +29,11 @@ export async function updateAirtableRecord({
 
   await airtableRateLimiter.process();
 
-  await fetch(
-    `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}/${record.id}`,
-    {
-      body: JSON.stringify({ Email: newEmail }),
-      headers: getAirtableHeaders({ includeContentType: true }),
-      method: 'patch',
-    }
-  );
+  await fetch(`${AIRTABLE_MEMBERS_URI}/${record.id}`, {
+    body: JSON.stringify({ Email: newEmail }),
+    headers: getAirtableHeaders({ includeContentType: true }),
+    method: 'patch',
+  });
 
   console.log({
     code: 'airtable_record_updated',

--- a/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
@@ -3,11 +3,11 @@ import { getAirtableRecord } from '@/modules/airtable/queries/get-airtable-recor
 import { IS_PRODUCTION } from '@/shared/env';
 import { NotFoundError } from '@/shared/errors';
 import {
-  AIRTABLE_API_KEY,
   AIRTABLE_API_URI,
   AIRTABLE_FAMILY_BASE_ID,
   AIRTABLE_MEMBERS_TABLE,
   airtableRateLimiter,
+  getAirtableHeaders,
 } from '../airtable.shared';
 
 /**
@@ -35,10 +35,7 @@ export async function updateAirtableRecord({
     `${AIRTABLE_API_URI}/${AIRTABLE_FAMILY_BASE_ID}/${AIRTABLE_MEMBERS_TABLE}/${record.id}`,
     {
       body: JSON.stringify({ Email: newEmail }),
-      headers: {
-        Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
+      headers: getAirtableHeaders({ includeContentType: true }),
       method: 'patch',
     }
   );

--- a/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
+++ b/packages/core/src/modules/airtable/use-cases/update-airtable-record.ts
@@ -10,6 +10,9 @@ import {
   airtableRateLimiter,
 } from '../airtable.shared';
 
+/**
+ * @see https://airtable.com/developers/web/api/update-record
+ */
 export async function updateAirtableRecord({
   newEmail,
   previousEmail,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,11 +2024,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
   integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
-"@types/node@>=8.0.0 <15":
-  version "14.18.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.37.tgz#0bfcd173e8e1e328337473a8317e37b3b14fd30d"
-  integrity sha512-7GgtHCs/QZrBrDzgIJnQtuSvhFSwhyYSI2uafSwZoNt1iOGhEN5fwNrQMjtONyHm9+/LoA4453jH0CMYcr06Pg==
-
 "@types/node@^16.0.0":
   version "16.11.59"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.59.tgz#823f238b9063ccc3b3b7f13186f143a57926c4f6"
@@ -2338,11 +2333,6 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abortcontroller-polyfill@^1.4.0:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
-  integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
-
 accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -2402,17 +2392,6 @@ ahocorasick@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ahocorasick/-/ahocorasick-1.0.2.tgz#9eee93aef9d02bfb476d9b648d9b7a40ef2fd500"
   integrity sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==
-
-airtable@^0.11.6:
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/airtable/-/airtable-0.11.6.tgz#3b90f9c671ee93c4ad647eb131d630dea9f1f84a"
-  integrity sha512-Na67L2TO1DflIJ1yOGhQG5ilMfL2beHpsR+NW/jhaYOa4QcoxZOtDFs08cpSd1tBMsLpz5/rrz/VMX/pGL/now==
-  dependencies:
-    "@types/node" ">=8.0.0 <15"
-    abort-controller "^3.0.0"
-    abortcontroller-polyfill "^1.4.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.7"
 
 ajv@^6.12.4:
   version "6.12.6"


### PR DESCRIPTION
## Description ✏️

Related to #151.

The `airtable` library is not compatible the Bun runtime so we'll need to remove it. This PR refactors the Airtable code to just use the native `fetch` API.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
