### PR TITLE
feat: add an "admins" tab in the admin dashboard 👥 

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.tsx
@@ -65,6 +65,11 @@ export default function DashboardLayout() {
                 />
                 <Dashboard.NavigationLink
                   icon={<User />}
+                  label="Admins"
+                  pathname={Route['/admins']}
+                />
+                <Dashboard.NavigationLink
+                  icon={<User />}
                   label="Students"
                   pathname={Route['/students']}
                 />
@@ -98,7 +103,6 @@ export default function DashboardLayout() {
                   label="Schools"
                   pathname={Route['/schools']}
                 />
-
                 <div className="my-2">
                   <Divider />
                 </div>

--- a/apps/admin-dashboard/app/routes/_dashboard.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.tsx
@@ -103,6 +103,7 @@ export default function DashboardLayout() {
                   label="Schools"
                   pathname={Route['/schools']}
                 />
+
                 <div className="my-2">
                   <Divider />
                 </div>

--- a/apps/admin-dashboard/app/routes/_profile.admins.tsx
+++ b/apps/admin-dashboard/app/routes/_profile.admins.tsx
@@ -1,0 +1,13 @@
+import { json, type LoaderFunctionArgs } from '@remix-run/node';
+
+import { ensureUserAuthenticated } from '@/shared/session.server';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await ensureUserAuthenticated(request);
+
+  return json({});
+}
+
+export default function AdminsPage() {
+  return null;
+}

--- a/apps/admin-dashboard/app/shared/constants.ts
+++ b/apps/admin-dashboard/app/shared/constants.ts
@@ -1,10 +1,10 @@
 const ROUTES = [
   '/',
+  '/admins',
   '/applications',
   '/applications/:id',
   '/applications/:id/accept',
   '/applications/:id/email',
-  '/admins',
   '/bull',
   '/bull/:queue',
   '/bull/:queue/jobs',

--- a/apps/admin-dashboard/app/shared/constants.ts
+++ b/apps/admin-dashboard/app/shared/constants.ts
@@ -4,6 +4,7 @@ const ROUTES = [
   '/applications/:id',
   '/applications/:id/accept',
   '/applications/:id/email',
+  '/admins',
   '/bull',
   '/bull/:queue',
   '/bull/:queue/jobs',


### PR DESCRIPTION
## Description ✏️

Closes https://github.com/colorstackorg/oyster/issues/248

Describe what this PR does.

This PR Provides the following two things
1. Adds an "Admins" tab in the Admin Dashboard sidebar. (The Admins tab uses the same Icon as Students)
![image](https://github.com/colorstackorg/oyster/assets/88134569/323a95cb-303d-4aae-aa2c-8c2675b57b8d)
2. Adds a new route at /admins. For now, this is just be a blank page.
![image](https://github.com/colorstackorg/oyster/assets/88134569/9226abdd-c501-4820-a7c2-726be92ee3c5)

Files Created:
_profile.admins.tsx 


## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
