### PR TITLE
refactor: rename `reportError` to `reportException` 🪲

### DIFF
--- a/apps/member-profile/app/routes/_profile.home.claim-swag-pack._index.tsx
+++ b/apps/member-profile/app/routes/_profile.home.claim-swag-pack._index.tsx
@@ -21,7 +21,7 @@ import {
 } from '@oyster/ui';
 
 import { Route } from '../shared/constants';
-import { claimSwagPack, db, reportError } from '../shared/core.server';
+import { claimSwagPack, db, reportException } from '../shared/core.server';
 import { ClaimSwagPackInput } from '../shared/core.ui';
 import { ensureUserAuthenticated, user } from '../shared/session.server';
 
@@ -81,7 +81,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     return redirect(Route.CLAIM_SWAG_PACK_CONFIRMATION);
   } catch (e) {
-    reportError(e);
+    reportException(e);
 
     return json({
       error: `Something went wrong. Please double check that you have a valid address. If you are still having trouble, reach out to membership@colorstack.org for further assistance.`,

--- a/apps/member-profile/app/routes/companies.tsx
+++ b/apps/member-profile/app/routes/companies.tsx
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 import {
-  reportError,
+  reportException,
   searchCrunchbaseOrganizations,
 } from '../shared/core.server';
 import { ensureUserAuthenticated } from '../shared/session.server';
@@ -33,7 +33,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       companies,
     });
   } catch (e) {
-    reportError(e);
+    reportException(e);
 
     return json({
       companies: [],

--- a/apps/member-profile/app/routes/integrations.oauth.github.ts
+++ b/apps/member-profile/app/routes/integrations.oauth.github.ts
@@ -6,7 +6,7 @@ import { ENV } from '../shared/constants.server';
 import {
   authenticateWithGithub,
   getGithubProfile,
-  reportError,
+  reportException,
   updateMember,
 } from '../shared/core.server';
 import { ensureUserAuthenticated, user } from '../shared/session.server';
@@ -53,7 +53,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       memberId,
     });
 
-    reportError(error);
+    reportException(error);
   }
 
   return redirect(Route['/profile/integrations']);

--- a/packages/core/src/infrastructure/bull/use-cases/job.ts
+++ b/packages/core/src/infrastructure/bull/use-cases/job.ts
@@ -1,6 +1,6 @@
 import { type JobsOptions } from 'bullmq';
 
-import { reportError } from '@/modules/sentry/use-cases/report-error';
+import { reportException } from '@/modules/sentry/use-cases/report-exception';
 import { QueueFromName } from '../bull';
 import { BullJob, type BullQueue, type GetBullJobData } from '../bull.types';
 
@@ -15,7 +15,7 @@ export function job<JobName extends BullJob['name']>(
   });
 
   if (!result.success) {
-    reportError(result.error);
+    reportException(result.error);
 
     return;
   }
@@ -25,7 +25,7 @@ export function job<JobName extends BullJob['name']>(
   const queueName = QueueNameFromJobName[job.name];
   const queue = QueueFromName[queueName];
 
-  queue.add(job.name, job.data, options).catch((e) => reportError(e));
+  queue.add(job.name, job.data, options).catch((e) => reportException(e));
 }
 
 const QueueNameFromJobName: Record<BullJob['name'], BullQueue> = {

--- a/packages/core/src/infrastructure/bull/use-cases/register-worker.ts
+++ b/packages/core/src/infrastructure/bull/use-cases/register-worker.ts
@@ -2,7 +2,7 @@ import { type Job, QueueEvents, Worker, type WorkerOptions } from 'bullmq';
 import { Redis } from 'ioredis';
 import { type z, type ZodType } from 'zod';
 
-import { reportError } from '@/modules/sentry/use-cases/report-error';
+import { reportException } from '@/modules/sentry/use-cases/report-exception';
 import { ENV } from '@/shared/env';
 import { ErrorWithContext, ZodParseError } from '@/shared/errors';
 import { type BullQueue } from '../bull.types';
@@ -40,7 +40,7 @@ export function registerWorker<Schema extends ZodType>(
   });
 
   queueEvents.on('failed', ({ failedReason, jobId }) => {
-    reportError(
+    reportException(
       new BullJobFailedError(failedReason).withContext({
         jobId,
       })

--- a/packages/core/src/member-profile.server.ts
+++ b/packages/core/src/member-profile.server.ts
@@ -45,7 +45,7 @@ export { changePrimaryEmail } from './modules/member/use-cases/change-primary-em
 export { joinMemberDirectory } from './modules/member/use-cases/join-member-directory';
 export { updateAllowEmailShare } from './modules/member/use-cases/update-allow-email-share';
 export { updateMember } from './modules/member/use-cases/update-member';
-export { reportError } from './modules/sentry/use-cases/report-error';
+export { reportException } from './modules/sentry/use-cases/report-exception';
 export { countMessagesSent } from './modules/slack/queries/count-messages-sent';
 export { claimSwagPack } from './modules/swag-pack/use-cases/claim-swag-pack';
 export { getIpAddress } from './shared/utils/ip.utils';

--- a/packages/core/src/modules/event/airmeet-event.service.ts
+++ b/packages/core/src/modules/event/airmeet-event.service.ts
@@ -5,7 +5,7 @@ import { Event, EventAttendee } from '@oyster/types';
 import { sleep } from '@oyster/utils';
 
 import { redis, RedisKey } from '@/infrastructure/redis';
-import { reportError } from '@/modules/sentry/use-cases/report-error';
+import { reportException } from '@/modules/sentry/use-cases/report-exception';
 import { ENV, IS_PRODUCTION } from '@/shared/env';
 import { ErrorWithContext } from '@/shared/errors';
 import { validate } from '@/shared/utils/zod.utils';
@@ -258,7 +258,7 @@ export async function registerForAirmeetEvent(input: RegisterForEventInput) {
   if (!response.ok) {
     const error = new RegisterForAirmeetEventError().withContext(data);
 
-    reportError(error);
+    reportException(error);
     throw error;
   }
 

--- a/packages/core/src/modules/member/events/member-created.ts
+++ b/packages/core/src/modules/member/events/member-created.ts
@@ -2,7 +2,7 @@ import { type GetBullJobData } from '@/infrastructure/bull/bull.types';
 import { job } from '@/infrastructure/bull/use-cases/job';
 import { db } from '@/infrastructure/database';
 import { addMailchimpListMember } from '@/modules/mailchimp/use-cases/add-mailchimp-list-member';
-import { reportError } from '@/modules/sentry/use-cases/report-error';
+import { reportException } from '@/modules/sentry/use-cases/report-exception';
 
 type StudentCreatedInput = GetBullJobData<'student.created'>;
 
@@ -45,6 +45,6 @@ export async function onMemberCreated(input: StudentCreatedInput) {
       lastName: student.lastName,
     });
   } catch (e) {
-    reportError(e);
+    reportException(e);
   }
 }

--- a/packages/core/src/modules/member/events/member-primary-email-changed.ts
+++ b/packages/core/src/modules/member/events/member-primary-email-changed.ts
@@ -2,7 +2,7 @@ import { type GetBullJobData } from '@/infrastructure/bull/bull.types';
 import { job } from '@/infrastructure/bull/use-cases/job';
 import { db } from '@/infrastructure/database';
 import { updateMailchimpListMember } from '@/modules/mailchimp/use-cases/update-mailchimp-list-member';
-import { reportError } from '@/modules/sentry/use-cases/report-error';
+import { reportException } from '@/modules/sentry/use-cases/report-exception';
 import { updateSlackEmail } from '@/modules/slack/services/slack-user.service';
 import { NotFoundError } from '@/shared/errors';
 
@@ -77,7 +77,7 @@ async function updateEmailMarketingMember(
       id: input.previousEmail,
     });
   } catch (e) {
-    reportError(e);
+    reportException(e);
   }
 }
 
@@ -91,6 +91,6 @@ async function updateEmailOnSlack(input: UpdateSlackUserInput) {
 
     await updateSlackEmail(id, input.email);
   } catch (e) {
-    reportError(e);
+    reportException(e);
   }
 }

--- a/packages/core/src/modules/sentry/use-cases/report-exception.ts
+++ b/packages/core/src/modules/sentry/use-cases/report-exception.ts
@@ -6,7 +6,7 @@ import {
   ErrorWithContext,
 } from '@/shared/errors';
 
-export function reportError(error: unknown): void {
+export function reportException(error: unknown): void {
   let context: ErrorContext | undefined = undefined;
   let level: ErrorLevel = 'error';
 

--- a/packages/core/src/modules/slack/services/slack-admin.service.ts
+++ b/packages/core/src/modules/slack/services/slack-admin.service.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { redis, RedisKey } from '@/infrastructure/redis';
-import { reportError } from '@/modules/sentry/use-cases/report-error';
+import { reportException } from '@/modules/sentry/use-cases/report-exception';
 import { ErrorWithContext, ZodParseError } from '@/shared/errors';
 import { RateLimiter } from '@/shared/utils/rate-limiter';
 
@@ -42,7 +42,7 @@ export async function deactivateSlackUser(id: string) {
   }
 
   if (error) {
-    reportError(error);
+    reportException(error);
     throw error;
   }
 
@@ -85,7 +85,7 @@ export async function inviteSlackUser(email: string) {
   }
 
   if (error) {
-    reportError(error);
+    reportException(error);
     throw error;
   }
 


### PR DESCRIPTION
## Description ✏️

Closes #164 

- Every instance of [`reportError`](https://github.com/colorstackorg/oyster/blob/1fe26e432ab19fffef421403402ac7ceb49150f9/packages/core/src/modules/sentry/use-cases/report-error.ts#L9) from the Sentry module has been renamed to `reportException`

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [X] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [X] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
