### PR TITLE
fix: add missing `benefits` column in job offers migration ❗️

### DIFF
--- a/packages/db/src/migrations/20241112182800_job_offers.ts
+++ b/packages/db/src/migrations/20241112182800_job_offers.ts
@@ -2,7 +2,7 @@ import { type Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>) {
   // Was never used and is no longer needed.
-  await db.schema.dropTable('job_offers').execute();
+  await db.schema.dropTable('job_offers').ifExists().execute();
 
   await db.schema
     .createTable('internship_job_offers')
@@ -48,6 +48,7 @@ export async function up(db: Kysely<any>) {
     .createTable('full_time_job_offers')
     .addColumn('additional_notes', 'text')
     .addColumn('base_salary', 'integer')
+    .addColumn('benefits', 'text')
     .addColumn('bonus', 'integer')
     .addColumn('company_id', 'text', (column) => {
       return column.references('companies.id');


### PR DESCRIPTION
## Description ✏️

Accidentally removed the `benefits` column from the `full_time_job_offers` table.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
