### PR TITLE
refactor: add `Button.Submit` to read submission status 🕰️

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import {
@@ -20,6 +16,7 @@ import {
   Modal,
   validateForm,
 } from '@oyster/ui';
+import { sleep } from '@oyster/utils';
 
 import { Route } from '../shared/constants';
 import { addAdmin } from '../shared/core.server';
@@ -38,6 +35,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   const session = await ensureUserAuthenticated(request);
+
+  await sleep(500000);
 
   const form = await request.formData();
 
@@ -97,8 +96,6 @@ const keys = AddAdminInput.keyof().enum;
 function AddAdminForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -147,9 +144,7 @@ function AddAdminForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Add
-        </Button>
+        <Button.Submit>Add</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
@@ -16,7 +16,6 @@ import {
   Modal,
   validateForm,
 } from '@oyster/ui';
-import { sleep } from '@oyster/utils';
 
 import { Route } from '../shared/constants';
 import { addAdmin } from '../shared/core.server';
@@ -35,8 +34,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   const session = await ensureUserAuthenticated(request);
-
-  await sleep(500000);
 
   const form = await request.formData();
 

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
@@ -143,10 +143,10 @@ export default function ApplicationPage() {
 
   const { formData, state } = useNavigation();
 
-  const acceptButtonLoading =
+  const acceptButtonSubmitting =
     state === 'submitting' && formData?.get('action') === 'accept';
 
-  const rejectButtonLoading =
+  const rejectButtonSubmitting =
     state === 'submitting' && formData?.get('action') === 'reject';
 
   const { application } = useLoaderData<typeof loader>();
@@ -189,8 +189,8 @@ export default function ApplicationPage() {
             <Button.Group>
               <Button
                 color="success"
-                loading={acceptButtonLoading}
                 name="action"
+                submitting={acceptButtonSubmitting}
                 type="submit"
                 value="accept"
               >
@@ -199,8 +199,8 @@ export default function ApplicationPage() {
 
               <Button
                 color="error"
-                loading={rejectButtonLoading}
                 name="action"
+                submitting={rejectButtonSubmitting}
                 type="submit"
                 value="reject"
               >

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
 
@@ -128,8 +127,6 @@ const { email } = UpdateApplicationEmailInput.keyof().enum;
 function UpdateApplicationEmailForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field error={errors.email} label="Email" labelFor={email} required>
@@ -139,9 +136,7 @@ function UpdateApplicationEmailForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Update
-        </Button>
+        <Button.Submit>Update</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -8,7 +8,6 @@ import {
   generatePath,
   Form as RemixForm,
   useActionData,
-  useNavigation,
   useParams,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -123,8 +122,6 @@ export default function AddJobPage() {
 function AddJobForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -153,9 +150,7 @@ function AddJobForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Add
-        </Button>
+        <Button.Submit>Add</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -8,7 +8,6 @@ import {
   generatePath,
   Form as RemixForm,
   useActionData,
-  useNavigation,
   useParams,
 } from '@remix-run/react';
 import { z } from 'zod';
@@ -115,8 +114,6 @@ export default function AddRepeatablePage() {
 function AddRepeatableForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -149,9 +146,7 @@ function AddRepeatableForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Add
-        </Button>
+        <Button.Submit>Add</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -12,7 +12,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -185,8 +184,6 @@ const { file } = ImportEventAttendeesInput.keyof().enum;
 function ImportEventAttendeesForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post" encType="multipart/form-data">
       <Form.Field error={errors.file} labelFor={file} required>
@@ -196,9 +193,7 @@ function ImportEventAttendeesForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Import
-        </Button>
+        <Button.Submit>Import</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { Event, EventType } from '@oyster/types';
@@ -119,8 +115,6 @@ const EVENT_TYPES = Object.values(EventType);
 function CreateEventForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field error={errors.name} label="Name" labelFor={name} required>
@@ -184,9 +178,7 @@ function CreateEventForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Create
-        </Button>
+        <Button.Submit>Create</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import {
@@ -88,7 +84,6 @@ const keys = SyncAirmeetEventFormData.keyof().enum;
 
 function SyncAirmeetEventForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <RemixForm className="form" method="post">
@@ -105,9 +100,7 @@ function SyncAirmeetEventForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Sync
-        </Button>
+        <Button.Submit>Sync</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.delete.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.delete.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useLoaderData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useLoaderData } from '@remix-run/react';
 
 import { Button, Modal } from '@oyster/ui';
 
@@ -56,7 +52,6 @@ export async function action({ params, request }: ActionFunctionArgs) {
 
 export default function DeleteFeatureFlagModal() {
   const { flag } = useLoaderData<typeof loader>();
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/feature-flags']}>
@@ -72,9 +67,7 @@ export default function DeleteFeatureFlagModal() {
 
       <RemixForm className="form" method="post">
         <Button.Group>
-          <Button color="error" loading={submitting} type="submit">
-            Delete
-          </Button>
+          <Button.Submit color="error">Delete</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 
 import {
@@ -88,7 +87,6 @@ const keys = EditFeatureFlagInput.keyof().enum;
 export default function EditFeatureFlagModal() {
   const { flag } = useLoaderData<typeof loader>();
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/feature-flags']}>
@@ -139,9 +137,7 @@ export default function EditFeatureFlagModal() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Edit
-          </Button>
+          <Button.Submit>Edit</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 
 import {
   Button,
@@ -76,7 +72,6 @@ const keys = CreateFeatureFlagInput.keyof().enum;
 
 export default function CreateFeatureFlagModal() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/feature-flags']}>
@@ -127,9 +122,7 @@ export default function CreateFeatureFlagModal() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Create
-          </Button>
+          <Button.Submit>Create</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
@@ -77,18 +77,13 @@ export default function ArchiveActivityPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
-          <Button
-            color="error"
-            loading={submitting}
-            type="submit"
-            variant="secondary"
-          >
+          <Button.Submit color="error" variant="secondary">
             Archive
-          </Button>
+          </Button.Submit>
 
           <Button
-            loading={submitting}
             onClick={onBack}
+            submitting={submitting}
             type="button"
             variant="secondary"
           >

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 
 import {
   Button,
@@ -83,8 +79,6 @@ const keys = AddIcebreakerPromptInput.keyof().enum;
 function AddIcebreakerPromptForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -99,9 +93,7 @@ function AddIcebreakerPromptForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Add
-        </Button>
+        <Button.Submit>Add</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { Button, Form, getActionErrors, Modal, validateForm } from '@oyster/ui';
@@ -88,7 +84,6 @@ const { attendees } = AddOnboardingSessionAttendeesInput.keyof().enum;
 
 export default function AddOnboardingSessionAttendeesPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/onboarding-sessions']}>
@@ -106,9 +101,7 @@ export default function AddOnboardingSessionAttendeesPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Upload
-          </Button>
+          <Button.Submit>Upload</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { Button, Form, getActionErrors, Modal, validateForm } from '@oyster/ui';
@@ -92,7 +88,6 @@ const { attendees, date } = UploadOnboardingSessionInput.keyof().enum;
 
 export default function UploadOnboardingSessionPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/onboarding-sessions']}>
@@ -111,9 +106,7 @@ export default function UploadOnboardingSessionPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Upload
-          </Button>
+          <Button.Submit>Upload</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/admin-dashboard/app/routes/_dashboard.programs.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.programs.create.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { Program } from '@oyster/types';
@@ -106,8 +102,6 @@ const { endDate, name, startDate } = CreateProgramInput.keyof().enum;
 function CreateProgramForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field error={errors.name} label="Name" labelFor={name} required>
@@ -135,9 +129,7 @@ function CreateProgramForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Create
-        </Button>
+        <Button.Submit>Create</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.resources.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resources.create.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { Resource, ResourceStatus } from '@oyster/types';
@@ -102,8 +98,6 @@ const { name } = CreateResourceInput.keyof().enum;
 function CreateResourceForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field error={errors.name} label="Name" labelFor={name} required>
@@ -113,9 +107,7 @@ function CreateResourceForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Create
-        </Button>
+        <Button.Submit>Create</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 
 import {
   Button,
@@ -88,8 +84,6 @@ const keys = CreateSchoolInput.keyof().enum;
 function CreateSchoolForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -152,9 +146,7 @@ function CreateSchoolForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Create
-        </Button>
+        <Button.Submit>Create</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
 
@@ -123,8 +122,6 @@ const { email } = UpdateStudentEmailInput.keyof().enum;
 function UpdateStudentEmailForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field error={errors.email} label="Email" labelFor={email} required>
@@ -134,9 +131,7 @@ function UpdateStudentEmailForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Update
-        </Button>
+        <Button.Submit>Update</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -117,8 +116,6 @@ export default function GrantPointsPage() {
 function GrantPointsForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -153,9 +150,7 @@ function GrantPointsForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Grant
-        </Button>
+        <Button.Submit>Grant</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.students.import.programs.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.import.programs.tsx
@@ -13,7 +13,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -191,8 +190,6 @@ function ImportProgramsForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { programs } = useLoaderData<typeof loader>();
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post" encType="multipart/form-data">
       <Form.Field
@@ -226,9 +223,7 @@ function ImportProgramsForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Import
-        </Button>
+        <Button.Submit>Import</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.students.import.resources.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.import.resources.tsx
@@ -13,7 +13,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { z } from 'zod';
@@ -210,8 +209,6 @@ function ImportResourcesForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { resources } = useLoaderData<typeof loader>();
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post" encType="multipart/form-data">
       <Form.Field
@@ -245,9 +242,7 @@ function ImportResourcesForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Import
-        </Button>
+        <Button.Submit>Import</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.students.import.scholarships.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.import.scholarships.tsx
@@ -8,11 +8,7 @@ import {
   unstable_parseMultipartFormData as parseMultipartFormData,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { z } from 'zod';
 
@@ -203,8 +199,6 @@ const { file } = ImportScholarshipRecipientsInput.keyof().enum;
 function ImportScholarshipsForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post" encType="multipart/form-data">
       <Form.Field
@@ -220,9 +214,7 @@ function ImportScholarshipsForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Import
-        </Button>
+        <Button.Submit>Import</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.surveys.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.surveys.$id.import.tsx
@@ -12,7 +12,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -122,8 +121,6 @@ const keys = ImportSurveyResponsesInput.keyof().enum;
 function ImportSurveyResponsesForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post" encType="multipart/form-data">
       <Form.Field error={errors.file} labelFor={keys.file} required>
@@ -139,9 +136,7 @@ function ImportSurveyResponsesForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Import
-        </Button>
+        <Button.Submit>Import</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.surveys.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.surveys.create.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { sql } from 'kysely';
 
@@ -100,8 +99,6 @@ function CreateSurveyForm() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { events } = useLoaderData<typeof loader>();
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <Form.Field
@@ -140,9 +137,7 @@ function CreateSurveyForm() {
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
       <Button.Group>
-        <Button loading={submitting} type="submit">
-          Create
-        </Button>
+        <Button.Submit>Create</Button.Submit>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/login.otp.send.tsx
+++ b/apps/admin-dashboard/app/routes/login.otp.send.tsx
@@ -1,9 +1,5 @@
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 
 import { Button, Form, getActionErrors, validateForm } from '@oyster/ui';
 
@@ -51,17 +47,11 @@ const keys = SendOneTimeCodeInput.keyof().enum;
 export default function SendOneTimeCodePage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <OneTimeCodeForm.EmailField error={errors.email} name={keys.email} />
-
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
-
-      <Button fill loading={submitting} type="submit">
-        Send Code
-      </Button>
+      <Button.Submit fill>Send Code</Button.Submit>
     </RemixForm>
   );
 }

--- a/apps/admin-dashboard/app/routes/login.otp.verify.tsx
+++ b/apps/admin-dashboard/app/routes/login.otp.verify.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 
 import { Button, Form, getActionErrors, validateForm } from '@oyster/ui';
@@ -96,8 +95,6 @@ export default function VerifyOneTimeCodePage() {
   const { description } = useLoaderData<typeof loader>();
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <OneTimeCodeForm.CodeField
@@ -108,9 +105,7 @@ export default function VerifyOneTimeCodePage() {
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
-      <Button fill loading={submitting} type="submit">
-        Verify Code
-      </Button>
+      <Button.Submit fill>Verify Code</Button.Submit>
     </RemixForm>
   );
 }

--- a/apps/member-profile/app/routes/_profile.census._index.tsx
+++ b/apps/member-profile/app/routes/_profile.census._index.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import React, { type PropsWithChildren, useContext, useState } from 'react';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
@@ -128,10 +124,6 @@ export default function CensusForm() {
   useRevalidateOnFocus();
 
   const { error } = getActionErrors(useActionData<typeof action>());
-  const { state, formData } = useNavigation();
-
-  const submitting =
-    state === 'submitting' && formData?.get('intent') === 'submit';
 
   const [hasGraduated, setHasGraduated] = useState<boolean | null>(null);
   const [hasTechnicalRole, setHasTechnicalRole] = useState<boolean>(false);
@@ -159,15 +151,7 @@ export default function CensusForm() {
 
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
-        <Button
-          fill
-          loading={submitting}
-          name="intent"
-          type="submit"
-          value="submit"
-        >
-          Submit
-        </Button>
+        <Button.Submit fill>Submit</Button.Submit>
       </CensusContext.Provider>
     </RemixForm>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.1.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.1.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -90,8 +89,6 @@ export default function UpdateGeneralInformationForm() {
   const { student } = useLoaderData<typeof loader>();
   const { errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <InputField
@@ -135,7 +132,7 @@ export default function UpdateGeneralInformationForm() {
       </Form.Field>
 
       <Button.Group>
-        <JoinDirectoryNextButton submitting={submitting} />
+        <JoinDirectoryNextButton />
       </Button.Group>
     </RemixForm>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.2.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.2.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -97,8 +96,6 @@ export default function UpdatePersonalInformationForm() {
   const { ethnicities, student } = useLoaderData<typeof loader>();
   const { errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <HometownField
@@ -121,7 +118,7 @@ export default function UpdatePersonalInformationForm() {
 
       <Button.Group spacing="between">
         <JoinDirectoryBackButton to={Route['/directory/join/1']} />
-        <JoinDirectoryNextButton submitting={submitting} />
+        <JoinDirectoryNextButton />
       </Button.Group>
     </RemixForm>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.3.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.3.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -95,8 +94,6 @@ export default function UpdateSocialsInformationForm() {
   const { student } = useLoaderData<typeof loader>();
   const { errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <InputField
@@ -139,9 +136,7 @@ export default function UpdateSocialsInformationForm() {
 
       <Button.Group spacing="between">
         <JoinDirectoryBackButton to={Route['/directory/join/2']} />
-        <JoinDirectoryNextButton submitting={submitting}>
-          Next
-        </JoinDirectoryNextButton>
+        <JoinDirectoryNextButton>Next</JoinDirectoryNextButton>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.4.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.4.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
@@ -132,8 +131,6 @@ const {
 export default function UpsertIcebreakerResponsesForm() {
   const { icebreakerResponses } = useLoaderData<typeof loader>();
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <IcebreakersProvider icebreakerResponses={icebreakerResponses}>
@@ -144,9 +141,7 @@ export default function UpsertIcebreakerResponsesForm() {
 
       <Button.Group spacing="between">
         <JoinDirectoryBackButton to={Route['/directory/join/3']} />
-        <JoinDirectoryNextButton submitting={submitting}>
-          Finish
-        </JoinDirectoryNextButton>
+        <JoinDirectoryNextButton>Finish</JoinDirectoryNextButton>
       </Button.Group>
     </RemixForm>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.tsx
@@ -131,11 +131,10 @@ export function JoinDirectoryBackButton({
 
 export function JoinDirectoryNextButton({
   children = 'Next',
-  submitting,
-}: PropsWithChildren<{ submitting: boolean }>) {
+}: PropsWithChildren) {
   return (
-    <Button loading={submitting} type="submit">
+    <Button.Submit>
       {children} <ArrowRight size={20} />
-    </Button>
+    </Button.Submit>
   );
 }

--- a/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
+++ b/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useLoaderData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useLoaderData } from '@remix-run/react';
 import { Calendar, Check, ExternalLink } from 'react-feather';
 
 import { Button, getButtonCn, Modal, Text } from '@oyster/ui';
@@ -116,7 +112,6 @@ async function registerForEvent({
 
 export default function EventRegisterPage() {
   const { event } = useLoaderData<typeof loader>();
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/events/upcoming']}>
@@ -158,9 +153,9 @@ export default function EventRegisterPage() {
           )}
 
           {!event.isRegistered && (
-            <Button loading={submitting} type="submit">
+            <Button.Submit>
               <Check className="h-5 w-5" /> Register
-            </Button>
+            </Button.Submit>
           )}
         </Button.Group>
       </RemixForm>

--- a/apps/member-profile/app/routes/_profile.home.claim-swag-pack._index.tsx
+++ b/apps/member-profile/app/routes/_profile.home.claim-swag-pack._index.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 
 import {
   Address,
@@ -95,8 +91,6 @@ const keys = ClaimSwagPackFormData.keyof().enum;
 export default function ClaimSwagPack() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <>
       <Modal.Header>
@@ -174,9 +168,7 @@ export default function ClaimSwagPack() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Claim Swag Pack
-          </Button>
+          <Button.Submit>Claim Swag Pack</Button.Submit>
         </Button.Group>
       </RemixForm>
     </>

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
@@ -9,7 +9,6 @@ import {
   useActionData,
   useLoaderData,
   useNavigate,
-  useNavigation,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { generatePath } from 'react-router';
@@ -159,8 +158,6 @@ export default function EditEducationPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { education } = useLoaderData<typeof loader>();
 
-  const submitting = useNavigation().state === 'submitting';
-
   const navigate = useNavigate();
 
   function onDelete() {
@@ -225,9 +222,9 @@ export default function EditEducationPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group flexDirection="row-reverse" spacing="between">
-          <Button name="action" loading={submitting} type="submit" value="edit">
+          <Button.Submit name="action" value="edit">
             Update
-          </Button>
+          </Button.Submit>
 
           <Button
             color="error"

--- a/apps/member-profile/app/routes/_profile.profile.education.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.add.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { type z } from 'zod';
 
@@ -105,7 +101,6 @@ const {
 
 export default function AddEducationPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/profile/education']}>
@@ -140,9 +135,7 @@ export default function AddEducationPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
 
@@ -167,7 +166,6 @@ const { code } = AddEmailFormData.keyof().enum;
 export default function AddEmailPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { email } = useLoaderData<typeof loader>();
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/profile/emails']}>
@@ -190,9 +188,7 @@ export default function AddEmailPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Verify
-          </Button>
+          <Button.Submit>Verify</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import {
@@ -135,7 +131,6 @@ const { email } = SendEmailCodeInput.keyof().enum;
 
 export default function AddEmailPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/profile/emails']}>
@@ -168,9 +163,7 @@ export default function AddEmailPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Send Code
-          </Button>
+          <Button.Submit>Send Code</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 
 import {
@@ -83,7 +82,6 @@ const keys = ChangePrimaryEmailInput.keyof().enum;
 export default function ChangePrimaryEmailPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
   const { emails } = useLoaderData<typeof loader>();
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <Modal onCloseTo={Route['/profile/emails']}>
@@ -124,9 +122,7 @@ export default function ChangePrimaryEmailPage() {
         </Form.Field>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.profile.general.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.general.tsx
@@ -7,7 +7,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { type z } from 'zod';
 
@@ -132,7 +131,6 @@ const {
 export default function UpdateGeneralInformationSection() {
   const { errors } = getActionErrors(useActionData<typeof action>());
   const { student } = useLoaderData<typeof loader>();
-  const submitting = useNavigation().state === 'submitting';
 
   return (
     <ProfileSection>
@@ -188,9 +186,7 @@ export default function UpdateGeneralInformationSection() {
         />
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </ProfileSection>

--- a/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
@@ -7,7 +7,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
@@ -150,8 +149,6 @@ const {
 export default function UpsertIcebreakerResponsesForm() {
   const { icebreakerResponses } = useLoaderData<typeof loader>();
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <ProfileSection>
       <ProfileHeader>
@@ -166,9 +163,7 @@ export default function UpsertIcebreakerResponsesForm() {
         </IcebreakersProvider>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </ProfileSection>

--- a/apps/member-profile/app/routes/_profile.profile.personal.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.personal.tsx
@@ -7,7 +7,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { sql } from 'kysely';
 import { z } from 'zod';
@@ -142,8 +141,6 @@ export default function UpdatePersonalInformationForm() {
   const { ethnicities, student } = useLoaderData<typeof loader>();
   const { errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <ProfileSection>
       <ProfileHeader>
@@ -199,9 +196,7 @@ export default function UpdatePersonalInformationForm() {
         />
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </ProfileSection>

--- a/apps/member-profile/app/routes/_profile.profile.socials.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.socials.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 import { z } from 'zod';
 
@@ -114,8 +113,6 @@ export default function UpdateSocialsInformationForm() {
   const { student } = useLoaderData<typeof loader>();
   const { errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <ProfileSection>
       <ProfileHeader>
@@ -173,9 +170,7 @@ export default function UpdateSocialsInformationForm() {
         />
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </ProfileSection>

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
@@ -240,14 +240,12 @@ export default function EditWorkExperiencePage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group flexDirection="row-reverse" spacing="between">
-          <Button loading={submitting} type="submit">
-            Update
-          </Button>
+          <Button.Submit>Update</Button.Submit>
 
           <Button
             color="error"
-            loading={submitting}
             onClick={onDelete}
+            submitting={submitting}
             type="button"
             variant="secondary"
           >

--- a/apps/member-profile/app/routes/_profile.profile.work.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.add.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { z } from 'zod';
 
@@ -98,8 +94,6 @@ const keys = AddWorkExperienceFormData.keyof().enum;
 export default function AddWorkExperiencePage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <Modal onCloseTo={Route['/profile/work']}>
       <Modal.Header>
@@ -154,9 +148,7 @@ export default function AddWorkExperiencePage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group>
-          <Button loading={submitting} type="submit">
-            Save
-          </Button>
+          <Button.Submit>Save</Button.Submit>
         </Button.Group>
       </RemixForm>
     </Modal>

--- a/apps/member-profile/app/routes/_public.apply._index.tsx
+++ b/apps/member-profile/app/routes/_public.apply._index.tsx
@@ -4,11 +4,7 @@ import {
   type MetaFunction,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { Application as ApplicationType } from '@oyster/types';
@@ -100,8 +96,6 @@ const ApplicationKey = ApplyFormData.keyof().enum;
 export default function ApplicationPage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <>
       <Text className="mb-8" color="gray-500">
@@ -192,9 +186,7 @@ export default function ApplicationPage() {
 
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
-        <Button fill loading={submitting} type="submit">
-          Apply
-        </Button>
+        <Button.Submit fill>Apply</Button.Submit>
       </RemixForm>
     </>
   );

--- a/apps/member-profile/app/routes/_public.login.otp.send.tsx
+++ b/apps/member-profile/app/routes/_public.login.otp.send.tsx
@@ -1,9 +1,5 @@
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form as RemixForm, useActionData } from '@remix-run/react';
 
 import { Button, Form, getActionErrors, validateForm } from '@oyster/ui';
 
@@ -51,17 +47,11 @@ const keys = SendOneTimeCodeInput.keyof().enum;
 export default function SendOneTimeCodePage() {
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <OneTimeCodeForm.EmailField error={errors.email} name={keys.email} />
-
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
-
-      <Button fill loading={submitting} type="submit">
-        Send Code
-      </Button>
+      <Button.Submit fill>Send Code</Button.Submit>
     </RemixForm>
   );
 }

--- a/apps/member-profile/app/routes/_public.login.otp.verify.tsx
+++ b/apps/member-profile/app/routes/_public.login.otp.verify.tsx
@@ -8,7 +8,6 @@ import {
   Form as RemixForm,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from '@remix-run/react';
 
 import { Button, Form, getActionErrors, validateForm } from '@oyster/ui';
@@ -101,8 +100,6 @@ export default function VerifyOneTimeCodePage() {
   const { description } = useLoaderData<typeof loader>();
   const { error, errors } = getActionErrors(useActionData<typeof action>());
 
-  const submitting = useNavigation().state === 'submitting';
-
   return (
     <RemixForm className="form" method="post">
       <OneTimeCodeForm.CodeField
@@ -113,9 +110,7 @@ export default function VerifyOneTimeCodePage() {
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
-      <Button fill loading={submitting} type="submit">
-        Verify Code
-      </Button>
+      <Button.Submit fill>Verify Code</Button.Submit>
     </RemixForm>
   );
 }

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@remix-run/react';
 import React, { type PropsWithChildren } from 'react';
 import { match } from 'ts-pattern';
 
@@ -10,8 +11,8 @@ type ButtonProps = Pick<
 > & {
   color?: 'error' | 'primary' | 'success';
   fill?: boolean;
-  loading?: boolean;
   size?: 'regular' | 'small';
+  submitting?: boolean;
   variant?: 'primary' | 'secondary';
 };
 
@@ -20,8 +21,8 @@ export const Button = ({
   color,
   disabled,
   fill,
-  loading,
   size,
+  submitting,
   type = 'button',
   variant,
   ...rest
@@ -29,15 +30,23 @@ export const Button = ({
   return (
     <button
       className={getButtonCn({ color, fill, size, variant })}
-      disabled={!!disabled || !!loading}
+      disabled={!!disabled || !!submitting}
       // @ts-expect-error b/c TS does not like it...
       type={type}
       {...rest}
     >
       {children}
-      {loading && <Spinner color={color} />}
+      {submitting && <Spinner color={color} />}
     </button>
   );
+};
+
+Button.Submit = function SubmitButton(
+  props: Omit<ButtonProps, 'loading' | 'type'>
+) {
+  const submitting = useNavigation().state === 'submitting';
+
+  return <Button submitting={submitting} type="submit" {...props} />;
 };
 
 export function getButtonCn({

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -27,7 +27,7 @@ export const Modal = ({
   children,
   onCloseTo,
 }: ModalProps): JSX.Element | null => {
-  const hydrated: boolean = useHydrated();
+  const hydrated = useHydrated();
 
   if (!hydrated) {
     return null;


### PR DESCRIPTION
## Description ✏️

Previously, there was a ton of places that we did this:

```ts
function SomeForm() {
  const submitting = useNavigation().status = 'submitting';

  return <Button loading={submitting} type="submit">Submit</Button>
}
```

In this PR, we abstract this pattern by introducing a `<Button.Submit />` component which automatically sets the button type to "submit" and reads the submitting status.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
