### PR TITLE
feat: implement ai chatbot reaction response 🤖 

### DIFF
--- a/apps/api/src/routers/slack.router.ts
+++ b/apps/api/src/routers/slack.router.ts
@@ -123,7 +123,7 @@ slackEventRouter.post('/slack/events', async (req: RawBodyRequest, res) => {
         return;
       }
 
-      job('slack.reaction.add', {
+      job('slack.reaction.added', {
         channelId: event.item.channel,
         messageId: event.item.ts,
         reaction: event.reaction,

--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -539,6 +539,14 @@ export const SlackBullJob = z.discriminatedUnion('name', [
       channelId: true,
       messageId: true,
       reaction: true,
+    }),
+  }),
+  z.object({
+    name: z.literal('slack.reaction.added'),
+    data: SlackReaction.pick({
+      channelId: true,
+      messageId: true,
+      reaction: true,
       userId: true,
     }),
   }),

--- a/packages/core/src/modules/slack/events/slack-reaction-added.ts
+++ b/packages/core/src/modules/slack/events/slack-reaction-added.ts
@@ -6,8 +6,8 @@ import { ErrorWithContext } from '@/shared/errors';
 import { retryWithBackoff } from '@/shared/utils/core.utils';
 import { getSlackMessage } from '../services/slack-message.service';
 
-export async function addSlackReaction(
-  data: GetBullJobData<'slack.reaction.add'>
+export async function onSlackReactionAdded(
+  data: GetBullJobData<'slack.reaction.added'>
 ) {
   await ensureMessageExists(data);
 
@@ -40,7 +40,9 @@ export async function addSlackReaction(
   }
 }
 
-async function ensureMessageExists(data: GetBullJobData<'slack.reaction.add'>) {
+async function ensureMessageExists(
+  data: GetBullJobData<'slack.reaction.added'>
+) {
   let waiting = false;
 
   await retryWithBackoff(

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -53,8 +53,7 @@ type AnswerChatbotQuestionInput = {
  * Answers the question asked by the user in its channel w/ the ColorStack bot.
  * The uses the underlying `getAnswerFromSlackHistory` function to answer the
  * question, and then sends the answer in the thread where the question was
- * asked. After the answer has been sent, the bot then reactions to the
- * original message with the ColorStack logo.
+ * asked.
  *
  * @param input - The question (ie: `text`) to respond to.
  */
@@ -278,7 +277,8 @@ type AnswerPublicQuestionInput = {
 
 /**
  * Answers a question asked in a public Slack message by linking to relevant
- * threads in our Slack workspace.
+ * threads in our Slack workspace. After the answer has been sent, the bot then
+ * reacts to the original message with the ColorStack logo.
  *
  * @param input - The message (public question) to answer.
  * @returns The result of the answer.

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -19,7 +19,6 @@ import { getPineconeIndex } from '@/modules/pinecone';
 import { slack } from '@/modules/slack/instances';
 import { IS_PRODUCTION } from '@/shared/env';
 import { fail, type Result, success } from '@/shared/utils/core.utils';
-import { addSlackReaction } from '@/modules/slack/use-cases/add-slack-reaction';
 
 // Constants
 

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -143,7 +143,7 @@ export async function answerChatbotQuestion({
   job('slack.reaction.add', {
     channelId: channelId,
     messageId: id,
-    reaction: 'colorstack-logo',
+    reaction: 'colorstack_logo',
     userId: userId,
   });
 

--- a/packages/core/src/modules/slack/slack.ts
+++ b/packages/core/src/modules/slack/slack.ts
@@ -139,14 +139,6 @@ export async function answerChatbotQuestion({
     workspace: 'regular',
   });
 
-  // React to the original message that served as the query
-  job('slack.reaction.add', {
-    channelId: channelId,
-    messageId: id,
-    reaction: 'colorstack_logo',
-    userId: userId,
-  });
-
   // TODO: Delete the loading message after the answer is sent.
 }
 
@@ -423,6 +415,12 @@ export async function answerPublicQuestion({
     message,
     threadId,
     workspace: 'regular',
+  });
+
+  job('slack.reaction.add', {
+    channelId,
+    messageId: threadId,
+    reaction: 'goldicon',
   });
 
   await db.transaction().execute(async (trx) => {

--- a/packages/core/src/modules/slack/slack.worker.ts
+++ b/packages/core/src/modules/slack/slack.worker.ts
@@ -3,6 +3,7 @@ import { match } from 'ts-pattern';
 import { SlackBullJob } from '@/infrastructure/bull/bull.types';
 import { registerWorker } from '@/infrastructure/bull/use-cases/register-worker';
 import { onSlackUserInvited } from '@/modules/slack/events/slack-user-invited';
+import { slack } from '@/modules/slack/instances';
 import {
   answerChatbotQuestion,
   answerPublicQuestion,
@@ -11,9 +12,9 @@ import {
 } from '@/modules/slack/slack';
 import { updateBirthdatesFromSlack } from '@/modules/slack/use-cases/update-birthdates-from-slack';
 import { onSlackProfilePictureChanged } from './events/slack-profile-picture-changed';
+import { onSlackReactionAdded } from './events/slack-reaction-added';
 import { onSlackWorkspaceJoined } from './events/slack-workspace-joined';
 import { addSlackMessage } from './use-cases/add-slack-message';
-import { addSlackReaction } from './use-cases/add-slack-reaction';
 import { archiveSlackChannel } from './use-cases/archive-slack-channel';
 import { changeSlackMessage } from './use-cases/change-slack-message';
 import { createSlackChannel } from './use-cases/create-slack-channel';
@@ -95,7 +96,14 @@ export const slackWorker = registerWorker(
         return result.data;
       })
       .with({ name: 'slack.reaction.add' }, async ({ data }) => {
-        return addSlackReaction(data);
+        return slack.reactions.add({
+          channel: data.channelId,
+          name: data.reaction,
+          timestamp: data.messageId,
+        });
+      })
+      .with({ name: 'slack.reaction.added' }, async ({ data }) => {
+        return onSlackReactionAdded(data);
       })
       .with({ name: 'slack.reaction.remove' }, async ({ data }) => {
         return removeSlackReaction(data);


### PR DESCRIPTION
## Description ✏️
Used `slack.reaction.add` to add a Slack reaction to the original message query that the ColorStack bot responds to once it provides an answer. Also, thanks to my Bloomberg mentor Pallav, was able to get some insight on how it may be possible to delete the loading message the bot sends once it provides an answer. Will include in the comments of this PR.

Closes #538

Describe what this PR does.

- Create a new job to add the ColorStack logo as a reaction to the Slack message the bot is responding to

## Type of Change 🐞

- [X] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [X] I have done a self-review of my code.
- [X] I have manually tested my code (if applicable).
- [X] I have added/updated any relevant documentation (if applicable).
