### PR TITLE
fix: add index on `company_id` for speed ⚡️

### DIFF
--- a/packages/db/src/migrations/20240610221927_work_experiences_index.ts
+++ b/packages/db/src/migrations/20240610221927_work_experiences_index.ts
@@ -1,0 +1,16 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .createIndex('work_experiences_company_id_idx')
+    .on('work_experiences')
+    .column('company_id')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .dropIndex('work_experiences_company_id_idx')
+    .on('work_experiences')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR adds an index on `work_experiences.company_id`, which dramatically speeds up the `listCompanies` query.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
