### PR TITLE
refactor: use `user_id` from `slack.auth.test` 🔒

### DIFF
--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -396,14 +396,14 @@ export async function answerPublicQuestion({
     return success({});
   }
 
-  const { team_id } = await slack.auth.test();
+  const { team_id, user_id } = await slack.auth.test();
 
   const message =
     'I found some threads in our workspace that _may_ be relevant to your question! 🧵' +
     '\n\n' +
     threads.join('\n') +
     '\n\n' +
-    `_I'm a ColorStack AI assistant! DM me a question <slack://user?team=${team_id}&id=U04TYGYMKQE|*here*> and I'll answer it using the full context of our Slack workspace!_`;
+    `_I'm a ColorStack AI assistant! DM me a question <slack://user?team=${team_id}&id=${user_id}|*here*> and I'll answer it using the full context of our Slack workspace!_`;
 
   job('notification.slack.send', {
     channel: channelId,


### PR DESCRIPTION
## Description ✏️

Small follow-up PR to use `user_id` from Slack API response.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
