### PR TITLE
feat: send email share preference to airtable 💨

### DIFF
--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -20,7 +20,6 @@ import {
   updateAllowEmailShare,
 } from '@oyster/core/member-profile/server';
 import { buildMeta } from '@oyster/core/remix';
-import { db } from '@oyster/db';
 import {
   Button,
   Checkbox,
@@ -87,9 +86,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return json({ errors }, { status: 400 });
   }
 
-  await db.transaction().execute(async (trx) => {
-    await updateAllowEmailShare(trx, user(session), data.allowEmailShare);
-  });
+  await updateAllowEmailShare(user(session), data.allowEmailShare);
 
   toast(session, {
     message: 'Updated!',


### PR DESCRIPTION
## Description ✏️

This PR implements the syncing of the email share preference column from our database to Airtable. This is a request that Johana had so that chapter ambassadors can use accordingly.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
