### PR TITLE
refactor: generalize table sticky column 🔀

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
@@ -216,6 +216,12 @@ function ApplicationsTable() {
         return `${reviewedByFirstName} ${reviewedByLastName}`;
       },
     },
+    {
+      show: () => ['pending', 'rejected'].includes(status),
+      size: '48',
+      sticky: true,
+      render: (application) => <ApplicationDropdown {...application} />,
+    },
   ];
 
   return (
@@ -223,9 +229,6 @@ function ApplicationsTable() {
       columns={columns}
       data={applications}
       emptyMessage="No pending applications left to review."
-      {...(['pending', 'rejected'].includes(status) && {
-        Dropdown: ApplicationDropdown,
-      })}
     />
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.tsx
@@ -431,13 +431,17 @@ function RepeatablesTable() {
       size: '200',
       render: (repeatable) => repeatable.tz,
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (repeatable) => <RepeatableDropdown {...repeatable} />,
+    },
   ];
 
   return (
     <Table
       columns={columns}
       data={repeatables}
-      Dropdown={RepeatableDropdown}
       emptyMessage="No repeatables found."
     />
   );
@@ -588,16 +592,14 @@ function JobsTable() {
       size: '200',
       render: (job) => job.processedAt || '-',
     },
+    {
+      size: '48',
+      render: (job) => <JobDropdown {...job} />,
+      sticky: true,
+    },
   ];
 
-  return (
-    <Table
-      columns={columns}
-      data={jobs}
-      emptyMessage="No jobs found."
-      Dropdown={JobDropdown}
-    />
-  );
+  return <Table columns={columns} data={jobs} emptyMessage="No jobs found." />;
 }
 
 function JobDropdown({ id, status }: JobInView) {

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.tsx
@@ -521,22 +521,7 @@ function JobsTable() {
     {
       displayName: 'ID',
       size: '120',
-      render: (job) => {
-        return (
-          <Link
-            className="link"
-            to={{
-              pathname: generatePath(Route['/bull/:queue/jobs/:id'], {
-                id: job.id,
-                queue,
-              }),
-              search,
-            }}
-          >
-            {job.id}
-          </Link>
-        );
-      },
+      render: (job) => job.id,
     },
     {
       displayName: 'Name',
@@ -599,7 +584,22 @@ function JobsTable() {
     },
   ];
 
-  return <Table columns={columns} data={jobs} emptyMessage="No jobs found." />;
+  return (
+    <Table
+      columns={columns}
+      data={jobs}
+      emptyMessage="No jobs found."
+      rowTo={(job) => {
+        return {
+          pathname: generatePath(Route['/bull/:queue/jobs/:id'], {
+            id: job.id,
+            queue,
+          }),
+          search,
+        };
+      }}
+    />
+  );
 }
 
 function JobDropdown({ id, status }: JobInView) {

--- a/apps/admin-dashboard/app/routes/_dashboard.events.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.tsx
@@ -189,15 +189,15 @@ function EventsTable() {
       render: (event) => `${event.startTime} - ${event.endTime}`,
       size: '200',
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (event) => <EventDropdown {...event} />,
+    },
   ];
 
   return (
-    <Table
-      columns={columns}
-      data={events}
-      emptyMessage="No events found."
-      Dropdown={EventDropdown}
-    />
+    <Table columns={columns} data={events} emptyMessage="No events found." />
   );
 }
 

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
@@ -89,13 +89,17 @@ function FeatureFlagsTable() {
       size: '800',
       render: (flag) => flag.description,
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (flag) => <FeatureFlagsTableDropdown {...flag} />,
+    },
   ];
 
   return (
     <Table
       columns={columns}
       data={flags}
-      Dropdown={FeatureFlagsTableDropdown}
       emptyMessage="No feature flags found."
     />
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.tsx
@@ -116,13 +116,17 @@ function ActivitiesTable() {
       size: '400',
       render: (activity) => activity.description,
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (activity) => <ActivitiesTableDropdown {...activity} />,
+    },
   ];
 
   return (
     <Table
       columns={columns}
       data={activities}
-      Dropdown={ActivitiesTableDropdown}
       emptyMessage="No activities found."
     />
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
@@ -178,13 +178,17 @@ function OnboardingSessionsTable() {
       render: (session) => session.ambassadorName,
       size: '200',
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (session) => <OnboardingSessionsDropdown {...session} />,
+    },
   ];
 
   return (
     <Table
       columns={columns}
       data={sessions}
-      Dropdown={OnboardingSessionsDropdown}
       emptyMessage="No onboarding sessions found."
     />
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.tsx
@@ -164,6 +164,11 @@ function ResumeBooksTable() {
         );
       },
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (resumeBook) => <ResumeBookDropdown {...resumeBook} />,
+    },
   ];
 
   return (
@@ -171,7 +176,6 @@ function ResumeBooksTable() {
       columns={columns}
       data={resumeBooks}
       emptyMessage="No resume books found."
-      Dropdown={ResumeBookDropdown}
     />
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
@@ -201,15 +201,15 @@ function SchoolsTable() {
       },
       size: '120',
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (school) => <SchoolsTableDropdown {...school} />,
+    },
   ];
 
   return (
-    <Table
-      columns={columns}
-      data={schools}
-      Dropdown={SchoolsTableDropdown}
-      emptyMessage="No schools found."
-    />
+    <Table columns={columns} data={schools} emptyMessage="No schools found." />
   );
 }
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.tsx
@@ -225,13 +225,17 @@ function StudentsTable() {
       size: '240',
       render: (student) => student.joinedAt,
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (student) => <StudentDropdown {...student} />,
+    },
   ];
 
   return (
     <Table
       columns={columns}
       data={students}
-      Dropdown={StudentDropdown}
       emptyMessage="No students found."
     />
   );

--- a/apps/admin-dashboard/app/routes/_dashboard.surveys.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.surveys.tsx
@@ -151,15 +151,15 @@ function SurveysTable() {
       render: (survey) => survey.eventName,
       size: '400',
     },
+    {
+      size: '48',
+      sticky: true,
+      render: (survey) => <SurveyDropdown {...survey} />,
+    },
   ];
 
   return (
-    <Table
-      columns={columns}
-      data={surveys}
-      emptyMessage="No surveys found."
-      Dropdown={SurveyDropdown}
-    />
+    <Table columns={columns} data={surveys} emptyMessage="No surveys found." />
   );
 }
 

--- a/packages/core/src/modules/admin/admin.ui.tsx
+++ b/packages/core/src/modules/admin/admin.ui.tsx
@@ -131,21 +131,21 @@ export function AdminTable({ admins }: AdminTableProps) {
         );
       },
     },
-  ];
-
-  return (
-    <Table
-      columns={columns}
-      data={admins}
-      emptyMessage="No admins found."
-      Dropdown={(row) => {
-        if (!row.canRemove) {
+    {
+      size: '48',
+      sticky: true,
+      render: (admin) => {
+        if (!admin.canRemove) {
           return null;
         }
 
-        return <AdminDropdown {...row} />;
-      }}
-    />
+        return <AdminDropdown {...admin} />;
+      },
+    },
+  ];
+
+  return (
+    <Table columns={columns} data={admins} emptyMessage="No admins found." />
   );
 }
 

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -99,12 +99,6 @@ export const Table = ({ columns, data, emptyMessage, rowTo }: TableProps) => {
   );
 };
 
-function getFilteredColumns(columns: TableProps['columns']) {
-  return columns.filter((column) => {
-    return !column.show || !!column.show();
-  });
-}
-
 function TableHead({ columns }: Pick<TableProps, 'columns'>) {
   const headerCellCn = cx(
     'top-0 border-b border-b-gray-200 bg-gray-50 p-2 py-3 text-left'
@@ -241,6 +235,12 @@ function TableBody({
       })}
     </tbody>
   );
+}
+
+function getFilteredColumns(columns: TableProps['columns']) {
+  return columns.filter((column) => {
+    return !column.show || !!column.show();
+  });
 }
 
 // Dropdown


### PR DESCRIPTION
## Description ✏️

Related to #561.

This PR refactors the `Table` component such that:
- There is no longer a `Dropdown` prop.
- Instead, we can just pass this into the `columns` prop, since it's just a column at the end of the day.
- We'll add the `sticky` field which will mimic the same functionality.

This is preparation for showing our opportunities in which you'll be able to bookmark within the row itself.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
