### PR TITLE
fix: set max-height for page in admin dashboard ❗️

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.tsx
@@ -126,7 +126,7 @@ export default function DashboardLayout() {
         <Dashboard.LogoutForm />
       </Dashboard.Sidebar>
 
-      <Dashboard.Page>
+      <Dashboard.Page className="max-h-screen">
         <Dashboard.MenuButton />
         <Outlet />
       </Dashboard.Page>

--- a/packages/ui/src/components/dashboard.tsx
+++ b/packages/ui/src/components/dashboard.tsx
@@ -151,13 +151,17 @@ Dashboard.NavigationList = function NavigationList({
   return <ul className="flex flex-col gap-2">{children}</ul>;
 };
 
-Dashboard.Page = function Page({ children }: PropsWithChildren) {
+Dashboard.Page = function Page({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
   return (
     <section
       className={cx(
         'box-border flex flex-col gap-4 @container',
         'p-4 pb-24',
-        'md:ml-[270px] md:p-6 md:pb-16'
+        'md:ml-[270px] md:p-6 md:pb-16',
+        className
       )}
     >
       {children}


### PR DESCRIPTION
## Description ✏️

This PR sets a `max-h-screen` in the Admin Dashboard.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
