### PR TITLE
fix: allow `mymdc.net` as email domain for applicants 📕

### DIFF
--- a/packages/types/src/domain/application.ts
+++ b/packages/types/src/domain/application.ts
@@ -41,7 +41,11 @@ export const Application = Student.pick({
       .min(1)
       .email()
       .refine((value) => {
-        return value.endsWith('.edu') || value.endsWith('.ca');
+        return (
+          value.endsWith('.edu') ||
+          value.endsWith('.ca') ||
+          value.endsWith('mymdc.net')
+        );
       }, 'Must be a valid .edu email.')
       .transform((value) => {
         return value.toLowerCase();


### PR DESCRIPTION
## Description ✏️

Miami Dade College does not use `.edu` emails, so we'll hardcode their email into being allowed.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
