### PR TITLE
fix: skip offer message when posted by bot ❗️

### DIFF
--- a/apps/api/src/routers/slack.router.ts
+++ b/apps/api/src/routers/slack.router.ts
@@ -108,6 +108,7 @@ slackEventRouter.post('/slack/events', async (req: RawBodyRequest, res) => {
         channelId: event.channel!,
         createdAt: new Date(Number(event.ts) * 1000),
         id: event.ts!,
+        isBot: !!event.app_id || !!event.bot_id,
         text: event.text!,
         threadId:
           event.ts && event.thread_ts && event.ts !== event.thread_ts

--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -477,6 +477,8 @@ export const SlackBullJob = z.discriminatedUnion('name', [
       text: true,
       threadId: true,
       userId: true,
+    }).extend({
+      isBot: z.boolean().optional(),
     }),
   }),
   z.object({

--- a/packages/core/src/modules/slack/use-cases/add-slack-message.ts
+++ b/packages/core/src/modules/slack/use-cases/add-slack-message.ts
@@ -67,7 +67,7 @@ export async function addSlackMessage(
       isFeatureFlagEnabled('compensation'),
     ]);
 
-    if (isAutoReplyChannel) {
+    if (!data.isBot && isAutoReplyChannel) {
       job('slack.question.answer.private', {
         channelId: data.channelId,
         question: data.text as string,
@@ -76,7 +76,7 @@ export async function addSlackMessage(
       });
     }
 
-    if (isCompensationEnabled && isCompensationChannel) {
+    if (!data.isBot && isCompensationEnabled && isCompensationChannel) {
       job('offer.share', {
         slackChannelId: data.channelId,
         slackMessageId: data.id,


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue that is creating a duplicate offer when the bot notification comes in.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
