### PR TITLE
feat: save slack id upon invitation 🆔

### DIFF
--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -395,6 +395,12 @@ export const SlackBullJob = z.discriminatedUnion('name', [
     }),
   }),
   z.object({
+    name: z.literal('slack.invited'),
+    data: z.object({
+      email: Student.shape.email,
+    }),
+  }),
+  z.object({
     name: z.literal('slack.joined'),
     data: z.object({
       email: Student.shape.email,

--- a/packages/core/src/infrastructure/bull/use-cases/job.ts
+++ b/packages/core/src/infrastructure/bull/use-cases/job.ts
@@ -68,6 +68,7 @@ const QueueNameFromJobName: Record<BullJob['name'], BullQueue> = {
   'slack.channel.unarchive': 'slack',
   'slack.deactivate': 'slack',
   'slack.invite': 'slack',
+  'slack.invited': 'slack',
   'slack.joined': 'slack',
   'slack.message.add': 'slack',
   'slack.message.added': 'slack',

--- a/packages/core/src/infrastructure/redis.ts
+++ b/packages/core/src/infrastructure/redis.ts
@@ -21,8 +21,6 @@ export const RedisKey = {
   SLACK_GET_MESSAGE_CONNECTIONS: 'slack:connections:get_message',
   SLACK_INVITE_USER_CONNECTIONS: 'slack:connections:invite_user',
   SLACK_JOIN_CHANNEL_CONNECTIONS: 'slack:connections:join_channel',
-  SLACK_LEGACY_COOKIE: 'slack:legacy_cookie',
-  SLACK_LEGACY_TOKEN: 'slack:legacy_token',
 } as const;
 
 export type RedisKey = ExtractValue<typeof RedisKey>;

--- a/packages/core/src/modules/slack/events/slack-user-invited.ts
+++ b/packages/core/src/modules/slack/events/slack-user-invited.ts
@@ -1,0 +1,29 @@
+import { type GetBullJobData } from '@/infrastructure/bull/bull.types';
+import { db } from '@/infrastructure/database';
+import { getSlackUserByEmail } from '@/modules/slack/services/slack-user.service';
+
+/**
+ * After the Slack user is invited to the workspace, we should update the
+ * member's Slack ID in the database.
+ *
+ * Unfortunately, Slack doesn't return the user ID in the response when inviting
+ * a user, so we'll have to fetch it from the Slack API separately. Since that
+ * is more error-prone, we extract this logic into a separate job (which can
+ * be retried if it fails).
+ */
+export async function onSlackUserInvited({
+  email,
+}: GetBullJobData<'slack.invited'>) {
+  const user = await getSlackUserByEmail(email);
+
+  if (!user) {
+    return;
+  }
+
+  await db
+    .updateTable('students')
+    .set({ slackId: user.id })
+    .where('email', '=', email)
+    .where('slackId', 'is', null)
+    .execute();
+}

--- a/packages/core/src/modules/slack/slack.worker.ts
+++ b/packages/core/src/modules/slack/slack.worker.ts
@@ -2,6 +2,7 @@ import { match } from 'ts-pattern';
 
 import { SlackBullJob } from '@/infrastructure/bull/bull.types';
 import { registerWorker } from '@/infrastructure/bull/use-cases/register-worker';
+import { onSlackUserInvited } from '@/modules/slack/events/slack-user-invited';
 import { onSlackMessageAdded } from './events/slack-message-added';
 import { onSlackProfilePictureChanged } from './events/slack-profile-picture-changed';
 import { onSlackWorkspaceJoined } from './events/slack-workspace-joined';
@@ -43,6 +44,9 @@ export const slackWorker = registerWorker(
       })
       .with({ name: 'slack.invite' }, async ({ data }) => {
         return inviteToSlackWorkspace(data);
+      })
+      .with({ name: 'slack.invited' }, async ({ data }) => {
+        return onSlackUserInvited(data);
       })
       .with({ name: 'slack.joined' }, async ({ data }) => {
         return onSlackWorkspaceJoined(data);


### PR DESCRIPTION
## Description ✏️

This PR does the following:
- Implements the `slack.invited` job, which queries the Slack API for a user by email. That gives us the Slack ID which we'll save to the member's profile.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
