### PR TITLE
fix: don't transform resource links to lowercase 😅

### DIFF
--- a/packages/core/src/modules/resource/resource.types.ts
+++ b/packages/core/src/modules/resource/resource.types.ts
@@ -41,7 +41,6 @@ const Resource = z.object({
     .trim()
     .startsWith('http', 'URL must start with "http://".')
     .url()
-    .transform((value) => value.toLowerCase())
     .optional(),
 
   postedAt: z.coerce.date().optional(),


### PR DESCRIPTION
## Description ✏️

Most links are case-sensitive (such as YouTube), so we shouldn't transform it to lowercase.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
