### PR TITLE
chore: auto assign assignees of PR's 🧑‍💼

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,15 @@
+# .github/workflows/auto-author-assign.yml
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,4 +1,3 @@
-# .github/workflows/auto-author-assign.yml
 name: Auto Author Assign
 
 on:


### PR DESCRIPTION
## Description ✏️

New Github PR [workflow](https://github.com/marketplace/actions/auto-author-assign) that auto fills the `assignees` column to the author of the PR when opened/reopened.   

![image](https://github.com/user-attachments/assets/32ba73fd-33ce-431e-a351-d52088f4e75a)

**Current PR's are missing some `assignees`**

![image](https://github.com/user-attachments/assets/42ce7faf-8f4c-4390-be92-2b7182f9d230)



## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [x] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
