### PR TITLE
feat: add ability to close our application 🔒

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
@@ -69,7 +69,7 @@ function FeatureFlagsTable() {
     },
     {
       displayName: 'Name',
-      size: '160',
+      size: '200',
       render: (flag) => {
         return (
           // TODO: Move styling to design system.

--- a/apps/member-profile/app/routes/_public.apply.tsx
+++ b/apps/member-profile/app/routes/_public.apply.tsx
@@ -1,8 +1,21 @@
-import { Outlet } from '@remix-run/react';
+import { json } from '@remix-run/node';
+import { Outlet, useLoaderData } from '@remix-run/react';
 
 import { Public, Text } from '@oyster/ui';
 
+import { isFeatureFlagEnabled } from '@/member-profile.server';
+
+export async function loader() {
+  const isApplicationOpen = await isFeatureFlagEnabled('family_application');
+
+  return json({
+    isApplicationOpen,
+  });
+}
+
 export default function ApplicationLayout() {
+  const { isApplicationOpen } = useLoaderData<typeof loader>();
+
   return (
     <Public.Content layout="lg">
       <img
@@ -16,7 +29,15 @@ export default function ApplicationLayout() {
         The ColorStack Family Application
       </Text>
 
-      <Outlet />
+      {isApplicationOpen ? (
+        <Outlet />
+      ) : (
+        <Text>
+          Unfortunately, our application is temporarily closed as we review
+          exising applications. Please check back in the upcoming days/weeks for
+          the opportunity to apply to ColorStack!
+        </Text>
+      )}
     </Public.Content>
   );
 }

--- a/packages/core/src/modules/feature-flag/feature-flag.types.ts
+++ b/packages/core/src/modules/feature-flag/feature-flag.types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { BooleanInput, Entity } from '@oyster/types';
 
-export type FeatureFlagName = '';
+export type FeatureFlagName = 'family_application';
 
 // Domain
 


### PR DESCRIPTION
## Description ✏️

Closes #218.

This PR introduces a feature flag that conditionally shows the family application, and if it's disabled, shows a message about it being closed.

![Screenshot 2024-05-14 at 4 49 12 PM](https://github.com/colorstackorg/oyster/assets/38056800/7c6698a8-687a-4109-8e27-10f21d86fb80)

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
