### PR TITLE
fix: parse slack message in activity history 👖

### DIFF
--- a/apps/member-profile/app/routes/_profile.points.tsx
+++ b/apps/member-profile/app/routes/_profile.points.tsx
@@ -41,6 +41,7 @@ import {
   EmptyStateContainer,
 } from '@/shared/components/empty-state';
 import { Leaderboard } from '@/shared/components/leaderboard';
+import { SlackMessage } from '@/shared/components/slack-message';
 import { Route } from '@/shared/constants';
 import { getTimezone } from '@/shared/cookies.server';
 import { ensureUserAuthenticated, user } from '@/shared/session.server';
@@ -595,12 +596,12 @@ function ActivityHistoryItemDescription({
           <div className="flex gap-2">
             <div className="border-r-2 border-r-gray-300" />
 
-            <Text
-              className="line-clamp-5 whitespace-pre-wrap [word-break:break-word]"
+            <SlackMessage
+              className="line-clamp-5 [word-break:break-word]"
               color="gray-500"
             >
               {activity.messageReactedToText}
-            </Text>
+            </SlackMessage>
           </div>
         </div>
       );
@@ -624,12 +625,12 @@ function ActivityHistoryItemDescription({
           <div className="flex gap-2">
             <div className="border-r-2 border-r-gray-300" />
 
-            <Text
-              className="line-clamp-5 whitespace-pre-wrap [word-break:break-word]"
+            <SlackMessage
+              className="line-clamp-5 [word-break:break-word]"
               color="gray-500"
             >
               {activity.threadRepliedToText}
-            </Text>
+            </SlackMessage>
           </div>
         </div>
       );

--- a/apps/member-profile/app/routes/_profile.recap.$date.announcements.tsx
+++ b/apps/member-profile/app/routes/_profile.recap.$date.announcements.tsx
@@ -6,7 +6,7 @@ import { emojify } from 'node-emoji';
 import { listSlackMessages } from '@oyster/core/slack.server';
 
 import { getDateRange, Recap } from '@/routes/_profile.recap.$date';
-import { SlackMessage } from '@/shared/components/slack-message';
+import { SlackMessageCard } from '@/shared/components/slack-message';
 import { ENV } from '@/shared/constants.server';
 import { ensureUserAuthenticated } from '@/shared/session.server';
 
@@ -54,7 +54,7 @@ export default function RecapAnnouncements() {
       <ul className="flex flex-col gap-4">
         {announcements.map((announcement) => {
           return (
-            <SlackMessage
+            <SlackMessageCard
               key={announcement.id}
               channelId={announcement.channelId}
               messageId={announcement.id}

--- a/apps/member-profile/app/shared/components/slack-message.tsx
+++ b/apps/member-profile/app/shared/components/slack-message.tsx
@@ -3,11 +3,17 @@ import React from 'react';
 import parseSlackMessage, { type Node, NodeType } from 'slack-message-parser';
 import { match } from 'ts-pattern';
 
-import { cx, getButtonCn, ProfilePicture, Text } from '@oyster/ui';
+import {
+  cx,
+  getButtonCn,
+  ProfilePicture,
+  Text,
+  type TextProps,
+} from '@oyster/ui';
 
 import { Card } from '@/shared/components/card';
 
-type SlackMessageProps = {
+type SlackMessageCardProps = {
   channelId?: string;
   messageId?: string;
   postedAt?: string;
@@ -19,7 +25,7 @@ type SlackMessageProps = {
 
 const SLACK_WORKSPACE_URL = 'https://colorstack-family.slack.com';
 
-export function SlackMessage({
+export function SlackMessageCard({
   channelId,
   messageId,
   postedAt,
@@ -27,7 +33,7 @@ export function SlackMessage({
   posterLastName = 'Member',
   posterProfilePicture,
   text,
-}: SlackMessageProps) {
+}: SlackMessageCardProps) {
   return (
     <Card>
       <header className="flex items-start justify-between gap-4">
@@ -64,10 +70,22 @@ export function SlackMessage({
         )}
       </header>
 
-      <Text className="whitespace-pre-wrap">
-        {<>{toHTML(parseSlackMessage(text))}</>}
-      </Text>
+      <SlackMessage>{text}</SlackMessage>
     </Card>
+  );
+}
+
+type SlackMessageProps = Pick<TextProps, 'children' | 'className' | 'color'>;
+
+export function SlackMessage({
+  children,
+  className,
+  ...rest
+}: SlackMessageProps) {
+  return (
+    <Text className={cx('whitespace-pre-wrap', className)} {...rest}>
+      {<>{toHTML(parseSlackMessage(children as string))}</>}
+    </Text>
   );
 }
 


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue which doesn't parse the raw Slack message text in the activity history.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
