### PR TITLE
feat: allow puerto rican addresses for swagup 🇵🇷

### DIFF
--- a/apps/member-profile/app/routes/_profile.home.claim-swag-pack._index.tsx
+++ b/apps/member-profile/app/routes/_profile.home.claim-swag-pack._index.tsx
@@ -70,13 +70,6 @@ export async function action({ request }: ActionFunctionArgs) {
     return json({ errors }, { status: 400 });
   }
 
-  if (data.addressState === 'PR') {
-    return json({
-      error: `Unfortunately, our swag pack provider, SwagUp, does not support shipments to Puerto Rico. Please reach out to membership@colorstack.org for further assistance.`,
-      errors,
-    });
-  }
-
   try {
     await claimSwagPack({
       addressCity: data.addressCity,


### PR DESCRIPTION
## Description ✏️

Closes #349.

This PR removes the logic that blocks Puerto Rico from being a valid state when claiming a swag pack.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
