### PR TITLE
docs: add instructions on manually change node version #️⃣

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,13 @@ which will automatically install the right node version for any given directory
 that you're working in, as long as there is a [`.nvmrc`](./.nvmrc) file found in
 that directory.
 
+If for whatever reason you don't want to set up a shell integration, you can
+switch to the appropriate Node version manually by doing:
+
+```sh
+nvm install && nvm use
+```
+
 ### Fork and Clone Repository
 
 1. [Fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ which will automatically install the right node version for any given directory
 that you're working in, as long as there is a [`.nvmrc`](./.nvmrc) file found in
 that directory.
 
-If for whatever reason you don't want to set up a shell integration, you can
-switch to the appropriate Node version manually by doing:
+If you don't want to set up a shell integration, you can switch to the
+appropriate Node version manually by doing:
 
 ```sh
 nvm install && nvm use


### PR DESCRIPTION
## Description ✏️

Some contributors may not set up an NVM shell integration to automatically switch the node version, so this PR adds instructions on how to manually update the Node version:

```sh
nvm install && nvm use
```

This reads the `.nvmrc` file and switches the Node version specified there.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [x] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
