### PR TITLE
fix: reject applicants who were already accepted in the past ❗️

### DIFF
--- a/packages/core/src/modules/application/application.core.ts
+++ b/packages/core/src/modules/application/application.core.ts
@@ -596,6 +596,16 @@ async function shouldReject(
     return [true, 'email_already_used'];
   }
 
+  const applicationAcceptedWithSameEmail = await db
+    .selectFrom('applications')
+    .where('email', 'ilike', application.email)
+    .where('status', '=', ApplicationStatus.ACCEPTED)
+    .executeTakeFirst();
+
+  if (applicationAcceptedWithSameEmail) {
+    return [true, 'email_already_used'];
+  }
+
   const postmark = getPostmarkInstance();
 
   const bounces = await postmark.getBounces({

--- a/packages/core/src/modules/application/application.core.ts
+++ b/packages/core/src/modules/application/application.core.ts
@@ -599,6 +599,7 @@ async function shouldReject(
   const applicationAcceptedWithSameEmail = await db
     .selectFrom('applications')
     .where('email', 'ilike', application.email)
+    .where('id', '!=', application.id)
     .where('status', '=', ApplicationStatus.ACCEPTED)
     .executeTakeFirst();
 


### PR DESCRIPTION
## Description ✏️

This PR rejects any applications in which the email has been used in a past application that was accepted. This is relevant for when we remove members who try to apply to ColorStack again.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
