### PR TITLE
fix: use `request.json` in mixpanel tracking 🟣

### DIFF
--- a/apps/member-profile/app/routes/api.mixpanel.track.ts
+++ b/apps/member-profile/app/routes/api.mixpanel.track.ts
@@ -7,13 +7,11 @@ import { getSession, user } from '@/shared/session.server';
 export async function action({ request }: ActionFunctionArgs) {
   const session = await getSession(request);
 
-  const form = await request.formData();
-  const values = Object.fromEntries(form);
+  const data = await request.json();
 
   track({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    event: values.event as any,
-    properties: values.properties,
+    event: data.event,
+    properties: data.properties,
     request,
     user: user(session),
   });


### PR DESCRIPTION
## Description ✏️

Fix issue with parsing Mixpanel tracking request on the server. Issue occurred because we're sending json data but we were previously trying to parse as if it was a `FormData` instance.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
