### PR TITLE
fix: add admin modal not showing in nested layout ❗️

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.add.tsx
@@ -68,7 +68,7 @@ export async function action({ request }: ActionFunctionArgs) {
     type: 'success',
   });
 
-  return redirect(Route['/'], {
+  return redirect(Route['/admins'], {
     headers: {
       'Set-Cookie': await commitSession(session),
     },

--- a/apps/admin-dashboard/app/routes/_dashboard.admins.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.tsx
@@ -1,4 +1,5 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
+import { Outlet } from '@remix-run/react';
 
 import { ensureUserAuthenticated } from '@/shared/session.server';
 
@@ -9,5 +10,5 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function AdminsPage() {
-  return null;
+  return <Outlet />;
 }


### PR DESCRIPTION
## Description ✏️

This PR:
- Adds an `<Outlet />` in the `/admins` layout.
- Redirects the user back to the `/admins` page after adding an admin.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
