### PR TITLE
feat: increase threshold + formatting of bot reply to thread 🧵

### DIFF
--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -219,14 +219,11 @@ export async function answerPublicQuestion({
     .map((thread, i) => {
       const date = dayjs(thread.createdAt)
         .tz('America/Los_Angeles')
-        .format('M/D/YY');
+        .format("MMM. 'YY");
 
-      const message =
-        thread.message.length > 100
-          ? thread.message.slice(0, 100) + '...'
-          : thread.message;
+      const uri = `https://colorstack-family.slack.com/archives/${thread.channelId}/p${thread.id}`;
 
-      return `${i + 1}. [${date}] <https://colorstack-family.slack.com/archives/${thread.channelId}/p${thread.id}|*${message}*>`;
+      return `• <${uri}|*Thread #${i + 1}*> [${date}]`;
     });
 
   if (!threads.length) {

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -200,9 +200,19 @@ export async function answerPublicQuestion({
     return threadsResult;
   }
 
-  const threads = threadsResult.data.filter((thread) => {
-    return thread.score >= 0.98;
-  });
+  const threads = threadsResult.data
+    .filter((thread) => {
+      return thread.score >= 0.98;
+    })
+    .map((thread, i) => {
+      const date = dayjs(thread.createdAt)
+        .tz('America/Los_Angeles')
+        .format("MMM. 'YY");
+
+      const uri = `https://colorstack-family.slack.com/archives/${thread.channelId}/p${thread.id}`;
+
+      return `• <${uri}|*Thread #${i + 1}*> [${date}]`;
+    });
 
   if (!threads.length) {
     // Though we didn't find any relevant threads, this is still a "success".
@@ -211,20 +221,10 @@ export async function answerPublicQuestion({
     return success({});
   }
 
-  const items = threadsResult.data.map((thread, i) => {
-    const date = dayjs(thread.createdAt)
-      .tz('America/Los_Angeles')
-      .format("MMM. 'YY");
-
-    const uri = `https://colorstack-family.slack.com/archives/${thread.channelId}/p${thread.id}`;
-
-    return `• <${uri}|*Thread #${i + 1}*> [${date}]`;
-  });
-
   const message =
     'I found some threads in our workspace that _may_ be relevant to your question! 🧵' +
     '\n\n' +
-    items.join('\n') +
+    threads.join('\n') +
     '\n\n' +
     `_I'm a ColorStack AI assistant! DM me a question <https://colorstack-family.slack.com/app_redirect?app=A04UHP3CKUZ|*here*> and I'll answer it using the full context of our Slack workspace!_`;
 

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import dedent from 'dedent';
 import { type ExpressionBuilder } from 'kysely';
-import { match } from 'ts-pattern';
 
 import { type DB, db } from '@oyster/db';
 


### PR DESCRIPTION
## Description ✏️

This PR:
- Increases the threshold of a match to `>= 0.98`, ensuring that it will only include a match if it is highly confident about it. Naturally, this means that certain responses that may actually be great but are scored lower will be left out. The thought process here is "a correct/excluded answer is better than a wrong/included one".
- Updates the formatting of the reply to use bullet points and removes long message (albeit not _real_ bullet points).
- Fixes an issue that included threads without replies in the reranking.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
