### PR TITLE
feat: improve ai chatbot prompt + ux 📈

### DIFF
--- a/apps/api/src/routers/slack-event.router.ts
+++ b/apps/api/src/routers/slack-event.router.ts
@@ -83,6 +83,10 @@ slackEventRouter.post('/slack/events', async (req: RawBodyRequest, res) => {
       });
     })
     .with({ type: 'message', channel_type: 'im' }, (event) => {
+      if (event.app_id) {
+        return;
+      }
+
       job('slack.chatbot.message', {
         channelId: event.channel!,
         id: event.ts!,

--- a/apps/api/src/routers/slack-event.types.ts
+++ b/apps/api/src/routers/slack-event.types.ts
@@ -60,6 +60,7 @@ type SlackMessageDeletedEvent = {
  * @see https://api.slack.com/events/message
  */
 type SlackMessageSentEvent = {
+  app_id?: string;
   channel: string;
   subtype: undefined;
   text: string;

--- a/packages/core/src/modules/ai/ai.ts
+++ b/packages/core/src/modules/ai/ai.ts
@@ -205,6 +205,8 @@ export async function getChatCompletion({
 
   const json = await response.json();
 
+  console.log(json.usage);
+
   if (!response.ok) {
     const message = match(response.status)
       .with(429, () => {

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -92,6 +92,12 @@ export async function answerChatbotQuestion({
   // TODO: Delete the loading message after the answer is sent.
 }
 
+/**
+ * Determines if the given text is a question.
+ *
+ * @param question - The text to determine if it's a question.
+ * @returns Whether the text is a question.
+ */
 async function isQuestion(question: string): Promise<Result<boolean>> {
   const result = await getChatCompletion({
     maxTokens: 5,

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -43,19 +43,43 @@ export async function answerChatbotQuestion({
     return;
   }
 
+  const questionResult = await isQuestion(text);
+
+  if (!questionResult.ok) {
+    throw new Error(questionResult.error);
+  }
+
+  if (!questionResult.ok || !questionResult.data) {
+    job('notification.slack.send', {
+      channel: channelId,
+      message:
+        'I apologize, but I can only answer questions. Is there something ' +
+        "specific you'd like to ask?",
+      threadId: id,
+      workspace: 'regular',
+    });
+
+    return;
+  }
+
+  job('notification.slack.send', {
+    channel: channelId,
+    message: 'Searching our Slack history...',
+    threadId: id,
+    workspace: 'regular',
+  });
+
   const answerResult = await getAnswerFromSlackHistory(text);
 
   if (!answerResult.ok) {
-    console.error(answerResult.error);
-
-    return;
+    throw new Error(answerResult.error);
   }
 
   // Remove all <thread></thread> references and replace them with an actual
   // Slack message link.
   const answerWithLinks = answerResult.data.replace(
-    /<thread>(.*?):(.*?)<\/thread>/g,
-    `<https://colorstack-family.slack.com/archives/$1/p$2|thread>`
+    /<thread>(.*?):(.*?):(.*?)<\/thread>/g,
+    `<https://colorstack-family.slack.com/archives/$1/p$2|*[$3]*>`
   );
 
   job('notification.slack.send', {
@@ -64,6 +88,37 @@ export async function answerChatbotQuestion({
     threadId: id,
     workspace: 'regular',
   });
+
+  // TODO: Delete the loading message after the answer is sent.
+}
+
+async function isQuestion(question: string): Promise<Result<boolean>> {
+  const result = await getChatCompletion({
+    maxTokens: 5,
+    messages: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: `Input: ${question}` }],
+      },
+    ],
+    system: [
+      {
+        cache: true,
+        type: 'text',
+        text: dedent`
+          Your only job is to determine if the user's question is a question.
+          If it is, respond with "true". If it is not, respond with "false".
+        `,
+      },
+    ],
+    temperature: 0,
+  });
+
+  if (!result.ok) {
+    return fail(result);
+  }
+
+  return success(result.data === 'true');
 }
 
 /**
@@ -93,7 +148,7 @@ async function getAnswerFromSlackHistory(
 
   const { matches } = await getPineconeIndex('slack-messages').query({
     includeMetadata: true,
-    topK: 3,
+    topK: 5,
     vector: embeddingResult.data,
   });
 
@@ -106,7 +161,7 @@ async function getAnswerFromSlackHistory(
         const [thread, replies] = await Promise.all([
           db
             .selectFrom('slackMessages')
-            .select(['channelId', 'text'])
+            .select(['channelId', 'createdAt', 'text'])
             .where('id', '=', threadId)
             .executeTakeFirstOrThrow(),
 
@@ -115,6 +170,7 @@ async function getAnswerFromSlackHistory(
             .select(['text'])
             .where('threadId', '=', threadId)
             .orderBy('createdAt', 'asc')
+            .limit(25)
             .execute(),
         ]);
 
@@ -124,8 +180,10 @@ async function getAnswerFromSlackHistory(
 
         return {
           channelId: thread.channelId,
+          createdAt: thread.createdAt.toISOString(),
           question: thread.text!,
           replies: formattedReplies,
+          score: match.score,
           threadId,
         };
       })
@@ -134,7 +192,7 @@ async function getAnswerFromSlackHistory(
   const stringifiedMessages = JSON.stringify(messages, null, 2);
 
   const completionResult = await getChatCompletion({
-    maxTokens: 4096,
+    maxTokens: 1000,
     messages: [
       {
         role: 'user',
@@ -159,17 +217,38 @@ async function getAnswerFromSlackHistory(
         text: dedent`
           You are a helpful assistant that can answer questions by utilizing
           knowledge found in Slack threads. You will be given a question and a
-          set of threads that may contain the answer to the question.
+          set of threads that MAY OR MAY NOT contain the answer to the question.
+          If there are no threads given, that means the question was not found
+          in the Slack history.
 
           Do your best to answer the question based on the threads. If you can't
           find the answer in the threads or are not confident, please respond
-          that you don't know the answer. Don't mention that you are using the
-          threads to answer the question.
+          that you don't know the answer. If the question is extremeley vague,
+          don't try to answer it using the threads. If you can't answer the
+          question, do NOT mention any threads that you were given.
 
           If you find something helpful in a thread, be sure to include a
-          reference by doing <thread>channel_id:thread_id</thread>.
-          These threads will be formatted as links (with the display text
-          "thread"), so be sure to take that into account.
+          reference by doing <thread>channel_id:thread_id:thread_number</thread>,
+          where thread_number is an autoincrementing number starting at 1. The
+          same thread_id should always have the same thread_number. These
+          threads will be formatted as links (with the display text
+          "<thread_number>", so put them AFTER the sentence that uses that
+          reference.
+
+          You should factor in the score AND the date of the thread when
+          answering the question. If a thread is very old, you should be less
+          confident in it's contents, unless you don't think time is super
+          relevant to the answer.
+
+          Other rules for responding:
+          - Be kind.
+          - Be concise.
+          - Use numbers or bullet points to organize thoughts where appropriate.
+          - Reference numbers should always be after the terminal punctuation.
+          - Never use phrases like "Based on the provided Slack threads...".
+            Just get to the answer and link the threads wherever they're used.
+          - If the question is not actually a question, respond that you can
+            only answer questions, and that's not a question.
         `,
       },
     ],

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
 export { type DB } from './shared/types';
 export { db } from './shared/db';
 export { point } from './shared/utils';
+export { createDatabaseConnection } from './use-cases/create-database-connection';

--- a/packages/db/src/use-cases/create-database-connection.ts
+++ b/packages/db/src/use-cases/create-database-connection.ts
@@ -4,8 +4,8 @@ import pg from 'pg';
 import { DATABASE_URL } from '../shared/env';
 import { type DB } from '../shared/types';
 
-export function createDatabaseConnection() {
-  if (!DATABASE_URL) {
+export function createDatabaseConnection(url: string = DATABASE_URL) {
+  if (!url) {
     throw new Error(
       '"DATABASE_URL" must be set to establish a connection to the database.'
     );
@@ -13,7 +13,7 @@ export function createDatabaseConnection() {
 
   const dialect = new PostgresDialect({
     pool: new pg.Pool({
-      connectionString: DATABASE_URL,
+      connectionString: url,
     }),
   });
 


### PR DESCRIPTION
## Description ✏️

This PR:
- Doesn't emit the `slack.chatbot.message` if the DM is from a bot (ie: `ColorStack` app).
- Logs the Anthropic token usage after a chat completion.
- Updates the `createDatabaseConnection` to accept an optional database URL as an argument.
- Improves the UX of the AI chatbot:
  - First checks whether or not the input is a question and if it's not, says "can't answer this".
  - Then, immediately sends a "Searching our Slack history..." message.
  - Updates the linked thread presentation (uses the **`[1]`** as an example).
  - Uses the top 5 most similar messages in the Pinecone query.
  - The prompt now takes into account the creation date + score of the match.
- Additionally, the max tokens is `1000`.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
