### PR TITLE
docs: Add contrib.rocks to README.md to show contributor profiles 🖼️

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -13,3 +13,4 @@
 - vazquezea96
 - aarontorres0
 - demekenega
+- ciaracade

--- a/README.md
+++ b/README.md
@@ -106,3 +106,11 @@ list on what we can configure, see
 ## Contributing
 
 Please see our [contributing guide](./CONTRIBUTING.md)! 👋
+
+Special thanks to our contributing ColorStack members! 🙏
+
+<a href="https://github.com/colorstackorg/oyster/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=colorstackorg/oyster" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ list on what we can configure, see
 
 Please see our [contributing guide](./CONTRIBUTING.md)! 👋
 
-Special thanks to our contributing ColorStack members! 🙏
+A heartfelt thanks to our ColorStack members for their contributions! 🙏
 
 <a href="https://github.com/colorstackorg/oyster/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=colorstackorg/oyster" />


### PR DESCRIPTION
## Description ✏️
Adds contributor profiles to the bottom of the README.md to show who contributed to the Oyster repository.
Also, added my name to contributions.

<img width="585" alt="Screenshot 2024-06-06 at 3 36 16 PM" src="https://github.com/colorstackorg/oyster/assets/62266962/83b7eebe-3707-4f19-928c-b3e50bafa523">


## Type of Change 🐞
-[ X] Documentation - A change only to in-code or markdown documentation.

## Checklist ✅

- [ X] I have done a self-review of my code.
- [ X] I have manually tested my code (if applicable).
- [ X] I have added/updated any relevant documentation (if applicable).
