### PR TITLE
feat: add an upcoming airmeet event in admin dashboard🏅

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -1,0 +1,125 @@
+import {
+  type ActionFunctionArgs,
+  json,
+  type LoaderFunctionArgs,
+  redirect,
+} from '@remix-run/node';
+import {
+  Form as RemixForm,
+  useActionData,
+  useNavigate,
+  useNavigation,
+} from '@remix-run/react';
+import { z } from 'zod';
+
+import { Event } from '@oyster/types';
+import {
+  Button,
+  Form,
+  getActionErrors,
+  Input,
+  Modal,
+  validateForm,
+} from '@oyster/ui';
+
+import { Route } from '../shared/constants';
+import { job } from '../shared/core.server';
+import {
+  commitSession,
+  ensureUserAuthenticated,
+  toast,
+} from '../shared/session.server';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await ensureUserAuthenticated(request);
+
+  return json({});
+}
+
+const SyncAirmeetEventFormData = z.object({
+  eventId: Event.shape.id,
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await ensureUserAuthenticated(request);
+
+  const form = await request.formData();
+
+  const { data, errors } = validateForm(
+    SyncAirmeetEventFormData,
+    Object.fromEntries(form)
+  );
+
+  if (!data) {
+    return json({
+      error: 'Something went wrong, please try again.',
+      errors,
+    });
+  }
+
+  const { eventId } = Object.fromEntries(form);
+
+  job('event.sync', {
+    eventId: eventId as string,
+  });
+
+  toast(session, {
+    message: `Airmeet Event Synced.`,
+    type: 'success',
+  });
+
+  return redirect(Route.EVENTS, {
+    headers: {
+      'Set-Cookie': await commitSession(session),
+    },
+  });
+}
+
+export default function SyncAirmeetEventPage() {
+  const navigate = useNavigate();
+
+  function onClose() {
+    navigate(-1);
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <Modal.Header>
+        <Modal.Title>Sync Airmeet Event</Modal.Title>
+        <Modal.CloseButton />
+      </Modal.Header>
+
+      <SyncAirmeetEventForm />
+    </Modal>
+  );
+}
+
+const { eventId } = SyncAirmeetEventFormData.keyof().enum;
+
+function SyncAirmeetEventForm() {
+  const { error, errors } = getActionErrors(useActionData<typeof action>());
+  const submitting = useNavigation().state === 'submitting';
+
+  return (
+    <RemixForm>
+      <Form.Field
+        error={errors.eventId}
+        label="Airmeet ID"
+        labelFor={eventId}
+        required
+      >
+        <Input id={eventId} name={eventId} required />
+      </Form.Field>
+
+      <br />
+
+      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+
+      <Button.Group>
+        <Button loading={submitting} type="submit">
+          Sync Airmeet Event
+        </Button>
+      </Button.Group>
+    </RemixForm>
+  );
+}

--- a/apps/admin-dashboard/app/routes/_dashboard.events.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.tsx
@@ -6,7 +6,7 @@ import {
 import { Link, Outlet, useLoaderData } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { useState } from 'react';
-import { Menu, Plus, Upload } from 'react-feather';
+import { Menu, Plus, RefreshCw, Upload } from 'react-feather';
 import { generatePath } from 'react-router';
 
 import { type Event } from '@oyster/types';
@@ -118,6 +118,11 @@ function EventsMenuDropdown() {
             <Dropdown.Item>
               <Link to={Route.CREATE_EVENT}>
                 <Plus /> Create Event
+              </Link>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Link to={Route.SYNC_AIRMEET_EVENT}>
+                <RefreshCw /> Sync Airmeet Event
               </Link>
             </Dropdown.Item>
           </Dropdown.List>

--- a/apps/admin-dashboard/app/shared/constants.ts
+++ b/apps/admin-dashboard/app/shared/constants.ts
@@ -25,6 +25,7 @@ export const Route = {
   CREATE_EVENT: '/events/create',
   EVENTS: '/events',
   IMPORT_EVENT_ATTENDEES: '/events/:id/import',
+  SYNC_AIRMEET_EVENT: '/events/sync-airmeet-event',
 
   // Feature Flags
 


### PR DESCRIPTION
## Description ✏️

Closes #170 

There is now an additional button under the menu button that says Sync Airmeet Event in the admin dashboard. It opens up a modal allowing the user to submit an Airmeet ID. Upon clicking submit, the Airmeet event is created in our database (and thus populated in the Member Profile) using the job function.

## Tasks

- Added modal to receive Airmeet ID from user.
<img width="1207" alt="Screenshot 2024-04-28 at 7 08 39 PM" src="https://github.com/colorstackorg/oyster/assets/121850312/62970e7e-bf56-4569-8b30-51b1ef77c8bd">

- Calls the job function to sync airmeet event to the database.

## Extra Info / Questions

- I have not ran an end to end simulation as I don't have an airmeet account.
- Should I add an extra type check to make sure eventID is a string?

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
