### PR TITLE
fix: dropdown formatting fix 🗄️ 

### DIFF
--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -181,7 +181,7 @@ function TableBody({
 
 Table.Dropdown = function TableDropdown({ children }: PropsWithChildren) {
   return (
-    <Dropdown className="fixed mr-4 mt-[unset] translate-x-[calc(-0.5rem)]">
+    <Dropdown className="fixed right-16 mt-[unset] md:right-20">
       {children}
     </Dropdown>
   );

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -181,7 +181,7 @@ function TableBody({
 
 Table.Dropdown = function TableDropdown({ children }: PropsWithChildren) {
   return (
-    <Dropdown className="fixed mr-4 translate-x-[calc(-0.5rem)]">
+    <Dropdown className="fixed mr-4 mt-[unset] translate-x-[calc(-0.5rem)]">
       {children}
     </Dropdown>
   );

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -181,7 +181,7 @@ function TableBody({
 
 Table.Dropdown = function TableDropdown({ children }: PropsWithChildren) {
   return (
-    <Dropdown className="fixed right-[unset] mt-[unset] translate-x-[calc(-100%-0.5rem)]">
+    <Dropdown className="fixed mr-4 translate-x-[calc(-0.5rem)]">
       {children}
     </Dropdown>
   );


### PR DESCRIPTION
## Description ✏️

Closes #191 

This PR adds a right margin to the `Dropdown` element so that the positioning is consistent and not pushed off the main window. 

Before: 
<img width="1200" alt="Screenshot 2024-05-08 at 11 35 02 AM" src="https://github.com/colorstackorg/oyster/assets/91388965/ad3805e7-c4a9-4af1-985f-ab47c08556a7">
After: 
<img width="1197" alt="Screenshot 2024-05-08 at 11 37 39 AM" src="https://github.com/colorstackorg/oyster/assets/91388965/e345f960-fcbe-4f84-af81-06fdea6d1602">

Before:
<img width="1196" alt="Screenshot 2024-05-08 at 11 36 23 AM" src="https://github.com/colorstackorg/oyster/assets/91388965/cd3ca619-921a-43cd-b60f-deb025480ab6">
After: 
<img width="1188" alt="Screenshot 2024-05-08 at 11 36 50 AM" src="https://github.com/colorstackorg/oyster/assets/91388965/10f3f841-e750-4659-b388-41fdf30695a5">


## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
