### PR TITLE
feat: make company review notification idempotent 1️⃣

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.$id.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.$id.tsx
@@ -40,6 +40,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     name,
     opts,
     processedOn,
+    returnvalue,
     timestamp,
   } = job.toJSON();
 
@@ -68,6 +69,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       failedReason,
     },
     options: opts,
+    result: returnvalue,
   });
 }
 
@@ -84,7 +86,7 @@ async function getJobFromParams(params: Params<string>) {
 }
 
 export default function JobPage() {
-  const { data, general, options } = useLoaderData<typeof loader>();
+  const { data, general, options, result } = useLoaderData<typeof loader>();
   const { queue } = useParams();
 
   return (
@@ -106,6 +108,11 @@ export default function JobPage() {
       <JobSection>
         <JobSectionTitle>Data</JobSectionTitle>
         <JobSectionData data={data} />
+      </JobSection>
+
+      <JobSection>
+        <JobSectionTitle>Result</JobSectionTitle>
+        <JobSectionData data={result} />
       </JobSection>
 
       <JobSection>

--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -610,7 +610,10 @@ export const StudentBullJob = z.discriminatedUnion('name', [
   }),
   z.object({
     name: z.literal('student.company_review_notifications'),
-    data: z.object({}),
+    data: z.object({
+      after: z.coerce.date().optional(),
+      before: z.coerce.date().optional(),
+    }),
   }),
 ]);
 

--- a/packages/core/src/modules/employment/use-cases/send-company-review-notifications.ts
+++ b/packages/core/src/modules/employment/use-cases/send-company-review-notifications.ts
@@ -68,7 +68,7 @@ export async function sendCompanyReviewNotifications({
     const message = dedent`
       Congratulations on completing your role as *${title}* at *${companyName}*! 🎉
 
-      Your ColorStack peers would love to hear about it -- please take a moment to <${reviewURL}|*share a review*>! 🗣️
+      Please take a moment to <${reviewURL}|*share a review*> -- your ColorStack peers would love to hear about it!
     `;
 
     job('notification.slack.send', {

--- a/packages/core/src/modules/employment/use-cases/send-company-review-notifications.ts
+++ b/packages/core/src/modules/employment/use-cases/send-company-review-notifications.ts
@@ -6,18 +6,31 @@ import { db } from '@oyster/db';
 import { job } from '@/infrastructure/bull/use-cases/job';
 import { ENV } from '@/shared/env';
 
-/**
- * This is a monthly job that runs and finds all students that have had a work
- * experience end in the last month. Then, it has the ColorStack bot send a DM
- * to all these students suggesting that they add a review of their experience.
- */
-export async function sendCompanyReviewNotifications() {
-  const startOfCurrentMonth = dayjs().startOf('month').toDate();
+type SendCompanyReviewNotificationsInput = {
+  after?: Date;
+  before?: Date;
+};
 
-  const startOfPreviousMonth = dayjs()
-    .startOf('month')
-    .subtract(1, 'month')
-    .toDate();
+/**
+ * This job finds all members who've had a work experience that ends after
+ * the `after` date and before the `before` date. It then sends a DM to them
+ * asking them to share a review of their experience.
+ *
+ * By default, `after` is the start of the previous month and `before` is the
+ * start of the current month.
+ *
+ * This job is idempotent. If it's run and a member has already received a
+ * notification for a work experience, they won't be notified about that
+ * experience again.
+ */
+export async function sendCompanyReviewNotifications({
+  after,
+  before,
+}: SendCompanyReviewNotificationsInput) {
+  const startOfCurrentMonth = dayjs().startOf('month');
+
+  after ||= startOfCurrentMonth.subtract(1, 'month').toDate();
+  before ||= startOfCurrentMonth.toDate();
 
   const workExperiences = await db
     .selectFrom('workExperiences')
@@ -36,10 +49,15 @@ export async function sendCompanyReviewNotifications() {
     ])
     .where('companies.name', 'is not', null)
     .where('companyReviews.id', 'is', null)
-    .where('workExperiences.endDate', '>=', startOfPreviousMonth)
-    .where('workExperiences.endDate', '<', startOfCurrentMonth)
+    .where('workExperiences.endDate', '>=', after)
+    .where('workExperiences.endDate', '<', before)
     .where('workExperiences.endDate', 'is not', null)
+    .where('workExperiences.reviewNotificationSentAt', 'is', null)
     .execute();
+
+  if (!workExperiences.length) {
+    return;
+  }
 
   workExperiences.forEach(({ companyName, id, memberSlackId, title }) => {
     const reviewURL = new URL(
@@ -50,7 +68,7 @@ export async function sendCompanyReviewNotifications() {
     const message = dedent`
       Congratulations on completing your role as *${title}* at *${companyName}*! 🎉
 
-      Please take a moment to <${reviewURL}|*share a review*> -- your ColorStack peers would love to hear about it!
+      Your ColorStack peers would love to hear about it -- please take a moment to <${reviewURL}|*share a review*>! 🗣️
     `;
 
     job('notification.slack.send', {
@@ -59,4 +77,18 @@ export async function sendCompanyReviewNotifications() {
       workspace: 'regular',
     });
   });
+
+  await db
+    .updateTable('workExperiences')
+    .set({ reviewNotificationSentAt: new Date() })
+    .where(
+      'id',
+      'in',
+      workExperiences.map(({ id }) => id)
+    )
+    .execute();
+
+  return {
+    notificationsSent: workExperiences.length,
+  };
 }

--- a/packages/core/src/modules/member/member.worker.ts
+++ b/packages/core/src/modules/member/member.worker.ts
@@ -28,7 +28,7 @@ export const memberWorker = registerWorker(
   'student',
   StudentBullJob,
   async (job) => {
-    return match(job)
+    const result = await match(job)
       .with({ name: 'student.activated' }, ({ data }) => {
         return onMemberActivated(data);
       })
@@ -40,6 +40,9 @@ export const memberWorker = registerWorker(
       )
       .with({ name: 'student.birthdate.daily' }, ({ data }) => {
         return sendBirthdayNotification(data);
+      })
+      .with({ name: 'student.company_review_notifications' }, ({ data }) => {
+        return sendCompanyReviewNotifications(data);
       })
       .with({ name: 'student.created' }, ({ data }) => {
         return onMemberCreated(data);
@@ -62,10 +65,9 @@ export const memberWorker = registerWorker(
       .with({ name: 'student.statuses.new' }, ({ data }) => {
         return createNewActiveStatuses(data);
       })
-      .with({ name: 'student.company_review_notifications' }, ({ data: _ }) => {
-        return sendCompanyReviewNotifications();
-      })
       .exhaustive();
+
+    return result;
   }
 );
 

--- a/packages/db/src/migrations/20241029041628_company_review_notification.ts
+++ b/packages/db/src/migrations/20241029041628_company_review_notification.ts
@@ -1,0 +1,15 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('work_experiences')
+    .addColumn('review_notification_sent_at', 'timestamptz')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('work_experiences')
+    .dropColumn('review_notification_sent_at')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

Follow up to #556, which makes the company review notification idempotent by marking each work experience's `reviewNotificationSentAt` column after sending a notification. This ensures we never send duplicates.

This PR also supports a `before`/`after` timestamp for the notification job, which will make it easier for us to backfill notifications for all work experiences that ended this summer, not just this last month.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
