### PR TITLE
fix: "division by zero" issue in updating points per day 🏆

### DIFF
--- a/packages/core/src/modules/member/member.worker.ts
+++ b/packages/core/src/modules/member/member.worker.ts
@@ -121,9 +121,12 @@ async function updatePointTotals() {
 
       ({ ref }) => {
         const daysSinceAccepted = sql<number>`
-          extract(
-            day from (
-              current_timestamp - ${ref('acceptedAt')}
+          greatest(
+            1,
+            extract(
+              day from (
+                current_timestamp - ${ref('acceptedAt')}
+              )
             )
           )
         `;


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue with the `updatePointTotals` SQL query where we divide by zero. We now use the `greatest` function in SQL to fallback to 1.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
