### PR TITLE
fix: corrected application sorting order 🔥

### DIFF
--- a/packages/core/src/modules/application/queries/list-applications.ts
+++ b/packages/core/src/modules/application/queries/list-applications.ts
@@ -36,6 +36,11 @@ export async function listApplications({
       return qb.where('applications.status', '=', status);
     });
 
+  const orderDirection =
+    status === 'accepted' || status === 'rejected' || status === 'all'
+      ? 'desc'
+      : 'asc';
+
   const [rows, { count }] = await Promise.all([
     query
       .leftJoin('schools', 'schools.id', 'applications.schoolId')
@@ -52,7 +57,7 @@ export async function listApplications({
             .as('school');
         },
       ])
-      .orderBy('applications.createdAt', 'asc')
+      .orderBy('applications.createdAt', orderDirection)
       .limit(limit)
       .offset((page - 1) * limit)
       .execute(),


### PR DESCRIPTION
## Description ✏️

Closes #165  

This PR fixes the sorting order for 'Accepted', 'Rejected', and 'All' applications to display them in descending order, ensuring the most recent applications are shown first. It maintains ascending order for 'Pending' applications.

- Adjusted the sorting logic based on the status of applications.
- Ensured that the 'All' category also follows descending order as required.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
