### PR TITLE
fix: order education history by end date first 🔽

### DIFF
--- a/apps/member-profile/app/shared/queries/index.ts
+++ b/apps/member-profile/app/shared/queries/index.ts
@@ -30,6 +30,7 @@ export async function getEducationExperiences(id: string) {
       },
     ])
     .where('studentId', '=', id)
+    .orderBy('endDate', 'desc')
     .orderBy('startDate', 'desc')
     .execute();
 

--- a/packages/core/src/modules/education/use-cases/check-most-recent-education.ts
+++ b/packages/core/src/modules/education/use-cases/check-most-recent-education.ts
@@ -29,8 +29,8 @@ export async function checkMostRecentEducation(studentId: string) {
     ])
     .where('degreeType', '=', DegreeType.BACHELORS)
     .where('studentId', '=', studentId)
-    .orderBy('startDate', 'desc')
     .orderBy('endDate', 'desc')
+    .orderBy('startDate', 'desc')
     .executeTakeFirst();
 
   if (!education) {

--- a/packages/core/src/modules/resume/resume.core.ts
+++ b/packages/core/src/modules/resume/resume.core.ts
@@ -125,8 +125,8 @@ export async function listResumeBooks<
   const resumeBooks = await db
     .selectFrom('resumeBooks')
     .select(select)
-    .orderBy('startDate', 'desc')
     .orderBy('endDate', 'desc')
+    .orderBy('startDate', 'desc')
     .orderBy('createdAt', 'desc')
     .execute();
 


### PR DESCRIPTION
## Description ✏️

This PR fixes a bug in which the education history was sorted by `start_date` then `end_date`, when it should've been the other way around.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
