### PR TITLE
feat: add empty header cell to all tables 🍽️

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.admins.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.tsx
@@ -56,7 +56,7 @@ function AdminsTable() {
     },
     {
       displayName: 'Status',
-      size: null,
+      size: '200',
       render: (admin) => {
         return admin.isArchived ? (
           <Pill color="gray-100">Archived</Pill>

--- a/apps/admin-dashboard/app/routes/_dashboard.events.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.tsx
@@ -171,7 +171,7 @@ function EventsTable() {
     {
       displayName: 'Time',
       render: (event) => `${event.startTime} - ${event.endTime}`,
-      size: null,
+      size: '200',
     },
   ];
 

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
@@ -86,7 +86,7 @@ function FeatureFlagsTable() {
     },
     {
       displayName: 'Description',
-      size: null,
+      size: '800',
       render: (flag) => flag.description,
     },
   ];

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
@@ -171,7 +171,7 @@ function OnboardingSessionsTable() {
     {
       displayName: 'Attendees',
       render: (session) => session.attendees,
-      size: null,
+      size: '800',
     },
     {
       displayName: 'Uploaded By',

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.tsx
@@ -126,11 +126,6 @@ function ResumeBooksTable() {
       size: '240',
       render: (resumeBook) => resumeBook.endDate,
     },
-    {
-      displayName: '',
-      size: null,
-      render: (_) => '',
-    },
   ];
 
   return (

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
@@ -165,7 +165,7 @@ function SchoolsTable() {
     {
       displayName: '# of Students',
       render: (school) => school.students,
-      size: null,
+      size: '120',
     },
   ];
 

--- a/apps/admin-dashboard/app/routes/_dashboard.surveys.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.surveys.tsx
@@ -149,7 +149,7 @@ function SurveysTable() {
     {
       displayName: 'Event',
       render: (survey) => survey.eventName,
-      size: null,
+      size: '400',
     },
   ];
 

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -34,7 +34,7 @@ export type TableColumnProps<T extends TableData> = {
     | '320'
     | '360'
     | '400'
-    | null;
+    | '800';
 };
 
 type TableDropdownProps<T extends TableData> = T & {
@@ -119,7 +119,7 @@ function TableHead({ columns }: Pick<TableProps, 'columns'>) {
                     .with('320', () => 'w-[320px]')
                     .with('360', () => 'w-[360px]')
                     .with('400', () => 'w-[400px]')
-                    .with(null, () => undefined)
+                    .with('800', () => 'w-[800px]')
                     .exhaustive()
                 )}
               >
@@ -128,6 +128,7 @@ function TableHead({ columns }: Pick<TableProps, 'columns'>) {
             );
           })}
 
+        <th className={headerCellCn}></th>
         <th className={cx(headerCellCn, 'right-0 w-12 px-0')} />
       </tr>
     </thead>


### PR DESCRIPTION
## Description ✏️

This PR removes the usage of `size: null` for table columns and adds an empty header by default to all tables so that tables remain consistent in their spacing given the `table-fixed` styling.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
