### PR TITLE
refactor: use `onCloseTo` in favor of `onClose` in modal props 🔗

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -81,14 +80,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function AddAdminPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/']}>
       <Modal.Header>
         <Modal.Title>Add Admin</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.tsx
@@ -1,5 +1,5 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { Outlet, useLocation, useNavigate } from '@remix-run/react';
+import { Outlet, useLocation } from '@remix-run/react';
 
 import { Modal } from '@oyster/ui';
 
@@ -15,19 +15,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function ApplicationLayout() {
-  const navigate = useNavigate();
-
   const { search } = useLocation();
 
-  function onClose() {
-    navigate({
-      pathname: Route['/applications'],
-      search,
-    });
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/applications'] + search}>
       <Outlet />
     </Modal>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.$id.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.$id.tsx
@@ -4,9 +4,10 @@ import {
   type LoaderFunctionArgs,
 } from '@remix-run/node';
 import {
+  generatePath,
   Form as RemixForm,
   useLoaderData,
-  useNavigate,
+  useParams,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { type PropsWithChildren } from 'react';
@@ -16,6 +17,7 @@ import { z } from 'zod';
 
 import { IconButton, Modal, Text } from '@oyster/ui';
 
+import { Route } from '../shared/constants';
 import { getTimezone } from '../shared/cookies.server';
 import { QueueFromName } from '../shared/core.server';
 import { BullQueue } from '../shared/core.ui';
@@ -142,15 +144,14 @@ async function getJobFromParams(params: object) {
 
 export default function JobPage() {
   const { data, general, options } = useLoaderData<typeof loader>();
-
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
+  const { queue } = useParams();
 
   return (
-    <Modal onClose={onClose}>
+    <Modal
+      onCloseTo={generatePath(Route['/bull/:queue/jobs'], {
+        queue: queue as string,
+      })}
+    >
       <Modal.Header>
         <Modal.Title>Job Details</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -8,8 +8,8 @@ import {
   generatePath,
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
+  useParams,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -102,14 +102,14 @@ export async function action({ params, request }: ActionFunctionArgs) {
 }
 
 export default function AddJobPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
+  const { queue } = useParams();
 
   return (
-    <Modal onClose={onClose}>
+    <Modal
+      onCloseTo={generatePath(Route['/bull/:queue/jobs'], {
+        queue: queue as string,
+      })}
+    >
       <Modal.Header>
         <Modal.Title>Add Job</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -8,8 +8,8 @@ import {
   generatePath,
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
+  useParams,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -94,14 +94,14 @@ export async function action({ params, request }: ActionFunctionArgs) {
 }
 
 export default function AddRepeatablePage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
+  const { queue } = useParams();
 
   return (
-    <Modal onClose={onClose}>
+    <Modal
+      onCloseTo={generatePath(Route['/bull/:queue/repeatables'], {
+        queue: queue as string,
+      })}
+    >
       <Modal.Header>
         <Modal.Title>Add Repeatable</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
 } from '@remix-run/react';
 
 import {
@@ -75,14 +74,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
 }
 
 export default function AddEventRecordingModal() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/events']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events']}>
       <Modal.Header>
         <Modal.Title>Add Recording</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -12,7 +12,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -165,14 +164,8 @@ async function importEventAttendees(
 export default function ImportEventAttendeesPage() {
   const { event } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/events']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events']}>
       <Modal.Header>
         <Modal.Title>Import Event Attendees</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -100,14 +99,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function CreateEventPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events']}>
       <Modal.Header>
         <Modal.Title>Create Event</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -73,14 +72,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function SyncAirmeetEventPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/events']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events']}>
       <Modal.Header>
         <Modal.Title>Sync Airmeet Event</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.delete.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.delete.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 
@@ -57,16 +56,10 @@ export async function action({ params, request }: ActionFunctionArgs) {
 
 export default function DeleteFeatureFlagModal() {
   const { flag } = useLoaderData<typeof loader>();
-
-  const navigate = useNavigate();
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/feature-flags']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/feature-flags']}>
       <Modal.Header>
         <Modal.Title>Delete Flag ({flag.displayName})</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 
@@ -89,16 +88,10 @@ const keys = EditFeatureFlagInput.keyof().enum;
 export default function EditFeatureFlagModal() {
   const { flag } = useLoaderData<typeof loader>();
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-
-  const navigate = useNavigate();
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/feature-flags']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/feature-flags']}>
       <Modal.Header>
         <Modal.Title>Edit Flag</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 
@@ -77,16 +76,10 @@ const keys = CreateFeatureFlagInput.keyof().enum;
 
 export default function CreateFeatureFlagModal() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-
-  const navigate = useNavigate();
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/feature-flags']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/feature-flags']}>
       <Modal.Header>
         <Modal.Title>Create Flag</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
@@ -57,16 +57,12 @@ export default function ArchiveActivityPage() {
 
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/gamification/activities']);
-  }
-
   function onBack() {
     navigate(-1);
   }
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/gamification/activities']}>
       <Modal.Header>
         <Modal.Title>Archive Activity</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.edit.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
 } from '@remix-run/react';
 import { type z } from 'zod';
 
@@ -103,14 +102,8 @@ export default function EditActivityPage() {
   const { activity } = useLoaderData<typeof loader>();
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/gamification/activities']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/gamification/activities']}>
       <Modal.Header>
         <Modal.Title>Edit Activity</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.add.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigate,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { Activity } from '@oyster/types';
@@ -91,14 +87,8 @@ const { description, name, period, points, type } =
 export default function AddActivityPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/gamification/activities']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/gamification/activities']}>
       <Modal.Header>
         <Modal.Title>Add Activity</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 
@@ -20,6 +19,7 @@ import {
   validateForm,
 } from '@oyster/ui';
 
+import { Route } from '../shared/constants';
 import { addIcebreakerPrompt } from '../shared/core.server';
 import { AddIcebreakerPromptInput } from '../shared/core.ui';
 import {
@@ -66,14 +66,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function AddIcebreakerPromptPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/']}>
       <Modal.Header>
         <Modal.Title>Add Icebreaker Prompt</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -89,17 +88,10 @@ const { attendees } = AddOnboardingSessionAttendeesInput.keyof().enum;
 
 export default function AddOnboardingSessionAttendeesPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-
   const submitting = useNavigation().state === 'submitting';
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/onboarding-sessions']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/onboarding-sessions']}>
       <Modal.Header>
         <Modal.Title>Add Onboarding Session Attendees</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -93,17 +92,10 @@ const { attendees, date } = UploadOnboardingSessionInput.keyof().enum;
 
 export default function UploadOnboardingSessionPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-
   const submitting = useNavigation().state === 'submitting';
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/onboarding-sessions']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/onboarding-sessions']}>
       <Modal.Header>
         <Modal.Title>Upload Onboarding Session</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.programs.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.programs.create.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
@@ -90,14 +89,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function CreateProgramPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>Create Program</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.resources.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resources.create.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
@@ -86,14 +85,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function CreateResourcePage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>Create Resource</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 
@@ -72,14 +71,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function CreateSchoolPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/schools']}>
       <Modal.Header>
         <Modal.Title>Create School</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.activate.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.activate.tsx
@@ -79,12 +79,8 @@ export default function ActivateStudentPage() {
     navigate(-1);
   }
 
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>Activate Student</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
@@ -99,14 +98,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
 export default function UpdateStudentEmailPage() {
   const { student } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>
           Update Email - {student.firstName} {student.lastName}

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -100,14 +99,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
 export default function GrantPointsPage() {
   const { student } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>
           Grant Points to {student.firstName} {student.lastName}

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.remove.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.remove.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useLoaderData,
-  useNavigate,
-} from '@remix-run/react';
+import { Form as RemixForm, useLoaderData } from '@remix-run/react';
 
 import { Button, Modal } from '@oyster/ui';
 
@@ -71,14 +67,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
 export default function RemoveMemberPage() {
   const { student } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>
           Remove {student.firstName} {student.lastName}

--- a/apps/admin-dashboard/app/routes/_dashboard.students.import.programs.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.import.programs.tsx
@@ -13,7 +13,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -174,14 +173,8 @@ async function importProgramParticipants(
 }
 
 export default function ImportProgramsPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>Import Program Participants</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.students.import.resources.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.import.resources.tsx
@@ -13,7 +13,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
@@ -193,14 +192,8 @@ async function importResourceUsers(input: ImportResourceUsersInput) {
 }
 
 export default function ImportResourcesPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>Import Resource Users</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.students.import.scholarships.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.import.scholarships.tsx
@@ -11,7 +11,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
@@ -187,14 +186,8 @@ async function importScholarshipRecipients(
 }
 
 export default function ImportScholarshipsPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/students']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/students']}>
       <Modal.Header>
         <Modal.Title>Import Scholarship Recipients</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.surveys.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.surveys.$id.import.tsx
@@ -12,7 +12,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -102,14 +101,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
 export default function ImportSurveyResponsesPage() {
   const { survey } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/surveys']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/surveys']}>
       <Modal.Header>
         <Modal.Title>Import Survey Responses</Modal.Title>
         <Modal.CloseButton />

--- a/apps/admin-dashboard/app/routes/_dashboard.surveys.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.surveys.create.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { sql } from 'kysely';
@@ -83,14 +82,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function CreateSurveyPage() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(-1);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/surveys']}>
       <Modal.Header>
         <Modal.Title>Create Survey</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.directory.join.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.tsx
@@ -1,5 +1,5 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { Link, Outlet, useLocation, useNavigate } from '@remix-run/react';
+import { Link, Outlet, useLocation } from '@remix-run/react';
 import { type PropsWithChildren } from 'react';
 import { ArrowLeft, ArrowRight, Check } from 'react-feather';
 import { match } from 'ts-pattern';
@@ -17,14 +17,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function JoinDirectoryLayout() {
   const { pathname } = useLocation();
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/home']);
-  }
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/home']}>
       <Modal.Header>
         <Modal.Title>Welcome to the Member Directory! 🤝</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.events.past.$id.attendees.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.$id.attendees.tsx
@@ -1,10 +1,5 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import {
-  generatePath,
-  Link,
-  useLoaderData,
-  useNavigate,
-} from '@remix-run/react';
+import { generatePath, Link, useLoaderData } from '@remix-run/react';
 
 import { type Student } from '@oyster/types';
 import { Modal, ProfilePicture } from '@oyster/ui';
@@ -40,14 +35,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
 export default function EventAttendeesPage() {
   const { attendees, attendeesCount } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/events/past']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events/past']}>
       <Modal.Header>
         <Modal.Title>Attendees List ({attendeesCount})</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
+++ b/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { Calendar, Check, ExternalLink } from 'react-feather';
@@ -117,16 +116,10 @@ async function registerForEvent({
 
 export default function EventRegisterPage() {
   const { event } = useLoaderData<typeof loader>();
-
-  const navigate = useNavigate();
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/events/upcoming']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events/upcoming']}>
       <Modal.Header>
         <Modal.Title>{event.name}</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.events.upcoming.$id.registrations.tsx
+++ b/apps/member-profile/app/routes/_profile.events.upcoming.$id.registrations.tsx
@@ -1,10 +1,5 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import {
-  generatePath,
-  Link,
-  useLoaderData,
-  useNavigate,
-} from '@remix-run/react';
+import { generatePath, Link, useLoaderData } from '@remix-run/react';
 
 import { type Student } from '@oyster/types';
 import { Modal, ProfilePicture } from '@oyster/ui';
@@ -41,14 +36,8 @@ async function getEventRegistrations(eventId: string) {
 export default function EventRegistrationsPage() {
   const { registrations } = useLoaderData<typeof loader>();
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/events/upcoming']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/events/upcoming']}>
       <Modal.Header>
         <Modal.Title>Guest List ({registrations.length})</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.home.claim-swag-pack.tsx
+++ b/apps/member-profile/app/routes/_profile.home.claim-swag-pack.tsx
@@ -1,5 +1,5 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { Outlet, useNavigate } from '@remix-run/react';
+import { Outlet } from '@remix-run/react';
 
 import { Modal } from '@oyster/ui';
 
@@ -15,14 +15,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function ClaimSwagPackLayout() {
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/home']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/home']}>
       <Outlet />
     </Modal>
   );

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.delete.tsx
@@ -82,16 +82,12 @@ export default function DeleteEducationPage() {
 
   const navigate = useNavigate();
 
-  function onClose() {
-    navigate(Route['/profile/education']);
-  }
-
   function onBack() {
     navigate(-1);
   }
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/education']}>
       <Modal.Header>
         <Modal.Title>Delete Education</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
@@ -163,10 +163,6 @@ export default function EditEducationPage() {
 
   const navigate = useNavigate();
 
-  function onClose() {
-    navigate(Route['/profile/education']);
-  }
-
   function onDelete() {
     navigate(
       generatePath(Route['/profile/education/:id/delete'], {
@@ -181,7 +177,7 @@ export default function EditEducationPage() {
       : { id: 'other', name: 'Other' };
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/education']}>
       <Modal.Header>
         <Modal.Title>Edit Education</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.education.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.add.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
@@ -106,17 +105,10 @@ const {
 
 export default function AddEducationPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/profile/education']);
-  }
-
   const submitting = useNavigation().state === 'submitting';
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/education']}>
       <Modal.Header>
         <Modal.Title>Add Education</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
@@ -168,17 +167,10 @@ const { code } = AddEmailFormData.keyof().enum;
 export default function AddEmailPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { email } = useLoaderData<typeof loader>();
-
-  const navigate = useNavigate();
-
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/profile/emails']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/emails']}>
       <Modal.Header>
         <Modal.Title>Add Email Address</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
@@ -136,17 +135,10 @@ const { email } = SendEmailCodeInput.keyof().enum;
 
 export default function AddEmailPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-
   const submitting = useNavigation().state === 'submitting';
 
-  const navigate = useNavigate();
-
-  function onClose() {
-    navigate(Route['/profile/emails']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/emails']}>
       <Modal.Header>
         <Modal.Title>Add Email Address</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 
@@ -84,17 +83,10 @@ const keys = ChangePrimaryEmailInput.keyof().enum;
 export default function ChangePrimaryEmailPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { emails } = useLoaderData<typeof loader>();
-
-  const navigate = useNavigate();
-
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/profile/emails']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/emails']}>
       <Modal.Header>
         <Modal.Title>Change Primary Email Address</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.delete.tsx
@@ -70,16 +70,12 @@ export default function DeleteWorkExperiencePage() {
 
   const navigate = useNavigate();
 
-  function onClose() {
-    navigate(Route['/profile/work']);
-  }
-
   function onBack() {
     navigate(-1);
   }
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/work']}>
       <Modal.Header>
         <Modal.Title>Delete Work Experience</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
@@ -146,10 +146,6 @@ export default function EditWorkExperiencePage() {
 
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/profile/work']);
-  }
-
   function onDelete() {
     navigate(
       generatePath(Route['/profile/work/:id/delete'], {
@@ -159,7 +155,7 @@ export default function EditWorkExperiencePage() {
   }
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/work']}>
       <Modal.Header>
         <Modal.Title>Edit Work Experience</Modal.Title>
         <Modal.CloseButton />

--- a/apps/member-profile/app/routes/_profile.profile.work.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.add.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Form as RemixForm,
   useActionData,
-  useNavigate,
   useNavigation,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
@@ -99,16 +98,10 @@ const keys = AddWorkExperienceFormData.keyof().enum;
 export default function AddWorkExperiencePage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const navigate = useNavigate();
-
   const submitting = useNavigation().state === 'submitting';
 
-  function onClose() {
-    navigate(Route['/profile/work']);
-  }
-
   return (
-    <Modal onClose={onClose}>
+    <Modal onCloseTo={Route['/profile/work']}>
       <Modal.Header>
         <Modal.Title>Add Work Experience</Modal.Title>
         <Modal.CloseButton />

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -1,3 +1,4 @@
+import { Link, useNavigate } from '@remix-run/react';
 import React, { type PropsWithChildren, useContext } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'react-feather';
@@ -9,12 +10,8 @@ import { cx } from '../utils/cx';
 
 const ModalContext = React.createContext({
   _initialized: false,
-  onClose: () => {},
+  onCloseTo: '',
 });
-
-type ModalProps = PropsWithChildren<{
-  onClose: VoidFunction;
-}>;
 
 export function useIsModalParent() {
   const { _initialized } = useContext(ModalContext);
@@ -22,9 +19,13 @@ export function useIsModalParent() {
   return !!_initialized;
 }
 
+type ModalProps = PropsWithChildren<{
+  onCloseTo: string;
+}>;
+
 export const Modal = ({
   children,
-  onClose,
+  onCloseTo,
 }: ModalProps): JSX.Element | null => {
   const hydrated: boolean = useHydrated();
 
@@ -33,7 +34,7 @@ export const Modal = ({
   }
 
   return createPortal(
-    <ModalContext.Provider value={{ _initialized: true, onClose }}>
+    <ModalContext.Provider value={{ _initialized: true, onCloseTo }}>
       <div
         className={cx(
           'flex h-screen w-screen items-end justify-center sm:items-center'
@@ -52,15 +53,12 @@ export const Modal = ({
         </aside>
       </div>
 
-      <div
-        aria-label="Modal Shader"
+      <Link
         className={cx(
           'fixed left-0 top-0 h-screen w-screen cursor-default bg-black',
           'animate-[modal-shader-animation_250ms_forwards]'
         )}
-        onClick={onClose}
-        role="button"
-        tabIndex={0}
+        to={onCloseTo}
       />
     </ModalContext.Provider>,
     document.body
@@ -68,14 +66,15 @@ export const Modal = ({
 };
 
 Modal.CloseButton = function ModalCloseButton() {
-  const { onClose } = useContext(ModalContext);
+  const { onCloseTo } = useContext(ModalContext);
+  const navigate = useNavigate();
 
   return (
     <IconButton
       backgroundColor="gray-100"
       backgroundColorOnHover="gray-200"
       icon={<X />}
-      onClick={onClose}
+      onClick={() => navigate(onCloseTo)}
     />
   );
 };


### PR DESCRIPTION
## Description ✏️

This PR removes the `onClose` prop on the `Modal` component in favor of an `onCloseTo` prop. The key difference is that the former was a function and the latter is a string. The reason being is because in our system, whenever we close a modal, we ALWAYS redirect back to a different URL. It didn't make sense to put the onus on the caller to have to control the redirection logic, we just need a pathname!

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).