### PR TITLE
fix: add prefetching in member profile 🤞

### DIFF
--- a/apps/member-profile/app/routes/_profile.tsx
+++ b/apps/member-profile/app/routes/_profile.tsx
@@ -36,28 +36,33 @@ export default function ProfileLayout() {
               icon={<Home />}
               label="Home"
               pathname={Route['/home']}
+              prefetch="intent"
             />
             <Dashboard.NavigationLink
               icon={<Folder />}
               label="Directory"
               pathname={Route['/directory']}
+              prefetch="intent"
             />
             {isResourceDatabaseEnabled && (
               <Dashboard.NavigationLink
                 icon={<BookOpen />}
                 label="Resources"
                 pathname={Route['/resources']}
+                prefetch="intent"
               />
             )}
             <Dashboard.NavigationLink
               icon={<Award />}
               label="Points"
               pathname={Route['/points']}
+              prefetch="intent"
             />
             <Dashboard.NavigationLink
               icon={<Calendar />}
               label="Events"
               pathname={Route['/events']}
+              prefetch="intent"
             />
             <Dashboard.NavigationLink
               icon={<User />}

--- a/packages/ui/src/components/dashboard.tsx
+++ b/packages/ui/src/components/dashboard.tsx
@@ -1,4 +1,10 @@
-import { Link, NavLink, Form as RemixForm, useSubmit } from '@remix-run/react';
+import {
+  Link,
+  type LinkProps,
+  NavLink,
+  Form as RemixForm,
+  useSubmit,
+} from '@remix-run/react';
 import React, {
   type PropsWithChildren,
   useContext,
@@ -110,12 +116,14 @@ type DashboardNavigationLinkProps = {
   icon: JSX.Element;
   label: string;
   pathname: string;
+  prefetch?: LinkProps['prefetch'];
 };
 
 Dashboard.NavigationLink = function NavigationLink({
   icon,
   label,
   pathname,
+  prefetch,
 }: DashboardNavigationLinkProps) {
   const { setOpen } = useContext(DashboardContext);
 
@@ -125,7 +133,12 @@ Dashboard.NavigationLink = function NavigationLink({
 
   return (
     <li>
-      <NavLink className={itemClassName} onClick={onClick} to={pathname}>
+      <NavLink
+        className={itemClassName}
+        onClick={onClick}
+        prefetch={prefetch}
+        to={pathname}
+      >
         {icon} {label}
       </NavLink>
     </li>


### PR DESCRIPTION
## Description ✏️

Adds prefetching to the top-level navigation in the Member Profile - this is somewhat of a band aid fix to the slow queries that run in the "Points" and "Home" pages.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
