### PR TITLE
feat: support ephemeral slack notifications + better ai replying 🤖

### DIFF
--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -323,6 +323,15 @@ export const NotificationBullJob = z.discriminatedUnion('name', [
     data: EmailTemplate,
   }),
   z.object({
+    name: z.literal('notification.slack.ephemeral.send'),
+    data: z.object({
+      channel: z.string().trim().min(1),
+      text: z.string().trim().min(1),
+      threadId: z.string().trim().min(1).optional(),
+      userId: z.string().trim().min(1),
+    }),
+  }),
+  z.object({
     name: z.literal('notification.slack.send'),
     data: z.discriminatedUnion('workspace', [
       z.object({

--- a/packages/core/src/modules/notification/notification.worker.ts
+++ b/packages/core/src/modules/notification/notification.worker.ts
@@ -2,6 +2,7 @@ import { match } from 'ts-pattern';
 
 import { NotificationBullJob } from '@/infrastructure/bull/bull.types';
 import { registerWorker } from '@/infrastructure/bull/use-cases/register-worker';
+import { sendEphemeralSlackNotification } from '@/modules/notification/use-cases/send-ephemeral-slack-notification';
 import { sendEmail } from './use-cases/send-email';
 import { sendSlackNotification } from './use-cases/send-slack-notification';
 
@@ -12,6 +13,9 @@ export const notificationWorker = registerWorker(
     return match(job)
       .with({ name: 'notification.email.send' }, async ({ data }) => {
         return sendEmail(data);
+      })
+      .with({ name: 'notification.slack.ephemeral.send' }, async ({ data }) => {
+        return sendEphemeralSlackNotification(data);
       })
       .with({ name: 'notification.slack.send' }, async ({ data }) => {
         return sendSlackNotification(data);

--- a/packages/core/src/modules/notification/use-cases/send-ephemeral-slack-notification.ts
+++ b/packages/core/src/modules/notification/use-cases/send-ephemeral-slack-notification.ts
@@ -1,0 +1,29 @@
+import { isFeatureFlagEnabled } from '@/modules/feature-flag/queries/is-feature-flag-enabled';
+import { slack } from '@/modules/slack/instances';
+
+type SendNotificationInput = {
+  channel: string;
+  text: string;
+  threadId?: string;
+  userId: string;
+};
+
+export async function sendEphemeralSlackNotification({
+  channel,
+  text,
+  threadId,
+  userId,
+}: SendNotificationInput) {
+  const enabled = await isFeatureFlagEnabled('send_slack_messages');
+
+  if (!enabled) {
+    return;
+  }
+
+  await slack.chat.postEphemeral({
+    channel,
+    text,
+    thread_ts: threadId,
+    user: userId,
+  });
+}

--- a/packages/core/src/modules/notification/use-cases/send-slack-notification.ts
+++ b/packages/core/src/modules/notification/use-cases/send-slack-notification.ts
@@ -10,6 +10,14 @@ type SendNotificationInput =
       workspace: 'regular';
     }
   | {
+      channel: string;
+      ephemeral: true;
+      message: string;
+      threadId?: string;
+      workspace: 'regular';
+      userId: string;
+    }
+  | {
       channel?: string;
       message: string;
       threadId?: string;
@@ -27,9 +35,18 @@ export async function sendSlackNotification(input: SendNotificationInput) {
 
   const channel = input.channel || ENV.INTERNAL_SLACK_NOTIFICATIONS_CHANNEL_ID;
 
-  await client.chat.postMessage({
-    channel,
-    text: input.message,
-    thread_ts: input.threadId,
-  });
+  if ('ephemeral' in input && input.ephemeral) {
+    await client.chat.postEphemeral({
+      channel,
+      text: input.message,
+      thread_ts: input.threadId,
+      user: input.userId,
+    });
+  } else {
+    await client.chat.postMessage({
+      channel,
+      text: input.message,
+      thread_ts: input.threadId,
+    });
+  }
 }

--- a/packages/core/src/modules/notification/use-cases/send-slack-notification.ts
+++ b/packages/core/src/modules/notification/use-cases/send-slack-notification.ts
@@ -33,18 +33,16 @@ export async function sendSlackNotification(input: SendNotificationInput) {
 
   const client = input.workspace === 'internal' ? internalSlack : slack;
 
-  const channel = input.channel || ENV.INTERNAL_SLACK_NOTIFICATIONS_CHANNEL_ID;
-
   if ('ephemeral' in input && input.ephemeral) {
     await client.chat.postEphemeral({
-      channel,
+      channel: input.channel,
       text: input.message,
       thread_ts: input.threadId,
       user: input.userId,
     });
   } else {
     await client.chat.postMessage({
-      channel,
+      channel: input.channel || ENV.INTERNAL_SLACK_NOTIFICATIONS_CHANNEL_ID,
       text: input.message,
       thread_ts: input.threadId,
     });

--- a/packages/core/src/modules/notification/use-cases/send-slack-notification.ts
+++ b/packages/core/src/modules/notification/use-cases/send-slack-notification.ts
@@ -10,14 +10,6 @@ type SendNotificationInput =
       workspace: 'regular';
     }
   | {
-      channel: string;
-      ephemeral: true;
-      message: string;
-      threadId?: string;
-      workspace: 'regular';
-      userId: string;
-    }
-  | {
       channel?: string;
       message: string;
       threadId?: string;
@@ -33,18 +25,11 @@ export async function sendSlackNotification(input: SendNotificationInput) {
 
   const client = input.workspace === 'internal' ? internalSlack : slack;
 
-  if ('ephemeral' in input && input.ephemeral) {
-    await client.chat.postEphemeral({
-      channel: input.channel,
-      text: input.message,
-      thread_ts: input.threadId,
-      user: input.userId,
-    });
-  } else {
-    await client.chat.postMessage({
-      channel: input.channel || ENV.INTERNAL_SLACK_NOTIFICATIONS_CHANNEL_ID,
-      text: input.message,
-      thread_ts: input.threadId,
-    });
-  }
+  const channel = input.channel || ENV.INTERNAL_SLACK_NOTIFICATIONS_CHANNEL_ID;
+
+  await client.chat.postMessage({
+    channel,
+    text: input.message,
+    thread_ts: input.threadId,
+  });
 }

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -180,12 +180,26 @@ export async function answerPublicQuestion({
   const questionResult = await isQuestion(text);
 
   if (!questionResult.ok) {
+    job('notification.slack.ephemeral.send', {
+      channel: channelId,
+      text: questionResult.error,
+      threadId,
+      userId,
+    });
+
     return questionResult;
   }
 
   const isValidQuestion = questionResult.data;
 
   if (!isValidQuestion) {
+    job('notification.slack.ephemeral.send', {
+      channel: channelId,
+      text: 'I can only respond to questions. Please try again on a different message!',
+      threadId,
+      userId,
+    });
+
     // Though it's not a valid question, this is still a "success" b/c we
     // gracefully/respectfully decided not to answer the question.
     return success({});
@@ -197,6 +211,13 @@ export async function answerPublicQuestion({
   });
 
   if (!threadsResult.ok) {
+    job('notification.slack.ephemeral.send', {
+      channel: channelId,
+      text: threadsResult.error,
+      threadId,
+      userId,
+    });
+
     return threadsResult;
   }
 
@@ -215,9 +236,14 @@ export async function answerPublicQuestion({
     });
 
   if (!threads.length) {
+    job('notification.slack.ephemeral.send', {
+      channel: channelId,
+      text: "I couldn't find any relevant threads in our workspace. Sorry!",
+      threadId,
+      userId,
+    });
+
     // Though we didn't find any relevant threads, this is still a "success".
-    // TODO: Send an ephemeral message to the user to acknowledge that we've
-    // processed their question.
     return success({});
   }
 

--- a/packages/db/src/migrations/20240916211925_slack_message_auto_reply.ts
+++ b/packages/db/src/migrations/20240916211925_slack_message_auto_reply.ts
@@ -1,0 +1,15 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('slack_messages')
+    .addColumn('auto_replied_at', 'timestamptz')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('slack_messages')
+    .dropColumn('auto_replied_at')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR:
- Supports ephemeral Slack notification using the `chat.postEphemeral` method on the Slack API, which requires a user ID since only they'll be able to see the message.
- Adds a corresponding `notification.slack.ephemeral.send` Bull job.
- Updates the auto responses to a public thread with ephemeral messages in the case that an error occurred or there was no relevant threads found.
- Adds a `auto_replied_at` column on the `slack_messages` table so that we can track if/when a message was auto-replied to.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
