### PR TITLE
chore: remove `version` from docker compose 🐋

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -56,3 +56,4 @@
 - Dharld
 - rod608
 - mdg258
+- wflore19

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@
 # development (this is not meant to be used in production), bypassing the need
 # to install and configure these services on our local machines.
 
-version: '3.9'
-
 services:
   postgres:
     container_name: oyster-postgres


### PR DESCRIPTION
## Description ✏️

- Added my name to the `contributors.yml` file
- Removes the 'version' property in the `docker-compose.yml` file. This property is now officially [considered obsolete](https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313).

Currently this warning message appears on `yarn dx:up`
```
\docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
```

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [x] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
