### PR TITLE
fix: add unique constraint to opportunity's slack message 👖

### DIFF
--- a/packages/db/src/migrations/20241116190627_opportunities_unique.ts
+++ b/packages/db/src/migrations/20241116190627_opportunities_unique.ts
@@ -1,0 +1,18 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('opportunities')
+    .addUniqueConstraint('opportunities_slack_message_key', [
+      'slack_channel_id',
+      'slack_message_id',
+    ])
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('opportunities')
+    .dropConstraint('opportunities_slack_message_key')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue that sometimes duplicates an opportunity from a failed Bull job by adding a unique constraint on `(slack_channel_id, slack_message_id)`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
