### PR TITLE
fix: handle case where `thread_ts` is not present in shortcut ❗️

### DIFF
--- a/apps/api/src/routers/slack.router.ts
+++ b/apps/api/src/routers/slack.router.ts
@@ -164,7 +164,7 @@ slackEventRouter.post('/slack/events', async (req: RawBodyRequest, res) => {
 type SlackShortcutPayload = {
   callback_id: 'ask_colorstack_ai';
   channel: { id: string };
-  message: { text: string; thread_ts: string };
+  message: { text: string; thread_ts?: string; ts: string };
   type: 'message_action';
   user: { id: string };
 };
@@ -198,7 +198,7 @@ slackShortcutsRouter.post(
             job('slack.message.answer', {
               channelId: payload.channel.id,
               text: payload.message.text,
-              threadId: payload.message.thread_ts,
+              threadId: payload.message.thread_ts || payload.message.ts,
               userId: payload.user.id,
             });
           }

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -192,6 +192,13 @@ export async function answerPublicQuestion({
     return success({});
   }
 
+  job('notification.slack.send', {
+    channel: channelId,
+    message: 'Searching our Slack history...',
+    threadId,
+    workspace: 'regular',
+  });
+
   const answerResult = await getAnswerFromSlackHistory(text);
 
   if (!answerResult.ok) {


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue with the "Ask ColorStack AI" functionality for top-level messages.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
