### PR TITLE
feat: allow skipping of CoC violation email 🚀

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.remove.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.remove.tsx
@@ -7,7 +7,8 @@ import {
 import { Form as RemixForm, useLoaderData } from '@remix-run/react';
 
 import { db } from '@oyster/db';
-import { Button, Modal } from '@oyster/ui';
+import { BooleanInput } from '@oyster/types';
+import { Button, Checkbox, Modal } from '@oyster/ui';
 
 import { job } from '@/admin-dashboard.server';
 import { Route } from '@/shared/constants';
@@ -48,9 +49,14 @@ export async function action({ params, request }: ActionFunctionArgs) {
     throw new Response(null, { status: 404 });
   }
 
+  const form = await request.formData();
+
+  const sendViolationEmail = BooleanInput.parse(form.get('sendViolationEmail'));
+
   job('student.removed', {
     airtableId: student.airtableId as string,
     email: student.email,
+    sendViolationEmail,
     slackId: student.slackId,
   });
 
@@ -85,6 +91,15 @@ export default function RemoveMemberPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
+        <Checkbox
+          color="amber-100"
+          defaultChecked={true}
+          label="Send a Code of Conduct violation email."
+          id="sendViolationEmail"
+          name="sendViolationEmail"
+          value="1"
+        />
+
         <Button.Group>
           <Button color="error" type="submit">
             Remove

--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -538,6 +538,7 @@ export const StudentBullJob = z.discriminatedUnion('name', [
     data: z.object({
       airtableId: z.string().trim().min(1),
       email: Student.shape.email,
+      sendViolationEmail: z.boolean(),
       slackId: Student.shape.slackId.nullable(),
     }),
   }),

--- a/packages/core/src/modules/member/events/member-removed.ts
+++ b/packages/core/src/modules/member/events/member-removed.ts
@@ -4,6 +4,7 @@ import { job } from '@/infrastructure/bull/use-cases/job';
 export async function onMemberRemoved({
   airtableId,
   email,
+  sendViolationEmail,
   slackId,
 }: GetBullJobData<'student.removed'>) {
   job('airtable.record.delete', {
@@ -25,9 +26,11 @@ export async function onMemberRemoved({
     });
   }
 
-  job('notification.email.send', {
-    to: email,
-    name: 'student-removed',
-    data: {},
-  });
+  if (sendViolationEmail) {
+    job('notification.email.send', {
+      to: email,
+      name: 'student-removed',
+      data: {},
+    });
+  }
 }

--- a/packages/email-templates/emails/student-removed.tsx
+++ b/packages/email-templates/emails/student-removed.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Email } from './components/email';
 import { type EmailTemplateData } from '../src/types';
 


### PR DESCRIPTION
## Description ✏️

This PR:
- Fixes an issue with the `student-removed` email template - was getting a:
  ```
  Error: React is not defined.
  ```
- Allows a checkbox input when removing a member which says whether or not to send a Code of Conduct violation email. This is important because sometimes we remove members for other reasons (ie: duplicate account).

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
