### PR TITLE
fix: separate wait for network idle in puppeteer ⏰

### DIFF
--- a/packages/core/src/shared/utils/browser.utils.ts
+++ b/packages/core/src/shared/utils/browser.utils.ts
@@ -4,6 +4,10 @@ import puppeteer, { type Browser, type Page } from 'puppeteer-core';
 
 const BROWSER_WS_ENDPOINT = process.env.BROWSER_WS_ENDPOINT as string;
 
+// Constants
+
+const DEFAULT_TIMEOUT = 10_000; // 10s
+
 // Core
 
 /**
@@ -16,7 +20,12 @@ const BROWSER_WS_ENDPOINT = process.env.BROWSER_WS_ENDPOINT as string;
 export async function getPageContent(url: string): Promise<string> {
   return withBrowser(async (_, page) => {
     await page.goto(url, {
-      waitUntil: 'networkidle0',
+      timeout: DEFAULT_TIMEOUT,
+      waitUntil: 'domcontentloaded',
+    });
+
+    await page.waitForNetworkIdle({
+      timeout: DEFAULT_TIMEOUT,
     });
 
     const content = await page.evaluate(() => {


### PR DESCRIPTION
## Description ✏️

This PR fixes an edge case that doesn't properly read some URLs related to opportunities. We separate the waiting of the network being idle.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
