### PR TITLE
fix: prevent scroll reset for offer modal ❗️

### DIFF
--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -63,6 +63,7 @@ export const Modal = ({
             'absolute inset-0 cursor-default bg-black',
             'animate-[modal-shader-animation_250ms_forwards]'
           )}
+          preventScrollReset
           to={onCloseTo}
         />
       </div>

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -197,14 +197,14 @@ function TableBody({
                 // As long as the click target is actually the row, then we
                 // want to trigger the row click.
                 if (isInteractiveElement?.tagName === 'TR') {
-                  navigate(rowTo(row));
+                  navigate(rowTo(row), { preventScrollReset: true });
                 }
               },
 
               onKeyDown(e) {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  navigate(rowTo(row));
+                  navigate(rowTo(row), { preventScrollReset: true });
                 }
               },
             })}


### PR DESCRIPTION
## Description ✏️

This PR prevents the page from resetting the scroll position when navigating from a table, and similarly when clicking the overlay of a modal.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
