### PR TITLE
fix: make pinecone api key optional in dev ❗️

### DIFF
--- a/docs/how-to-enable-integrations.md
+++ b/docs/how-to-enable-integrations.md
@@ -10,6 +10,7 @@ We have integrations with the following platforms:
 - Crunchbase (Company Database)
 - Google (Authentication)
 - Mailchimp (Email Marketing)
+- Pinecone (Vector Database)
 - Sentry (Error Monitoring)
 - Slack (Community Home, Authentication)
 - SwagUp (Swag Packs)
@@ -104,6 +105,18 @@ To enable the **Mailchimp** integration:
    MAILCHIMP_API_KEY
    MAILCHIMP_AUDIENCE_ID
    MAILCHIMP_SERVER_PREFIX
+   ```
+
+## Pinecone
+
+To enable the **Pinecone** integration:
+
+1. See
+   [this](https://docs.pinecone.io/guides/get-started/quickstart#2-get-an-api-key)
+   Pinecone documentation to generate an API key.
+2. In `/api/.env`, set the following variables:
+   ```
+   PINECONE_API_KEY
    ```
 
 ## Sentry

--- a/packages/core/src/modules/pinecone.ts
+++ b/packages/core/src/modules/pinecone.ts
@@ -6,9 +6,17 @@ const PINECONE_API_KEY = process.env.PINECONE_API_KEY as string;
 
 // Instances
 
-const pinecone = new Pinecone({
-  apiKey: PINECONE_API_KEY,
-});
+let pinecone: Pinecone;
+
+if (PINECONE_API_KEY) {
+  pinecone = new Pinecone({
+    apiKey: PINECONE_API_KEY,
+  });
+} else {
+  console.warn(
+    'PINECONE_API_KEY is not set. Vector database operations will not be available.'
+  );
+}
 
 // Types/Constants
 


### PR DESCRIPTION
## Description ✏️

Closes #567 
#505 

- Makes Pinecone API configuration optional in local development
- Adds a console warning message

![image](https://github.com/user-attachments/assets/8538fa9e-7ee3-4d6f-aa89-a18a7a2f5c60)

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [x] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
