### PR TITLE
feat: edit review directly from companies page 🖌️ 

### DIFF
--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -26,7 +26,7 @@ import { ensureUserAuthenticated, user } from '@/shared/session.server';
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const session = await ensureUserAuthenticated(request);
 
-  const studentId = user(session);
+  const userId = user(session);
 
   const id = params.id as string;
 
@@ -112,7 +112,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   );
 
   return json({
-    studentId,
+    userId,
     company,
     currentEmployees,
     pastEmployees,
@@ -187,7 +187,7 @@ function AverageRating({
 }
 
 function ReviewsList() {
-  const { reviews, studentId } = useLoaderData<typeof loader>();
+  const { reviews, userId } = useLoaderData<typeof loader>();
 
   if (!reviews.length) {
     return null;
@@ -222,7 +222,7 @@ function ReviewsList() {
                 reviewerId={review.reviewerId || ''}
                 reviewerLastName={review.reviewerLastName || ''}
                 reviewerProfilePicture={review.reviewerProfilePicture}
-                studentId={studentId}
+                userId={userId}
                 text={review.text}
                 title={review.title || ''}
                 workExperiencesId={review.workExperiencesId!}

--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -222,8 +222,10 @@ function ReviewsList() {
                 reviewerId={review.reviewerId || ''}
                 reviewerLastName={review.reviewerLastName || ''}
                 reviewerProfilePicture={review.reviewerProfilePicture}
+                studentId={studentId}
                 text={review.text}
                 title={review.title || ''}
+                workExperiencesId={review.workExperiencesId!}
               />
             );
           })}

--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -21,10 +21,12 @@ import { cx, Divider, getTextCn, ProfilePicture, Text } from '@oyster/ui';
 import { Card } from '@/shared/components/card';
 import { CompanyReview } from '@/shared/components/company-review';
 import { Route } from '@/shared/constants';
-import { ensureUserAuthenticated } from '@/shared/session.server';
+import { ensureUserAuthenticated, user } from '@/shared/session.server';
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
-  await ensureUserAuthenticated(request);
+  const session = await ensureUserAuthenticated(request);
+
+  const studentId = user(session);
 
   const id = params.id as string;
 
@@ -63,6 +65,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         'workExperiences.locationType',
         'workExperiences.startDate',
         'workExperiences.title',
+        'workExperiences.id as workExperiencesId',
       ],
       where: { companyId: id },
     }),
@@ -109,6 +112,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   );
 
   return json({
+    studentId,
     company,
     currentEmployees,
     pastEmployees,
@@ -183,7 +187,7 @@ function AverageRating({
 }
 
 function ReviewsList() {
-  const { reviews } = useLoaderData<typeof loader>();
+  const { reviews, studentId } = useLoaderData<typeof loader>();
 
   if (!reviews.length) {
     return null;

--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -225,7 +225,7 @@ function ReviewsList() {
                 userId={userId}
                 text={review.text}
                 title={review.title || ''}
-                workExperiencesId={review.workExperiencesId!}
+                workExperiencesId={review.workExperiencesId || ''}
               />
             );
           })}

--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -26,8 +26,6 @@ import { ensureUserAuthenticated, user } from '@/shared/session.server';
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const session = await ensureUserAuthenticated(request);
 
-  const userId = user(session);
-
   const id = params.id as string;
 
   const [company, _employees, _reviews] = await Promise.all([
@@ -65,7 +63,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         'workExperiences.locationType',
         'workExperiences.startDate',
         'workExperiences.title',
-        'workExperiences.id as workExperiencesId',
+        'workExperiences.id as workExperienceId',
       ],
       where: { companyId: id },
     }),
@@ -106,13 +104,13 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       return {
         ...review,
         date: `${startMonth} - ${endMonth}`,
+        editable: review.reviewerId === user(session),
         reviewedAt: dayjs().to(createdAt),
       };
     }
   );
 
   return json({
-    userId,
     company,
     currentEmployees,
     pastEmployees,
@@ -187,7 +185,7 @@ function AverageRating({
 }
 
 function ReviewsList() {
-  const { reviews, userId } = useLoaderData<typeof loader>();
+  const { reviews } = useLoaderData<typeof loader>();
 
   if (!reviews.length) {
     return null;
@@ -211,6 +209,7 @@ function ReviewsList() {
                   name: review.companyName || '',
                 }}
                 date={review.date}
+                editable={review.editable}
                 employmentType={review.employmentType as EmploymentType}
                 locationCity={review.locationCity}
                 locationState={review.locationState}
@@ -222,10 +221,9 @@ function ReviewsList() {
                 reviewerId={review.reviewerId || ''}
                 reviewerLastName={review.reviewerLastName || ''}
                 reviewerProfilePicture={review.reviewerProfilePicture}
-                userId={userId}
                 text={review.text}
                 title={review.title || ''}
-                workExperiencesId={review.workExperiencesId || ''}
+                workExperienceId={review.workExperienceId || ''}
               />
             );
           })}

--- a/apps/member-profile/app/shared/components/company-review.tsx
+++ b/apps/member-profile/app/shared/components/company-review.tsx
@@ -81,20 +81,22 @@ export const CompanyReview = ({
         </div>
 
         {studentId === reviewerId && (
-          <Tooltip>
-            <TooltipTrigger aria-label="Edit Review">
-              <Link
-                to={generatePath(Route['/profile/work/:id/review/edit'], {
-                  id: workExperiencesId!,
-                })}
-              >
-                <Edit />
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>
-              <TooltipText>Edit Review</TooltipText>
-            </TooltipContent>
-          </Tooltip>
+          <div className="ml-auto">
+            <Tooltip>
+              <TooltipTrigger aria-label="Edit Review">
+                <Link
+                  to={generatePath(Route['/profile/work/:id/review/edit'], {
+                    id: workExperiencesId!,
+                  })}
+                >
+                  <Edit />
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent>
+                <TooltipText>Edit Review</TooltipText>
+              </TooltipContent>
+            </Tooltip>
+          </div>
         )}
       </header>
 

--- a/apps/member-profile/app/shared/components/company-review.tsx
+++ b/apps/member-profile/app/shared/components/company-review.tsx
@@ -64,21 +64,19 @@ export const CompanyReview = ({
 }: CompanyReviewProps) => {
   return (
     <Card>
-      <header className="space-between flex items-center">
-        <div className="flex items-center gap-1">
-          <CompanyReviewer
-            reviewerFirstName={reviewerFirstName}
-            reviewerLastName={reviewerLastName}
-            reviewerId={reviewerId}
-            reviewerProfilePicture={reviewerProfilePicture}
-          />
-          <Text color="gray-500" variant="sm">
-            &bull;
-          </Text>
-          <Text color="gray-500" variant="sm">
-            {reviewedAt}
-          </Text>
-        </div>
+      <header className="flex items-center gap-1">
+        <CompanyReviewer
+          reviewerFirstName={reviewerFirstName}
+          reviewerLastName={reviewerLastName}
+          reviewerId={reviewerId}
+          reviewerProfilePicture={reviewerProfilePicture}
+        />
+        <Text color="gray-500" variant="sm">
+          &bull;
+        </Text>
+        <Text color="gray-500" variant="sm">
+          {reviewedAt}
+        </Text>
 
         {studentId === reviewerId && (
           <div className="ml-auto">

--- a/apps/member-profile/app/shared/components/company-review.tsx
+++ b/apps/member-profile/app/shared/components/company-review.tsx
@@ -8,7 +8,14 @@ import {
   FORMATTED_LOCATION_TYPE,
   type LocationType,
 } from '@oyster/core/employment';
-import { cx, getTextCn, Pill, ProfilePicture, Text } from '@oyster/ui';
+import {
+  cx,
+  getIconButtonCn,
+  getTextCn,
+  Pill,
+  ProfilePicture,
+  Text,
+} from '@oyster/ui';
 import {
   Tooltip,
   TooltipContent,
@@ -20,12 +27,13 @@ import { Card } from '@/shared/components/card';
 import { Route } from '@/shared/constants';
 
 type CompanyReviewProps = {
-  date: string;
   company?: {
     id: string;
     image: string;
     name: string;
   };
+  date: string;
+  editable?: boolean;
   employmentType: EmploymentType;
   locationCity: string | null;
   locationState: string | null;
@@ -37,15 +45,15 @@ type CompanyReviewProps = {
   reviewerId: string;
   reviewerProfilePicture: string | null;
   reviewedAt: string;
-  userId: string;
   text: string;
   title: string;
-  workExperiencesId: string;
+  workExperienceId?: string;
 };
 
 export const CompanyReview = ({
   company,
   date,
+  editable,
   employmentType,
   locationCity,
   locationState,
@@ -57,10 +65,9 @@ export const CompanyReview = ({
   reviewerLastName,
   reviewerProfilePicture,
   reviewedAt,
-  userId,
   text,
   title,
-  workExperiencesId,
+  workExperienceId,
 }: CompanyReviewProps) => {
   return (
     <Card>
@@ -78,13 +85,17 @@ export const CompanyReview = ({
           {reviewedAt}
         </Text>
 
-        {userId === reviewerId && (
+        {editable && workExperienceId && (
           <div className="ml-auto">
             <Tooltip>
-              <TooltipTrigger aria-label="Edit Review">
+              <TooltipTrigger asChild>
                 <Link
+                  className={getIconButtonCn({
+                    backgroundColor: 'gray-100',
+                    backgroundColorOnHover: 'gray-200',
+                  })}
                   to={generatePath(Route['/profile/work/:id/review/edit'], {
-                    id: workExperiencesId,
+                    id: workExperienceId,
                   })}
                 >
                   <Edit />

--- a/apps/member-profile/app/shared/components/company-review.tsx
+++ b/apps/member-profile/app/shared/components/company-review.tsx
@@ -37,10 +37,10 @@ type CompanyReviewProps = {
   reviewerId: string;
   reviewerProfilePicture: string | null;
   reviewedAt: string;
-  studentId?: string;
+  userId: string;
   text: string;
   title: string;
-  workExperiencesId?: string;
+  workExperiencesId: string;
 };
 
 export const CompanyReview = ({
@@ -57,7 +57,7 @@ export const CompanyReview = ({
   reviewerLastName,
   reviewerProfilePicture,
   reviewedAt,
-  studentId,
+  userId,
   text,
   title,
   workExperiencesId,
@@ -78,7 +78,7 @@ export const CompanyReview = ({
           {reviewedAt}
         </Text>
 
-        {studentId === reviewerId && (
+        {userId === reviewerId && (
           <div className="ml-auto">
             <Tooltip>
               <TooltipTrigger aria-label="Edit Review">

--- a/apps/member-profile/app/shared/components/company-review.tsx
+++ b/apps/member-profile/app/shared/components/company-review.tsx
@@ -1,6 +1,6 @@
 import { generatePath, Link } from '@remix-run/react';
 import { type PropsWithChildren, useState } from 'react';
-import { Check, ChevronDown, ChevronUp, Star, X } from 'react-feather';
+import { Check, ChevronDown, ChevronUp, Edit, Star, X } from 'react-feather';
 
 import {
   type EmploymentType,
@@ -9,6 +9,12 @@ import {
   type LocationType,
 } from '@oyster/core/employment';
 import { cx, getTextCn, Pill, ProfilePicture, Text } from '@oyster/ui';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipText,
+  TooltipTrigger,
+} from '@oyster/ui/tooltip';
 
 import { Card } from '@/shared/components/card';
 import { Route } from '@/shared/constants';
@@ -31,8 +37,10 @@ type CompanyReviewProps = {
   reviewerId: string;
   reviewerProfilePicture: string | null;
   reviewedAt: string;
+  studentId?: string;
   text: string;
   title: string;
+  workExperiencesId?: string;
 };
 
 export const CompanyReview = ({
@@ -49,26 +57,45 @@ export const CompanyReview = ({
   reviewerLastName,
   reviewerProfilePicture,
   reviewedAt,
+  studentId,
   text,
   title,
+  workExperiencesId,
 }: CompanyReviewProps) => {
   return (
     <Card>
-      <header className="flex items-center gap-1">
-        <CompanyReviewer
-          reviewerFirstName={reviewerFirstName}
-          reviewerLastName={reviewerLastName}
-          reviewerId={reviewerId}
-          reviewerProfilePicture={reviewerProfilePicture}
-        />
+      <header className="space-between flex items-center">
+        <div className="flex items-center gap-1">
+          <CompanyReviewer
+            reviewerFirstName={reviewerFirstName}
+            reviewerLastName={reviewerLastName}
+            reviewerId={reviewerId}
+            reviewerProfilePicture={reviewerProfilePicture}
+          />
+          <Text color="gray-500" variant="sm">
+            &bull;
+          </Text>
+          <Text color="gray-500" variant="sm">
+            {reviewedAt}
+          </Text>
+        </div>
 
-        <Text color="gray-500" variant="sm">
-          &bull;
-        </Text>
-
-        <Text color="gray-500" variant="sm">
-          {reviewedAt}
-        </Text>
+        {studentId === reviewerId && (
+          <Tooltip>
+            <TooltipTrigger aria-label="Edit Review">
+              <Link
+                to={generatePath(Route['/profile/work/:id/review/edit'], {
+                  id: workExperiencesId!,
+                })}
+              >
+                <Edit />
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent>
+              <TooltipText>Edit Review</TooltipText>
+            </TooltipContent>
+          </Tooltip>
+        )}
       </header>
 
       <div className="flex items-center gap-4">

--- a/apps/member-profile/app/shared/components/company-review.tsx
+++ b/apps/member-profile/app/shared/components/company-review.tsx
@@ -84,7 +84,7 @@ export const CompanyReview = ({
               <TooltipTrigger aria-label="Edit Review">
                 <Link
                   to={generatePath(Route['/profile/work/:id/review/edit'], {
-                    id: workExperiencesId!,
+                    id: workExperiencesId,
                   })}
                 >
                   <Edit />


### PR DESCRIPTION
## Description ✏️

Closes [#318](https://github.com/colorstackorg/oyster/issues/318)

-  Add: `studentId` & `workExperiencesId` props to `<CompanyReview>` component
   -  Conditionally renders 'Edit Review' feature if `studentId` EQUALS reviewerId
   -  Pass `workExperiencesId` as id to render the correct `/work/:id/review/edit` modal page
-  Add: Tool tip to the 'Edit Review' feature.
-  Add: `div` wrapper to add space between header elements in `<CompanyReview>` component
![image](https://github.com/colorstackorg/oyster/assets/58885172/5caa8439-ea18-4433-ab60-9c9942df714d)

   Notes:
   Props `studentId` & `workExperienceId` are optional b/c the `<CompanyReview>` component is used in `/recap/:date/reviews` page (I'm not sure what the this page is, but it won't need `studentId` & `workExperienceId` props, _i think??????_)

   On form submission, the action function in `/work/:id/review/edit` modal redirects to a static path `redirect(Route['/profile/work']`, this should be dynamic based on what page the 'Review Edit' update was on (work OR company page). This could be a new issue.

## Type of Change 🐞

-  [x] Feature - A non-breaking change which adds functionality.
-  [ ] Fix - A non-breaking change which fixes an issue.
-  [ ] Refactor - A change that neither fixes a bug nor adds a feature.
-  [ ] Documentation - A change only to in-code or markdown documentation.
-  [ ] Tests - A change that adds missing unit/integration tests.
-  [ ] Chore - A change that is likely none of the above.

## Checklist ✅

-  [x] I have done a self-review of my code.
-  [ ] I have manually tested my code (if applicable).
-  [ ] I have added/updated any relevant documentation (if applicable).
