### PR TITLE
fix: reset `orderBy` query param when sorting resources 🔼

### DIFF
--- a/apps/member-profile/app/routes/_profile.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.tsx
@@ -261,7 +261,7 @@ function SortResourcesForm() {
         <option value={sortKeys.most_upvotes}>Most Upvotes</option>
       </Select>
 
-      <ExistingSearchParams />
+      <ExistingSearchParams exclude={['orderBy']} />
     </RemixForm>
   );
 }


### PR DESCRIPTION
## Description ✏️

This fixes an issue where upon choosing a sort, we add another "orderBy" param to the query instead of resetting its value. See image below.

<img width="1032" alt="Screenshot 2024-05-26 at 12 33 02 AM" src="https://github.com/colorstackorg/oyster/assets/9708571/5cfa27ef-bbb3-40f9-9a91-70dbc0fb4d10">


## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
