### PR TITLE
fix: add null check to birthday notification ❎

### DIFF
--- a/packages/core/src/modules/member/use-cases/send-birthday-notification.ts
+++ b/packages/core/src/modules/member/use-cases/send-birthday-notification.ts
@@ -23,6 +23,7 @@ export async function sendBirthdayNotification(
       sql`EXTRACT(DAY FROM CURRENT_DATE)`
     )
     .where('birthdateNotification', 'is', true)
+    .where('slackId', 'is not', null)
     .execute();
 
   // We won't send a notification if there are no members with birthdays today!


### PR DESCRIPTION
## Description ✏️

This PR is a follow up to #416 which only fetches records with a valid `slack_id`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
