### PR TITLE
fix: don't send resume review nudge unless file was shared 🗂️

### DIFF
--- a/apps/api/src/routers/slack.router.ts
+++ b/apps/api/src/routers/slack.router.ts
@@ -107,6 +107,7 @@ slackEventRouter.post('/slack/events', async (req: RawBodyRequest, res) => {
       job('slack.message.add', {
         channelId: event.channel!,
         createdAt: new Date(Number(event.ts) * 1000),
+        hasFile: !!event.files && !!event.files.length,
         id: event.ts!,
         isBot: !!event.app_id || !!event.bot_id,
         text: event.text!,

--- a/apps/api/src/routers/slack.types.ts
+++ b/apps/api/src/routers/slack.types.ts
@@ -63,6 +63,7 @@ type SlackMessageSentEvent = {
   app_id?: string;
   bot_id?: string;
   channel: string;
+  files?: unknown[];
   subtype: undefined;
   text: string;
   thread_ts: string | undefined;

--- a/packages/core/src/infrastructure/bull/bull.types.ts
+++ b/packages/core/src/infrastructure/bull/bull.types.ts
@@ -488,6 +488,7 @@ export const SlackBullJob = z.discriminatedUnion('name', [
       threadId: true,
       userId: true,
     }).extend({
+      hasFile: z.boolean().optional(),
       isBot: z.boolean().optional(),
     }),
   }),

--- a/packages/core/src/modules/slack/use-cases/add-slack-message.ts
+++ b/packages/core/src/modules/slack/use-cases/add-slack-message.ts
@@ -94,7 +94,7 @@ export async function addSlackMessage(
       });
     }
 
-    if (isResumeReviewChannel) {
+    if (data.hasFile && isResumeReviewChannel) {
       job('resume_review.check', {
         userId: data.userId,
       });


### PR DESCRIPTION
## Description ✏️

This PR is a follow up to #597 that checks if a file was shared or not. Sometimes members will share a file in the following (or previous) message, they will ask for a review. We don't want to send multiple notifications in that case.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
