### PR TITLE
fix: improve parsing to avoid hallucinations in resume review ❗️

### DIFF
--- a/packages/core/src/modules/resume/resume.core.ts
+++ b/packages/core/src/modules/resume/resume.core.ts
@@ -35,7 +35,7 @@ import {
 } from '@/modules/resume/resume.types';
 import { ColorStackError } from '@/shared/errors';
 import { fail, type Result, success } from '@/shared/utils/core.utils';
-import { convertPdfToImage } from '@/shared/utils/file.utils';
+import { getTextFromPDF } from '@/shared/utils/file.utils';
 
 // Environment Variables
 
@@ -516,8 +516,10 @@ export async function reviewResume({
   `;
 
   const userPrompt = dedent`
-    Please review this resume. Only return JSON that respects the following Zod
-    schema:
+    The following is a resume that has been parsed to text from a PDF. Please
+    review this resume.
+
+    IMPORTANT: Only return JSON that respects the following Zod schema:
 
     const ResumeBullet = z.object({
       content: z.string(),
@@ -544,7 +546,7 @@ export async function reviewResume({
     });
   `;
 
-  const imageBase64 = await convertPdfToImage(resume);
+  const resumeText = await getTextFromPDF(resume);
 
   const completionResult = await getChatCompletion({
     maxTokens: 8192,
@@ -557,12 +559,8 @@ export async function reviewResume({
             text: userPrompt,
           },
           {
-            type: 'image',
-            source: {
-              data: imageBase64,
-              media_type: 'image/png',
-              type: 'base64',
-            },
+            type: 'text',
+            text: resumeText,
           },
         ],
       },

--- a/packages/core/src/modules/resume/resume.core.ts
+++ b/packages/core/src/modules/resume/resume.core.ts
@@ -529,6 +529,7 @@ export async function reviewResume({
     });
 
     z.object({
+      // This should also include leadership experiences.
       experiences: z
         .object({
           bullets: ResumeBullet.array(),

--- a/packages/core/src/shared/utils/file.utils.ts
+++ b/packages/core/src/shared/utils/file.utils.ts
@@ -36,3 +36,59 @@ export async function convertPdfToImage(file: File): Promise<string> {
 
   return base64;
 }
+
+/**
+ * Extracts the text content from a PDF file.
+ *
+ * @param file - The PDF file to extract text from.
+ * @returns The text content of the PDF file.
+ */
+export async function getTextFromPDF(file: File) {
+  const arrayBuffer = await file.arrayBuffer();
+  const data = new Uint8Array(arrayBuffer);
+
+  const document = await getDocument({ data }).promise;
+
+  let result = '';
+
+  // Tracks the y-coordinate of the last text item, which will help us
+  // determine whether or not to render a newline character (multiple items
+  // could be on the same line)
+  let lastY = 0;
+
+  for (let i = 1; i <= document.numPages; i++) {
+    const page = await document.getPage(i);
+    const content = await page.getTextContent();
+
+    content.items.filter((item) => {
+      // We're only interested in text items, not marked content or images.
+      if (!('str' in item)) {
+        return;
+      }
+
+      // The transform matrix is an array of 6 numbers that represent the
+      // transformation matrix required to position the text on the page. The
+      // 5th and 6th numbers are the x and y coordinates of the text.
+      const y = item.transform[5];
+
+      // If the y coordinate has changed, we're on a new line, so add a newline
+      // character. Note that it doesn't have to be exact...
+      if (Math.round(y) !== Math.round(lastY)) {
+        result += '\n';
+      }
+
+      // The actual content of the text item gets added.
+      result += item.str;
+
+      // If the text item has an EOL (end of line) property, add a newline
+      // character.
+      if (item.hasEOL) {
+        result += '\n';
+      }
+
+      lastY = y;
+    });
+  }
+
+  return result;
+}

--- a/packages/core/src/shared/utils/zod.utils.ts
+++ b/packages/core/src/shared/utils/zod.utils.ts
@@ -10,7 +10,7 @@ export const FileLike = z.custom<File>((value) => {
     'text' in value &&
     'type' in value
   );
-});
+}, 'This is not a valid file object.');
 
 /**
  * Returns the error message that lives within the `error`. Note that even if


### PR DESCRIPTION
## Description ✏️

Closes #448 and #449.

This PR:
- Implements the `getTextFromPDF` function which parses the PDF into a string.
- In the `reviewResume` function, we're now passing in the parsed text of a resume, instead of an image of the resume like we were doing before. This is the huge gain because we no longer have to rely on the AI's image parsing abilities, it just parses text which is much more certain and simple.
- Updated the prompt to include leadership experiences.
- Adds validation to the `action` in the review resume page, ensuring that only files are being uploaded (not sure how some people may have gotten around that).

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
