### PR TITLE
fix: rename `s3_key` to `object_key` ❗️

### DIFF
--- a/apps/member-profile/app/routes/_profile.recap.$date.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.recap.$date.resources.tsx
@@ -70,7 +70,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
                 mimeType: attachment.mimeType,
                 uri: await getPresignedURL({
                   expiresIn: 60 * 60, // 1 hour
-                  key: attachment.s3Key,
+                  key: attachment.objectKey,
                 }),
               };
             })

--- a/apps/member-profile/app/routes/_profile.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.tsx
@@ -108,7 +108,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
                 mimeType: attachment.mimeType,
                 uri: await getPresignedURL({
                   expiresIn: 60 * 60, // 1 hour
-                  key: attachment.s3Key,
+                  key: attachment.objectKey,
                 }),
               };
             })

--- a/packages/core/src/modules/resource/queries/list-resources.ts
+++ b/packages/core/src/modules/resource/queries/list-resources.ts
@@ -87,7 +87,7 @@ export async function listResources<
       buildTagsField,
 
       // The "attachments" field is a JSON array of objects, each containing
-      // the "mimeType" and "s3Key" of an attachment associated with the
+      // the "mimeType" and "objectKey" of an attachment associated with the
       // resource.
       (eb) => {
         return eb
@@ -96,13 +96,13 @@ export async function listResources<
           .select(({ fn, ref }) => {
             const object = jsonBuildObject({
               mimeType: ref('resourceAttachments.mimeType'),
-              s3Key: ref('resourceAttachments.s3Key'),
+              objectKey: ref('resourceAttachments.objectKey'),
             });
 
             return fn
               .jsonAgg(sql`${object} order by ${ref('createdAt')} asc`)
-              .filterWhere('s3Key', 'is not', null)
-              .$castTo<{ mimeType: string; s3Key: string }[]>()
+              .filterWhere('objectKey', 'is not', null)
+              .$castTo<{ mimeType: string; objectKey: string }[]>()
               .as('attachments');
           })
           .as('attachments');

--- a/packages/core/src/modules/resource/use-cases/add-resource.ts
+++ b/packages/core/src/modules/resource/use-cases/add-resource.ts
@@ -50,8 +50,8 @@ export async function addResource(input: AddResourceInput) {
         .values({
           id: attachmentId,
           mimeType: attachment.type,
+          objectKey: attachmentKey,
           resourceId: resource.id,
-          s3Key: attachmentKey,
         })
         .execute();
     }

--- a/packages/db/src/migrations/20240717035628_resource_object_key.ts
+++ b/packages/db/src/migrations/20240717035628_resource_object_key.ts
@@ -1,0 +1,16 @@
+import { type Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  // We're using custom SQL here b/c we now want to use the
+  // "underscoreBeforeDigits" option with our database client, which affects
+  // the column name "s3_key".
+  await sql`
+    alter table resource_attachments rename column s3_key to object_key;
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>) {
+  await sql`
+    alter table resource_attachments rename column object_key to s3_key;
+  `.execute(db);
+}


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue caused by introducing the `underscoreBeforeDigits` option on the database client.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
