### PR TITLE
refactor: rename form components (ie: field, error message) 🔄

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.admins.$id.remove.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.$id.remove.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { getAdmin, removeAdmin } from '@oyster/core/admins';
 import { Button, ErrorMessage, Modal } from '@oyster/ui';
@@ -78,13 +74,13 @@ export default function RemoveAdminPage() {
         This is not an undoable action. Are you sure want to remove this admin?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{actionData?.error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Remove</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.admins.$id.remove.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.$id.remove.tsx
@@ -11,7 +11,7 @@ import {
 } from '@remix-run/react';
 
 import { getAdmin, removeAdmin } from '@oyster/core/admins';
-import { Button, Form, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -79,7 +79,7 @@ export default function RemoveAdminPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{actionData?.error}</Form.ErrorMessage>
+        <ErrorMessage>{actionData?.error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Remove</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
@@ -24,7 +24,7 @@ import {
   type OtherDemographic,
   type Race,
 } from '@oyster/types';
-import { Button, Dropdown, FormField, Select, Text } from '@oyster/ui';
+import { Button, Dropdown, Field, Select, Text } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ENV } from '@/shared/constants.server';
@@ -266,7 +266,7 @@ function RejectDropdown() {
       {open && (
         <Dropdown className="p-2">
           <Form className="form" method="post">
-            <FormField
+            <Field
               description="Select a reason for rejecting this application."
               label="Rejection Reason"
               required
@@ -286,7 +286,7 @@ function RejectDropdown() {
                 </option>
                 <option value={ApplicationRejectionReason.OTHER}>Other</option>
               </Select>
-            </FormField>
+            </Field>
 
             <Button
               color="error"

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
@@ -29,7 +29,7 @@ import {
   type OtherDemographic,
   type Race,
 } from '@oyster/types';
-import { Button, Dropdown, Form, Select, Text } from '@oyster/ui';
+import { Button, Dropdown, FormField, Select, Text } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ENV } from '@/shared/constants.server';
@@ -271,7 +271,7 @@ function RejectDropdown() {
       {open && (
         <Dropdown className="p-2">
           <RemixForm className="form" method="post">
-            <Form.Field
+            <FormField
               description="Select a reason for rejecting this application."
               label="Rejection Reason"
               required
@@ -291,7 +291,7 @@ function RejectDropdown() {
                 </option>
                 <option value={ApplicationRejectionReason.OTHER}>Other</option>
               </Select>
-            </Form.Field>
+            </FormField>
 
             <Button
               color="error"

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id._index.tsx
@@ -4,12 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Link,
-  Form as RemixForm,
-  useLoaderData,
-  useNavigation,
-} from '@remix-run/react';
+import { Form, Link, useLoaderData, useNavigation } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { type PropsWithChildren, useState } from 'react';
 import { ChevronDown, Info } from 'react-feather';
@@ -196,7 +191,7 @@ export default function ApplicationPage() {
         </div>
 
         {application.status === 'pending' && (
-          <RemixForm method="post">
+          <Form method="post">
             <Button.Group>
               <Button
                 color="success"
@@ -210,7 +205,7 @@ export default function ApplicationPage() {
 
               <RejectDropdown />
             </Button.Group>
-          </RemixForm>
+          </Form>
         )}
       </header>
 
@@ -270,7 +265,7 @@ function RejectDropdown() {
 
       {open && (
         <Dropdown className="p-2">
-          <RemixForm className="form" method="post">
+          <Form className="form" method="post">
             <FormField
               description="Select a reason for rejecting this application."
               label="Rejection Reason"
@@ -304,7 +299,7 @@ function RejectDropdown() {
             >
               Reject
             </Button>
-          </RemixForm>
+          </Form>
         </Dropdown>
       )}
     </Dropdown.Container>

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
@@ -11,7 +11,7 @@ import {
 } from '@remix-run/react';
 
 import { acceptApplication, getApplication } from '@oyster/core/applications';
-import { Button, Form, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -80,7 +80,7 @@ export default function AcceptApplicationPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button type="submit">Accept</Button>

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { acceptApplication, getApplication } from '@oyster/core/applications';
 import { Button, ErrorMessage, Modal } from '@oyster/ui';
@@ -79,13 +75,13 @@ export default function AcceptApplicationPage() {
         previously rejected.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button type="submit">Accept</Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
@@ -19,6 +19,7 @@ import { Application } from '@oyster/types';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
@@ -18,7 +18,7 @@ import {
 import { Application } from '@oyster/types';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -136,7 +136,7 @@ function UpdateApplicationEmailForm() {
         <Input id={keys.email} name={keys.email} required />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Update</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
@@ -126,14 +126,14 @@ function UpdateApplicationEmailForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         error={errors.email}
         label="Email"
         labelFor={keys.email}
         required
       >
         <Input id={keys.email} name={keys.email} required />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
@@ -15,7 +15,7 @@ import { Application } from '@oyster/types';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -123,14 +123,9 @@ function UpdateApplicationEmailForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
-        error={errors.email}
-        label="Email"
-        labelFor={keys.email}
-        required
-      >
+      <Field error={errors.email} label="Email" labelFor={keys.email} required>
         <Input id={keys.email} name={keys.email} required />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.email.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import {
@@ -126,7 +122,7 @@ function UpdateApplicationEmailForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         error={errors.email}
         label="Email"
@@ -141,6 +137,6 @@ function UpdateApplicationEmailForm() {
       <Button.Group>
         <Button.Submit>Update</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
@@ -4,9 +4,9 @@ import {
   type SerializeFrom,
 } from '@remix-run/node';
 import {
+  Form,
   Link,
   Outlet,
-  Form as RemixForm,
   useLoaderData,
   useLocation,
   useSubmit,
@@ -94,7 +94,7 @@ function FilterApplicationsForm() {
   const [searchParams] = useSearchParams(ApplicationsSearchParams);
 
   return (
-    <RemixForm
+    <Form
       className="flex w-full items-center"
       method="get"
       onChange={(e) => submit(e.currentTarget)}
@@ -125,7 +125,7 @@ function FilterApplicationsForm() {
           })}
         </Select>
       </div>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -111,23 +111,13 @@ function AddJobForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
-        error={errors.name}
-        label="Name"
-        labelFor={keys.name}
-        required
-      >
+      <FormField error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
-        error={errors.data}
-        label="Data"
-        labelFor={keys.data}
-        required
-      >
+      <FormField error={errors.data} label="Data" labelFor={keys.data} required>
         <Textarea id={keys.data} minRows={4} name={keys.data} required />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -120,7 +120,7 @@ function AddJobForm() {
         <Textarea id={keys.data} minRows={4} name={keys.data} required />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Add</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -4,12 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  generatePath,
-  Form as RemixForm,
-  useActionData,
-  useParams,
-} from '@remix-run/react';
+import { Form, generatePath, useActionData, useParams } from '@remix-run/react';
 import { z } from 'zod';
 
 import {
@@ -111,7 +106,7 @@ function AddJobForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
       </FormField>
@@ -125,6 +120,6 @@ function AddJobForm() {
       <Button.Group>
         <Button.Submit>Add</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.jobs.add.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -107,13 +107,13 @@ function AddJobForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField error={errors.name} label="Name" labelFor={keys.name} required>
+      <Field error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
-      </FormField>
+      </Field>
 
-      <FormField error={errors.data} label="Data" labelFor={keys.data} required>
+      <Field error={errors.data} label="Data" labelFor={keys.data} required>
         <Textarea id={keys.data} minRows={4} name={keys.data} required />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -97,11 +97,11 @@ function AddRepeatableForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField error={errors.name} label="Name" labelFor={keys.name} required>
+      <Field error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description="Please format the job to be in the PT timezone."
         error={errors.pattern}
         label="Pattern (CRON)"
@@ -109,7 +109,7 @@ function AddRepeatableForm() {
         required
       >
         <Input id={keys.pattern} name={keys.pattern} required />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -4,12 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  generatePath,
-  Form as RemixForm,
-  useActionData,
-  useParams,
-} from '@remix-run/react';
+import { Form, generatePath, useActionData, useParams } from '@remix-run/react';
 import { z } from 'zod';
 
 import {
@@ -101,7 +96,7 @@ function AddRepeatableForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
       </FormField>
@@ -121,6 +116,6 @@ function AddRepeatableForm() {
       <Button.Group>
         <Button.Submit>Add</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -116,7 +116,7 @@ function AddRepeatableForm() {
         <Input id={keys.pattern} name={keys.pattern} required />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Add</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.repeatables.add.tsx
@@ -101,16 +101,11 @@ function AddRepeatableForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
-        error={errors.name}
-        label="Name"
-        labelFor={keys.name}
-        required
-      >
+      <FormField error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description="Please format the job to be in the PT timezone."
         error={errors.pattern}
         label="Pattern (CRON)"
@@ -118,7 +113,7 @@ function AddRepeatableForm() {
         required
       >
         <Input id={keys.pattern} name={keys.pattern} required />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.bull.$queue.tsx
@@ -6,9 +6,9 @@ import {
   type SerializeFrom,
 } from '@remix-run/node';
 import {
+  Form,
   Link,
   Outlet,
-  Form as RemixForm,
   useLoaderData,
   useLocation,
   useNavigate,
@@ -373,7 +373,7 @@ function QueueDropdown() {
               </Link>
             </Dropdown.Item>
             <Dropdown.Item>
-              <RemixForm method="post">
+              <Form method="post">
                 <button
                   name="action"
                   type="submit"
@@ -381,10 +381,10 @@ function QueueDropdown() {
                 >
                   <RefreshCw /> Clean Queue
                 </button>
-              </RemixForm>
+              </Form>
             </Dropdown.Item>
             <Dropdown.Item>
-              <RemixForm method="post">
+              <Form method="post">
                 <button
                   name="action"
                   type="submit"
@@ -392,7 +392,7 @@ function QueueDropdown() {
                 >
                   <Trash2 /> Obliterate Queue
                 </button>
-              </RemixForm>
+              </Form>
             </Dropdown.Item>
           </Dropdown.List>
         </Dropdown>
@@ -464,7 +464,7 @@ function RepeatableDropdown({ id }: RepeatableInView) {
         <Table.Dropdown>
           <Dropdown.List>
             <Dropdown.Item>
-              <RemixForm method="post">
+              <Form method="post">
                 <button
                   name="action"
                   type="submit"
@@ -474,7 +474,7 @@ function RepeatableDropdown({ id }: RepeatableInView) {
                 </button>
 
                 <input type="hidden" name="key" value={id} />
-              </RemixForm>
+              </Form>
             </Dropdown.Item>
           </Dropdown.List>
         </Table.Dropdown>
@@ -620,7 +620,7 @@ function JobDropdown({ id, status }: JobInView) {
           <Dropdown.List>
             {status === 'failed' && (
               <Dropdown.Item>
-                <RemixForm method="post">
+                <Form method="post">
                   <button
                     name="action"
                     type="submit"
@@ -630,12 +630,12 @@ function JobDropdown({ id, status }: JobInView) {
                   </button>
 
                   <input type="hidden" name="id" value={id} />
-                </RemixForm>
+                </Form>
               </Dropdown.Item>
             )}
 
             <Dropdown.Item>
-              <RemixForm method="post">
+              <Form method="post">
                 <button
                   name="action"
                   type="submit"
@@ -645,12 +645,12 @@ function JobDropdown({ id, status }: JobInView) {
                 </button>
 
                 <input type="hidden" name="id" value={id} />
-              </RemixForm>
+              </Form>
             </Dropdown.Item>
 
             {(status === 'delayed' || status === 'waiting') && (
               <Dropdown.Item>
-                <RemixForm method="post">
+                <Form method="post">
                   <button
                     name="action"
                     type="submit"
@@ -660,12 +660,12 @@ function JobDropdown({ id, status }: JobInView) {
                   </button>
 
                   <input type="hidden" name="id" value={id} />
-                </RemixForm>
+                </Form>
               </Dropdown.Item>
             )}
 
             <Dropdown.Item>
-              <RemixForm method="post">
+              <Form method="post">
                 <button
                   name="action"
                   type="submit"
@@ -675,7 +675,7 @@ function JobDropdown({ id, status }: JobInView) {
                 </button>
 
                 <input type="hidden" name="id" value={id} />
-              </RemixForm>
+              </Form>
             </Dropdown.Item>
           </Dropdown.List>
         </Table.Dropdown>

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
@@ -14,7 +14,7 @@ import { AddEventRecordingLinkInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -91,7 +91,7 @@ function AddEventRecordingForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
+      <Field
         description="Please add the full URL of the event recording."
         error={errors.recordingLink}
         label="Recording Link"
@@ -105,7 +105,7 @@ function AddEventRecordingForm() {
           placeholder="https://www.youtube.com/watch?v=..."
           required
         />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
@@ -18,6 +18,7 @@ import { AddEventRecordingLinkInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import {
   addEventRecordingLink,
@@ -94,7 +90,7 @@ function AddEventRecordingForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         description="Please add the full URL of the event recording."
         error={errors.recordingLink}
@@ -116,6 +112,6 @@ function AddEventRecordingForm() {
       <Button.Group>
         <Button type="submit">Add</Button>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
@@ -94,7 +94,7 @@ function AddEventRecordingForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         description="Please add the full URL of the event recording."
         error={errors.recordingLink}
         label="Recording Link"
@@ -108,7 +108,7 @@ function AddEventRecordingForm() {
           placeholder="https://www.youtube.com/watch?v=..."
           required
         />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.add-recording.tsx
@@ -17,7 +17,7 @@ import {
 import { AddEventRecordingLinkInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -111,7 +111,7 @@ function AddEventRecordingForm() {
         />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button type="submit">Add</Button>

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.delete.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.delete.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { getEvent } from '@oyster/core/admin-dashboard/server';
 import { deleteEvent } from '@oyster/core/events';
@@ -68,13 +64,13 @@ export default function DeleteEventModal() {
         action cannot be undone.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.delete.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.delete.tsx
@@ -12,7 +12,7 @@ import {
 
 import { getEvent } from '@oyster/core/admin-dashboard/server';
 import { deleteEvent } from '@oyster/core/events';
-import { Button, Form, getErrors, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -69,7 +69,7 @@ export default function DeleteEventModal() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -22,6 +22,7 @@ import {
   Button,
   FileUploader,
   Form,
+  FormField,
   getErrors,
   Modal,
   validateForm,

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -187,14 +187,14 @@ function ImportEventAttendeesForm() {
 
   return (
     <RemixForm className="form" method="post" encType="multipart/form-data">
-      <Form.Field error={errors.file} labelFor={keys.file} required>
+      <FormField error={errors.file} labelFor={keys.file} required>
         <FileUploader
           accept={['text/csv']}
           id={keys.file}
           name={keys.file}
           required
         />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -8,11 +8,7 @@ import {
   unstable_parseMultipartFormData as parseMultipartFormData,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { getEvent, job, parseCsv } from '@oyster/core/admin-dashboard/server';
@@ -187,7 +183,7 @@ function ImportEventAttendeesForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post" encType="multipart/form-data">
+    <Form className="form" method="post" encType="multipart/form-data">
       <FormField error={errors.file} labelFor={keys.file} required>
         <FileUploader
           accept={['text/csv']}
@@ -202,6 +198,6 @@ function ImportEventAttendeesForm() {
       <Button.Group>
         <Button.Submit>Import</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -17,8 +17,8 @@ import { Email, EventAttendee } from '@oyster/types';
 import {
   Button,
   ErrorMessage,
+  Field,
   FileUploader,
-  FormField,
   getErrors,
   Modal,
   validateForm,
@@ -184,14 +184,14 @@ function ImportEventAttendeesForm() {
 
   return (
     <Form className="form" method="post" encType="multipart/form-data">
-      <FormField error={errors.file} labelFor={keys.file} required>
+      <Field error={errors.file} labelFor={keys.file} required>
         <FileUploader
           accept={['text/csv']}
           id={keys.file}
           name={keys.file}
           required
         />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.$id.import.tsx
@@ -20,8 +20,8 @@ import { db } from '@oyster/db';
 import { Email, EventAttendee } from '@oyster/types';
 import {
   Button,
+  ErrorMessage,
   FileUploader,
-  Form,
   FormField,
   getErrors,
   Modal,
@@ -197,7 +197,7 @@ function ImportEventAttendeesForm() {
         />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Import</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   DatePicker,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -13,7 +13,7 @@ import {
   Button,
   DatePicker,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -110,11 +110,11 @@ function CreateEventForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField error={errors.name} label="Name" labelFor={keys.name} required>
+      <Field error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
-      </FormField>
+      </Field>
 
-      <FormField error={errors.type} label="Type" labelFor={keys.type} required>
+      <Field error={errors.type} label="Type" labelFor={keys.type} required>
         <Select id={keys.type} name={keys.type} required>
           {EVENT_TYPES.map((type) => {
             return (
@@ -124,17 +124,17 @@ function CreateEventForm() {
             );
           })}
         </Select>
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.description}
         label="Description"
         labelFor={keys.description}
       >
         <Textarea id={keys.description} minRows={2} name={keys.description} />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.startTime}
         label="Start Date/Time"
         labelFor={keys.startTime}
@@ -146,9 +146,9 @@ function CreateEventForm() {
           type="datetime-local"
           required
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.endTime}
         label="End Date/Time"
         labelFor={keys.endTime}
@@ -160,7 +160,7 @@ function CreateEventForm() {
           type="datetime-local"
           required
         />
-      </FormField>
+      </Field>
 
       <input
         name={keys.timezone}

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { createEvent } from '@oyster/core/admin-dashboard/server';
@@ -109,7 +109,7 @@ function CreateEventForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
       </FormField>
@@ -173,6 +173,6 @@ function CreateEventForm() {
       <Button.Group>
         <Button.Submit>Create</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -12,7 +12,7 @@ import { Event, EventType } from '@oyster/types';
 import {
   Button,
   DatePicker,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -168,7 +168,7 @@ function CreateEventForm() {
         value={new window.Intl.DateTimeFormat().resolvedOptions().timeZone}
       />
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Create</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.create.tsx
@@ -109,21 +109,11 @@ function CreateEventForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
-        error={errors.name}
-        label="Name"
-        labelFor={keys.name}
-        required
-      >
+      <FormField error={errors.name} label="Name" labelFor={keys.name} required>
         <Input id={keys.name} name={keys.name} required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
-        error={errors.type}
-        label="Type"
-        labelFor={keys.type}
-        required
-      >
+      <FormField error={errors.type} label="Type" labelFor={keys.type} required>
         <Select id={keys.type} name={keys.type} required>
           {EVENT_TYPES.map((type) => {
             return (
@@ -133,17 +123,17 @@ function CreateEventForm() {
             );
           })}
         </Select>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.description}
         label="Description"
         labelFor={keys.description}
       >
         <Textarea id={keys.description} minRows={2} name={keys.description} />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.startTime}
         label="Start Date/Time"
         labelFor={keys.startTime}
@@ -155,9 +145,9 @@ function CreateEventForm() {
           type="datetime-local"
           required
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.endTime}
         label="End Date/Time"
         labelFor={keys.endTime}
@@ -169,7 +159,7 @@ function CreateEventForm() {
           type="datetime-local"
           required
         />
-      </Form.Field>
+      </FormField>
 
       <input
         name={keys.timezone}

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -11,7 +11,7 @@ import { job } from '@oyster/core/admin-dashboard/server';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -85,7 +85,7 @@ function SyncAirmeetEventForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
+      <Field
         description="You can find the ID from the Airmeet event URL."
         error={errors.eventId}
         label="Airmeet ID"
@@ -93,7 +93,7 @@ function SyncAirmeetEventForm() {
         required
       >
         <Input id={keys.eventId} name={keys.eventId} required />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { job } from '@oyster/core/admin-dashboard/server';
@@ -84,7 +84,7 @@ function SyncAirmeetEventForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         description="You can find the ID from the Airmeet event URL."
         error={errors.eventId}
@@ -100,6 +100,6 @@ function SyncAirmeetEventForm() {
       <Button.Group>
         <Button.Submit>Sync</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -11,6 +11,7 @@ import { job } from '@oyster/core/admin-dashboard/server';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -84,7 +84,7 @@ function SyncAirmeetEventForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         description="You can find the ID from the Airmeet event URL."
         error={errors.eventId}
         label="Airmeet ID"
@@ -92,7 +92,7 @@ function SyncAirmeetEventForm() {
         required
       >
         <Input id={keys.eventId} name={keys.eventId} required />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.sync-airmeet-event.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { job } from '@oyster/core/admin-dashboard/server';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -95,7 +95,7 @@ function SyncAirmeetEventForm() {
         <Input id={keys.eventId} name={keys.eventId} required />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Sync</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.delete.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.delete.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useLoaderData } from '@remix-run/react';
+import { Form, useLoaderData } from '@remix-run/react';
 
 import {
   deleteFeatureFlag,
@@ -71,11 +71,11 @@ export default function DeleteFeatureFlagModal() {
         undone.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -15,7 +15,7 @@ import {
   Button,
   Checkbox,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -94,7 +94,7 @@ export default function EditFeatureFlagModal() {
       </Modal.Header>
 
       <Form className="form" method="post">
-        <FormField
+        <Field
           description="This is the name that will be displayed in the UI."
           error={errors.displayName}
           label="Display Name"
@@ -107,9 +107,9 @@ export default function EditFeatureFlagModal() {
             name={keys.displayName}
             required
           />
-        </FormField>
+        </Field>
 
-        <FormField
+        <Field
           description="An optional, but recommended, description of what the flag is for."
           error={errors.description}
           label="Description"
@@ -121,7 +121,7 @@ export default function EditFeatureFlagModal() {
             minRows={2}
             name={keys.description}
           />
-        </FormField>
+        </Field>
 
         <Checkbox
           color="lime-100"

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -97,7 +97,7 @@ export default function EditFeatureFlagModal() {
       </Modal.Header>
 
       <RemixForm className="form" method="post">
-        <Form.Field
+        <FormField
           description="This is the name that will be displayed in the UI."
           error={errors.displayName}
           label="Display Name"
@@ -110,9 +110,9 @@ export default function EditFeatureFlagModal() {
             name={keys.displayName}
             required
           />
-        </Form.Field>
+        </FormField>
 
-        <Form.Field
+        <FormField
           description="An optional, but recommended, description of what the flag is for."
           error={errors.description}
           label="Description"
@@ -124,7 +124,7 @@ export default function EditFeatureFlagModal() {
             minRows={2}
             name={keys.description}
           />
-        </Form.Field>
+        </FormField>
 
         <Checkbox
           color="lime-100"

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -18,7 +18,7 @@ import { EditFeatureFlagInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
   Checkbox,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -136,7 +136,7 @@ export default function EditFeatureFlagModal() {
           value="1"
         />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Edit</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import {
   editFeatureFlag,
@@ -97,7 +93,7 @@ export default function EditFeatureFlagModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <FormField
           description="This is the name that will be displayed in the UI."
           error={errors.displayName}
@@ -141,7 +137,7 @@ export default function EditFeatureFlagModal() {
         <Button.Group>
           <Button.Submit>Edit</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.$id.edit.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   Checkbox,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 
 import { createFeatureFlag } from '@oyster/core/admin-dashboard/server';
 import { CreateFeatureFlagInput } from '@oyster/core/admin-dashboard/ui';
@@ -79,7 +79,7 @@ export default function CreateFeatureFlagModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <FormField
           description="This should be snake case (ie: all_lower_with_underscores)."
           error={errors.name}
@@ -123,7 +123,7 @@ export default function CreateFeatureFlagModal() {
         <Button.Group>
           <Button.Submit>Create</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -11,7 +11,7 @@ import { CreateFeatureFlagInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
   Checkbox,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -118,7 +118,7 @@ export default function CreateFeatureFlagModal() {
           value="1"
         />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Create</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Checkbox,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   Checkbox,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -80,7 +80,7 @@ export default function CreateFeatureFlagModal() {
       </Modal.Header>
 
       <Form className="form" method="post">
-        <FormField
+        <Field
           description="This should be snake case (ie: all_lower_with_underscores)."
           error={errors.name}
           label="Name"
@@ -88,9 +88,9 @@ export default function CreateFeatureFlagModal() {
           required
         >
           <Input autoFocus id={keys.name} name={keys.name} required />
-        </FormField>
+        </Field>
 
-        <FormField
+        <Field
           description="This is the name that will be displayed in the UI."
           error={errors.displayName}
           label="Display Name"
@@ -98,16 +98,16 @@ export default function CreateFeatureFlagModal() {
           required
         >
           <Input id={keys.displayName} name={keys.displayName} required />
-        </FormField>
+        </Field>
 
-        <FormField
+        <Field
           description="An optional, but recommended, description of what the flag is for."
           error={errors.description}
           label="Description"
           labelFor={keys.description}
         >
           <Textarea id={keys.description} minRows={2} name={keys.description} />
-        </FormField>
+        </Field>
 
         <Checkbox
           color="lime-100"

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.create.tsx
@@ -79,7 +79,7 @@ export default function CreateFeatureFlagModal() {
       </Modal.Header>
 
       <RemixForm className="form" method="post">
-        <Form.Field
+        <FormField
           description="This should be snake case (ie: all_lower_with_underscores)."
           error={errors.name}
           label="Name"
@@ -87,9 +87,9 @@ export default function CreateFeatureFlagModal() {
           required
         >
           <Input autoFocus id={keys.name} name={keys.name} required />
-        </Form.Field>
+        </FormField>
 
-        <Form.Field
+        <FormField
           description="This is the name that will be displayed in the UI."
           error={errors.displayName}
           label="Display Name"
@@ -97,16 +97,16 @@ export default function CreateFeatureFlagModal() {
           required
         >
           <Input id={keys.displayName} name={keys.displayName} required />
-        </Form.Field>
+        </FormField>
 
-        <Form.Field
+        <FormField
           description="An optional, but recommended, description of what the flag is for."
           error={errors.description}
           label="Description"
           labelFor={keys.description}
         >
           <Textarea id={keys.description} minRows={2} name={keys.description} />
-        </Form.Field>
+        </FormField>
 
         <Checkbox
           color="lime-100"

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
@@ -12,7 +12,7 @@ import {
 } from '@remix-run/react';
 
 import { archiveActivity } from '@oyster/core/gamification';
-import { Button, Form, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -71,7 +71,7 @@ export default function ArchiveActivityPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
           <Button.Submit color="error" variant="secondary">

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.$id.archive.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useNavigate,
   useNavigation,
@@ -70,7 +70,7 @@ export default function ArchiveActivityPage() {
         for completing it.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
@@ -87,7 +87,7 @@ export default function ArchiveActivityPage() {
             Back
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -11,7 +11,7 @@ import { AddIcebreakerPromptInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -76,14 +76,9 @@ function AddIcebreakerPromptForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
-        error={errors.text}
-        label="Prompt"
-        labelFor={keys.text}
-        required
-      >
+      <Field error={errors.text} label="Prompt" labelFor={keys.text} required>
         <Input id={keys.text} name={keys.text} required />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 
 import { addIcebreakerPrompt } from '@oyster/core/admin-dashboard/server';
 import { AddIcebreakerPromptInput } from '@oyster/core/admin-dashboard/ui';
@@ -75,7 +75,7 @@ function AddIcebreakerPromptForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         error={errors.text}
         label="Prompt"
@@ -90,6 +90,6 @@ function AddIcebreakerPromptForm() {
       <Button.Group>
         <Button.Submit>Add</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -11,6 +11,7 @@ import { AddIcebreakerPromptInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -75,14 +75,14 @@ function AddIcebreakerPromptForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         error={errors.text}
         label="Prompt"
         labelFor={keys.text}
         required
       >
         <Input id={keys.text} name={keys.text} required />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.icebreakers.add.tsx
@@ -10,7 +10,7 @@ import { addIcebreakerPrompt } from '@oyster/core/admin-dashboard/server';
 import { AddIcebreakerPromptInput } from '@oyster/core/admin-dashboard/ui';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -85,7 +85,7 @@ function AddIcebreakerPromptForm() {
         <Input id={keys.text} name={keys.text} required />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Add</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { addOnboardingSessionAttendees } from '@oyster/core/admin-dashboard/server';
@@ -93,7 +93,7 @@ export default function AddOnboardingSessionAttendeesPage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <OnboardingSessionAttendeesField
           error={errors.attendees}
           name={keys.attendees}
@@ -104,7 +104,7 @@ export default function AddOnboardingSessionAttendeesPage() {
         <Button.Group>
           <Button.Submit>Upload</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.$id.add-attendees.tsx
@@ -9,7 +9,13 @@ import { z } from 'zod';
 
 import { addOnboardingSessionAttendees } from '@oyster/core/admin-dashboard/server';
 import { db } from '@oyster/db';
-import { Button, Form, getErrors, Modal, validateForm } from '@oyster/ui';
+import {
+  Button,
+  ErrorMessage,
+  getErrors,
+  Modal,
+  validateForm,
+} from '@oyster/ui';
 
 import { OnboardingSessionAttendeesField } from '@/shared/components/onboarding-session-form';
 import { Route } from '@/shared/constants';
@@ -93,7 +99,7 @@ export default function AddOnboardingSessionAttendeesPage() {
           name={keys.attendees}
         />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Upload</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { uploadOnboardingSession } from '@oyster/core/admin-dashboard/server';
@@ -99,7 +99,7 @@ export default function UploadOnboardingSessionPage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <OnboardingSessionForm.DateField error={errors.date} name={keys.date} />
         <OnboardingSessionAttendeesField
           error={errors.attendees}
@@ -111,7 +111,7 @@ export default function UploadOnboardingSessionPage() {
         <Button.Group>
           <Button.Submit>Upload</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.upload.tsx
@@ -9,7 +9,13 @@ import { z } from 'zod';
 
 import { uploadOnboardingSession } from '@oyster/core/admin-dashboard/server';
 import { OnboardingSession } from '@oyster/core/admin-dashboard/ui';
-import { Button, Form, getErrors, Modal, validateForm } from '@oyster/ui';
+import {
+  Button,
+  ErrorMessage,
+  getErrors,
+  Modal,
+  validateForm,
+} from '@oyster/ui';
 
 import {
   OnboardingSessionAttendeesField,
@@ -100,7 +106,7 @@ export default function UploadOnboardingSessionPage() {
           name={keys.attendees}
         />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Upload</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.$id.edit.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import dayjs from 'dayjs';
 
 import { getResumeBook, updateResumeBook } from '@oyster/core/resume-books';
@@ -99,7 +95,7 @@ export default function EditResumeBookModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ResumeBookNameField defaultValue={name} error={errors.name} />
         <ResumeBookStartDateField
           defaultValue={startDate}
@@ -110,7 +106,7 @@ export default function EditResumeBookModal() {
         <Button.Group>
           <Button.Submit>Edit</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData, useFetcher } from '@remix-run/react';
+import { Form, useActionData, useFetcher } from '@remix-run/react';
 import { useEffect } from 'react';
 
 import { createResumeBook } from '@oyster/core/resume-books';
@@ -87,7 +87,7 @@ export default function CreateResumeBookModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ResumeBookNameField error={errors.name} />
         <ResumeBookStartDateField error={errors.startDate} />
         <ResumeBookEndDateField error={errors.endDate} />
@@ -96,7 +96,7 @@ export default function CreateResumeBookModal() {
         <Button.Group>
           <Button.Submit>Create</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
@@ -18,7 +18,7 @@ import {
 import {
   Button,
   ComboboxPopover,
-  Form,
+  FormField,
   getErrors,
   Modal,
   MultiCombobox,

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
@@ -112,7 +112,7 @@ function SponsorsField() {
   const companies = fetcher.data?.companies || [];
 
   return (
-    <Form.Field
+    <FormField
       description="Please choose all of the companies that are sponsoring this resume book."
       error={errors.sponsors}
       label="Sponsors"
@@ -152,6 +152,6 @@ function SponsorsField() {
           </ul>
         </ComboboxPopover>
       </MultiCombobox>
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.create.tsx
@@ -18,7 +18,7 @@ import {
 import {
   Button,
   ComboboxPopover,
-  FormField,
+  Field,
   getErrors,
   Modal,
   MultiCombobox,
@@ -112,7 +112,7 @@ function SponsorsField() {
   const companies = fetcher.data?.companies || [];
 
   return (
-    <FormField
+    <Field
       description="Please choose all of the companies that are sponsoring this resume book."
       error={errors.sponsors}
       label="Sponsors"
@@ -152,6 +152,6 @@ function SponsorsField() {
           </ul>
         </ComboboxPopover>
       </MultiCombobox>
-    </FormField>
+    </Field>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.$id.edit.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { getSchool, updateSchool } from '@oyster/core/education';
 import { UpdateSchoolInput } from '@oyster/core/education/types';
@@ -93,7 +89,7 @@ export default function EditSchoolModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <SchoolNameField defaultValue={school.name} error={errors.name} />
         <SchoolTagsField defaultValue={school.tags?.[0]} error={errors.tags} />
         <SchoolCityField
@@ -112,7 +108,7 @@ export default function EditSchoolModal() {
         <Button.Group>
           <Button.Submit>Edit</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 
 import { createSchool } from '@oyster/core/education';
 import { CreateSchoolInput } from '@oyster/core/education/types';
@@ -66,7 +66,7 @@ export default function CreateSchoolPage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <SchoolNameField error={errors.name} />
         <SchoolCityField error={errors.addressCity} />
         <SchoolStateField error={errors.addressState} />
@@ -75,7 +75,7 @@ export default function CreateSchoolPage() {
         <Button.Group>
           <Button.Submit>Create</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.activate.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.activate.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useNavigate,
@@ -90,7 +90,7 @@ export default function ActivateStudentPage() {
         merch store.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
@@ -100,7 +100,7 @@ export default function ActivateStudentPage() {
             Back
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.activate.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.activate.tsx
@@ -13,7 +13,7 @@ import {
 
 import { activateMember } from '@oyster/core/admin-dashboard/server';
 import { db } from '@oyster/db';
-import { Button, Form, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -91,7 +91,7 @@ export default function ActivateStudentPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
           <Button type="submit">Activate</Button>

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { updateMemberEmail } from '@oyster/core/admin-dashboard/server';
@@ -119,7 +115,7 @@ function UpdateStudentEmailForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         error={errors.email}
         label="Email"
@@ -134,6 +130,6 @@ function UpdateStudentEmailForm() {
       <Button.Group>
         <Button.Submit>Update</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -16,7 +16,7 @@ import { db } from '@oyster/db';
 import { Student } from '@oyster/types';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -129,7 +129,7 @@ function UpdateStudentEmailForm() {
         <Input id={keys.email} name={keys.email} required />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Update</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -17,6 +17,7 @@ import { Student } from '@oyster/types';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -13,7 +13,7 @@ import { Student } from '@oyster/types';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -116,14 +116,9 @@ function UpdateStudentEmailForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
-        error={errors.email}
-        label="Email"
-        labelFor={keys.email}
-        required
-      >
+      <Field error={errors.email} label="Email" labelFor={keys.email} required>
         <Input id={keys.email} name={keys.email} required />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.email.tsx
@@ -119,14 +119,14 @@ function UpdateStudentEmailForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         error={errors.email}
         label="Email"
         labelFor={keys.email}
         required
       >
         <Input id={keys.email} name={keys.email} required />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { createGoodyOrder } from '@oyster/core/goody';
@@ -106,7 +106,7 @@ export default function SendGiftModal() {
         This will send a DoorDash gift card to this member.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <FormField
           description="Add a message to the gift so the member knows why they are receiving this."
           label="Message"
@@ -127,7 +127,7 @@ export default function SendGiftModal() {
         <Button.Group>
           <Button.Submit>Send</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
@@ -9,7 +9,14 @@ import { z } from 'zod';
 
 import { createGoodyOrder } from '@oyster/core/goody';
 import { db } from '@oyster/db';
-import { Button, Form, Modal, Textarea, validateForm } from '@oyster/ui';
+import {
+  Button,
+  Form,
+  FormField,
+  Modal,
+  Textarea,
+  validateForm,
+} from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
@@ -11,7 +11,7 @@ import { createGoodyOrder } from '@oyster/core/goody';
 import { db } from '@oyster/db';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   Modal,
   Textarea,
@@ -122,7 +122,7 @@ export default function SendGiftModal() {
           />
         </FormField>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Send</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
@@ -100,7 +100,7 @@ export default function SendGiftModal() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.Field
+        <FormField
           description="Add a message to the gift so the member knows why they are receiving this."
           label="Message"
           labelFor="message"
@@ -113,7 +113,7 @@ export default function SendGiftModal() {
             placeholder="Congratulations..."
             required
           />
-        </Form.Field>
+        </FormField>
 
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.gift.tsx
@@ -12,7 +12,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   Modal,
   Textarea,
   validateForm,
@@ -107,7 +107,7 @@ export default function SendGiftModal() {
       </Modal.Description>
 
       <Form className="form" method="post">
-        <FormField
+        <Field
           description="Add a message to the gift so the member knows why they are receiving this."
           label="Message"
           labelFor="message"
@@ -120,7 +120,7 @@ export default function SendGiftModal() {
             placeholder="Congratulations..."
             required
           />
-        </FormField>
+        </Field>
 
         <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -15,7 +15,7 @@ import { GrantPointsInput } from '@oyster/core/gamification/types';
 import { db } from '@oyster/db';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -132,7 +132,7 @@ function GrantPointsForm() {
         />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Grant</Button.Submit>

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -102,7 +102,7 @@ function GrantPointsForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         error={errors.points}
         label="Points"
         labelFor={keys.points}
@@ -115,9 +115,9 @@ function GrantPointsForm() {
           required
           type="number"
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.description}
         label="Description"
         labelFor={keys.description}
@@ -129,7 +129,7 @@ function GrantPointsForm() {
           name={keys.description}
           required
         />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { grantPoints } from '@oyster/core/gamification';
 import { GrantPointsInput } from '@oyster/core/gamification/types';
@@ -102,7 +98,7 @@ function GrantPointsForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         error={errors.points}
         label="Points"
@@ -137,6 +133,6 @@ function GrantPointsForm() {
       <Button.Group>
         <Button.Submit>Grant</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -12,7 +12,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -99,7 +99,7 @@ function GrantPointsForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
+      <Field
         error={errors.points}
         label="Points"
         labelFor={keys.points}
@@ -112,9 +112,9 @@ function GrantPointsForm() {
           required
           type="number"
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.description}
         label="Description"
         labelFor={keys.description}
@@ -126,7 +126,7 @@ function GrantPointsForm() {
           name={keys.description}
           required
         />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.points.grant.tsx
@@ -16,6 +16,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/admin-dashboard/app/routes/_dashboard.students.$id.remove.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.$id.remove.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useLoaderData } from '@remix-run/react';
+import { Form, useLoaderData } from '@remix-run/react';
 
 import { job } from '@oyster/core/admin-dashboard/server';
 import { db } from '@oyster/db';
@@ -90,7 +90,7 @@ export default function RemoveMemberPage() {
         you sure want to remove this member?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <Checkbox
           color="amber-100"
           defaultChecked={true}
@@ -105,7 +105,7 @@ export default function RemoveMemberPage() {
             Remove
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/admin-dashboard/app/routes/login._index.tsx
+++ b/apps/admin-dashboard/app/routes/login._index.tsx
@@ -2,7 +2,7 @@ import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 import { getGoogleAuthUri } from '@oyster/core/admin-dashboard/server';
-import { Form, Login } from '@oyster/ui';
+import { ErrorMessage, Login } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ENV } from '@/shared/constants.server';
@@ -43,7 +43,7 @@ export default function LoginPage() {
 
       {error && (
         <div className="mt-4">
-          <Form.ErrorMessage>{error}</Form.ErrorMessage>
+          <ErrorMessage>{error}</ErrorMessage>
         </div>
       )}
     </Login.ButtonGroup>

--- a/apps/admin-dashboard/app/routes/login.otp.send.tsx
+++ b/apps/admin-dashboard/app/routes/login.otp.send.tsx
@@ -6,7 +6,7 @@ import {
   OneTimeCodeForm,
   SendOneTimeCodeInput,
 } from '@oyster/core/admin-dashboard/ui';
-import { Button, Form, getErrors, validateForm } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, validateForm } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { oneTimeCodeIdCookie } from '@/shared/cookies.server';
@@ -45,7 +45,7 @@ export default function SendOneTimeCodePage() {
   return (
     <RemixForm className="form" method="post">
       <OneTimeCodeForm.EmailField error={errors.email} name={keys.email} />
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
       <Button.Submit fill>Send Code</Button.Submit>
     </RemixForm>
   );

--- a/apps/admin-dashboard/app/routes/login.otp.send.tsx
+++ b/apps/admin-dashboard/app/routes/login.otp.send.tsx
@@ -1,5 +1,5 @@
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 
 import { sendOneTimeCode } from '@oyster/core/admin-dashboard/server';
 import {
@@ -43,10 +43,10 @@ export default function SendOneTimeCodePage() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <OneTimeCodeForm.EmailField error={errors.email} name={keys.email} />
       <ErrorMessage>{error}</ErrorMessage>
       <Button.Submit fill>Send Code</Button.Submit>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/routes/login.otp.verify.tsx
+++ b/apps/admin-dashboard/app/routes/login.otp.verify.tsx
@@ -15,7 +15,7 @@ import {
   OneTimeCodeForm,
   VerifyOneTimeCodeInput,
 } from '@oyster/core/admin-dashboard/ui';
-import { Button, Form, getErrors, validateForm } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, validateForm } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ENV } from '@/shared/constants.server';
@@ -98,7 +98,7 @@ export default function VerifyOneTimeCodePage() {
         name={keys.value}
       />
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Submit fill>Verify Code</Button.Submit>
     </RemixForm>

--- a/apps/admin-dashboard/app/routes/login.otp.verify.tsx
+++ b/apps/admin-dashboard/app/routes/login.otp.verify.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { verifyOneTimeCode } from '@oyster/core/admin-dashboard/server';
 import {
@@ -91,7 +87,7 @@ export default function VerifyOneTimeCodePage() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <OneTimeCodeForm.CodeField
         description={description}
         error={errors.value}
@@ -101,6 +97,6 @@ export default function VerifyOneTimeCodePage() {
       <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Submit fill>Verify Code</Button.Submit>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/admin-dashboard/app/shared/components/onboarding-session-form.tsx
+++ b/apps/admin-dashboard/app/shared/components/onboarding-session-form.tsx
@@ -26,7 +26,7 @@ export function OnboardingSessionAttendeesField({ error, name }: FieldProps) {
   const members = fetcher.data?.members || [];
 
   return (
-    <Form.Field
+    <FormField
       description="Please select any other students who attended this onboarding session."
       error={error}
       label="Attendees"
@@ -68,7 +68,7 @@ export function OnboardingSessionAttendeesField({ error, name }: FieldProps) {
           </ComboboxPopover>
         )}
       </MultiCombobox>
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -77,8 +77,8 @@ OnboardingSessionForm.DateField = function DateField({
   name,
 }: FieldProps) {
   return (
-    <Form.Field error={error} label="Date" labelFor={name} required>
+    <FormField error={error} label="Date" labelFor={name} required>
       <DatePicker id={name} name={name} type="date" required />
-    </Form.Field>
+    </FormField>
   );
 };

--- a/apps/admin-dashboard/app/shared/components/onboarding-session-form.tsx
+++ b/apps/admin-dashboard/app/shared/components/onboarding-session-form.tsx
@@ -3,7 +3,7 @@ import { useFetcher } from '@remix-run/react';
 import {
   ComboboxPopover,
   DatePicker,
-  FormField,
+  Field,
   MultiCombobox,
   MultiComboboxDisplay,
   MultiComboboxItem,
@@ -26,7 +26,7 @@ export function OnboardingSessionAttendeesField({ error, name }: FieldProps) {
   const members = fetcher.data?.members || [];
 
   return (
-    <FormField
+    <Field
       description="Please select any other students who attended this onboarding session."
       error={error}
       label="Attendees"
@@ -68,7 +68,7 @@ export function OnboardingSessionAttendeesField({ error, name }: FieldProps) {
           </ComboboxPopover>
         )}
       </MultiCombobox>
-    </FormField>
+    </Field>
   );
 }
 
@@ -77,8 +77,8 @@ OnboardingSessionForm.DateField = function DateField({
   name,
 }: FieldProps) {
   return (
-    <FormField error={error} label="Date" labelFor={name} required>
+    <Field error={error} label="Date" labelFor={name} required>
       <DatePicker id={name} name={name} type="date" required />
-    </FormField>
+    </Field>
   );
 };

--- a/apps/admin-dashboard/app/shared/components/onboarding-session-form.tsx
+++ b/apps/admin-dashboard/app/shared/components/onboarding-session-form.tsx
@@ -3,7 +3,7 @@ import { useFetcher } from '@remix-run/react';
 import {
   ComboboxPopover,
   DatePicker,
-  Form,
+  FormField,
   MultiCombobox,
   MultiComboboxDisplay,
   MultiComboboxItem,

--- a/apps/member-profile/app/routes/_profile.ask-ai.tsx
+++ b/apps/member-profile/app/routes/_profile.ask-ai.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useNavigation,
@@ -158,7 +158,7 @@ function ChatbotForm() {
   }
 
   return (
-    <RemixForm className="flex flex-col gap-4" method="post">
+    <Form className="flex flex-col gap-4" method="post">
       <div
         // This is the "input" styling...really should be getting it from
         // the input component, but this is a quick fix.
@@ -223,7 +223,7 @@ function ChatbotForm() {
           );
         })}
       </div>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.companies.tsx
+++ b/apps/member-profile/app/routes/_profile.companies.tsx
@@ -4,10 +4,10 @@ import {
   type SerializeFrom,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
   Outlet,
-  Form as RemixForm,
   useLoaderData,
   useSearchParams,
   useSubmit,
@@ -130,7 +130,7 @@ function SortCompaniesForm() {
   const sortKeys = ListCompaniesOrderBy._def.innerType.enum;
 
   return (
-    <RemixForm
+    <Form
       className="flex min-w-[12rem] items-center gap-4"
       method="get"
       onChange={(e) => submit(e.currentTarget)}
@@ -154,7 +154,7 @@ function SortCompaniesForm() {
       </Select>
 
       <ExistingSearchParams exclude={['orderBy']} />
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.directory.join.1.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.1.tsx
@@ -105,7 +105,7 @@ export default function UpdateGeneralInformationForm() {
 
       <Divider />
 
-      <Form.Field
+      <FormField
         description={<HistoryFieldDescription />}
         labelFor="history"
         label="Work + Education History"
@@ -119,7 +119,7 @@ export default function UpdateGeneralInformationForm() {
           required
           value="1"
         />
-      </Form.Field>
+      </FormField>
 
       <Button.Group>
         <JoinDirectoryNextButton />

--- a/apps/member-profile/app/routes/_profile.directory.join.1.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.1.tsx
@@ -13,7 +13,7 @@ import {
   Button,
   Checkbox,
   Divider,
-  FormField,
+  Field,
   getErrors,
   InputField,
   Link,
@@ -101,7 +101,7 @@ export default function UpdateGeneralInformationForm() {
 
       <Divider />
 
-      <FormField
+      <Field
         description={<HistoryFieldDescription />}
         labelFor="history"
         label="Work + Education History"
@@ -115,7 +115,7 @@ export default function UpdateGeneralInformationForm() {
           required
           value="1"
         />
-      </FormField>
+      </Field>
 
       <Button.Group>
         <JoinDirectoryNextButton />

--- a/apps/member-profile/app/routes/_profile.directory.join.1.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.1.tsx
@@ -17,7 +17,7 @@ import {
   Button,
   Checkbox,
   Divider,
-  Form,
+  FormField,
   getErrors,
   InputField,
   Link,

--- a/apps/member-profile/app/routes/_profile.directory.join.1.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.1.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { updateMember } from '@oyster/core/member-profile/server';
@@ -80,7 +76,7 @@ export default function UpdateGeneralInformationForm() {
   const { errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <InputField
         defaultValue={student.headline || undefined}
         description="A LinkedIn-style headline."
@@ -124,7 +120,7 @@ export default function UpdateGeneralInformationForm() {
       <Button.Group>
         <JoinDirectoryNextButton />
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.directory.join.2.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.2.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { updateMember } from '@oyster/core/member-profile/server';
@@ -87,7 +83,7 @@ export default function UpdatePersonalInformationForm() {
   const { errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <HometownField
         defaultLatitude={student.hometownCoordinates?.y}
         defaultLongitude={student.hometownCoordinates?.x}
@@ -110,6 +106,6 @@ export default function UpdatePersonalInformationForm() {
         <JoinDirectoryBackButton to={Route['/directory/join/1']} />
         <JoinDirectoryNextButton />
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/member-profile/app/routes/_profile.directory.join.3.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.3.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { updateMember } from '@oyster/core/member-profile/server';
@@ -80,7 +76,7 @@ export default function UpdateSocialsInformationForm() {
   const { errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <InputField
         defaultValue={student.linkedInUrl || undefined}
         error={errors.linkedInUrl}
@@ -123,6 +119,6 @@ export default function UpdateSocialsInformationForm() {
         <JoinDirectoryBackButton to={Route['/directory/join/2']} />
         <JoinDirectoryNextButton>Next</JoinDirectoryNextButton>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/member-profile/app/routes/_profile.directory.join.4.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.4.tsx
@@ -21,7 +21,7 @@ import {
 import { db } from '@oyster/db';
 import {
   Button,
-  FormField,
+  Field,
   getErrors,
   Select,
   Textarea,
@@ -175,7 +175,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <FormField
+      <Field
         error={errors[promptName]}
         label={label}
         labelFor={promptName}
@@ -198,9 +198,9 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
             );
           })}
         </Select>
-      </FormField>
+      </Field>
 
-      <FormField error={errors[responseName]} labelFor={responseName} required>
+      <Field error={errors[responseName]} labelFor={responseName} required>
         <Textarea
           defaultValue={response?.text || undefined}
           id={responseName}
@@ -210,7 +210,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
           placeholder="Maximum of 280 characters..."
           required
         />
-      </FormField>
+      </Field>
     </div>
   );
 }

--- a/apps/member-profile/app/routes/_profile.directory.join.4.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.4.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
 
@@ -123,7 +119,7 @@ export default function UpsertIcebreakerResponsesForm() {
   const { icebreakerResponses } = useLoaderData<typeof loader>();
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <IcebreakersProvider icebreakerResponses={icebreakerResponses}>
         <IcebreakerGroup number="1" />
         <IcebreakerGroup number="2" />
@@ -134,7 +130,7 @@ export default function UpsertIcebreakerResponsesForm() {
         <JoinDirectoryBackButton to={Route['/directory/join/3']} />
         <JoinDirectoryNextButton>Finish</JoinDirectoryNextButton>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.directory.join.4.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.4.tsx
@@ -25,7 +25,6 @@ import {
 import { db } from '@oyster/db';
 import {
   Button,
-  Form,
   FormField,
   getErrors,
   Select,

--- a/apps/member-profile/app/routes/_profile.directory.join.4.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.4.tsx
@@ -179,7 +179,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <Form.Field
+      <FormField
         error={errors[promptName]}
         label={label}
         labelFor={promptName}
@@ -202,9 +202,9 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
             );
           })}
         </Select>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field error={errors[responseName]} labelFor={responseName} required>
+      <FormField error={errors[responseName]} labelFor={responseName} required>
         <Textarea
           defaultValue={response?.text || undefined}
           id={responseName}
@@ -214,7 +214,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
           placeholder="Maximum of 280 characters..."
           required
         />
-      </Form.Field>
+      </FormField>
     </div>
   );
 }

--- a/apps/member-profile/app/routes/_profile.directory.join.4.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.4.tsx
@@ -26,6 +26,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Select,
   Textarea,

--- a/apps/member-profile/app/routes/_profile.directory.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.tsx
@@ -4,10 +4,10 @@ import {
   type SerializeFrom,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
   Outlet,
-  Form as RemixForm,
   useLoaderData,
 } from '@remix-run/react';
 import dayjs from 'dayjs';
@@ -279,7 +279,7 @@ function FilterForm({ close }: { close: VoidFunction }) {
   const [searchParams] = useSearchParams(DirectorySearchParams);
 
   return (
-    <RemixForm className="form" method="get" onSubmit={close}>
+    <Form className="form" method="get" onSubmit={close}>
       <Select
         placeholder="Select a field..."
         onChange={(e) => {
@@ -386,7 +386,7 @@ function FilterForm({ close }: { close: VoidFunction }) {
           )
         );
       })}
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.events.$id.check-in.tsx
+++ b/apps/member-profile/app/routes/_profile.events.$id.check-in.tsx
@@ -3,11 +3,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Check } from 'react-feather';
 
 import { checkIntoEvent } from '@oyster/core/events';
@@ -101,11 +97,11 @@ export default function EventCheckIn() {
             it!
           </Modal.Description>
 
-          <RemixForm className="form mt-4" method="post">
+          <Form className="form mt-4" method="post">
             <Button.Submit fill>
               <Check className="h-5 w-5" /> Check In!
             </Button.Submit>
-          </RemixForm>
+          </Form>
         </>
       )}
     </Modal>

--- a/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
+++ b/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useLoaderData } from '@remix-run/react';
+import { Form, useLoaderData } from '@remix-run/react';
 import { Calendar, Check, ExternalLink } from 'react-feather';
 
 import { getEvent, job } from '@oyster/core/member-profile/server';
@@ -140,7 +140,7 @@ export default function EventRegisterPage() {
         </Text>
       )}
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <Button.Group>
           {event.externalLink && (
             <a
@@ -158,7 +158,7 @@ export default function EventRegisterPage() {
             </Button.Submit>
           )}
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.offers.full-time.$id_.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.$id_.delete.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -105,13 +105,13 @@ export default function DeleteFullTimeOffer() {
         Are you sure you want to delete this full-time offer for {companyName}?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.offers.full-time.$id_.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.$id_.delete.tsx
@@ -13,7 +13,7 @@ import {
 
 import { deleteOffer, hasOfferWritePermission } from '@oyster/core/offers';
 import { db } from '@oyster/db';
-import { Button, Form, getErrors, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -106,7 +106,7 @@ export default function DeleteFullTimeOffer() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.offers.full-time.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.$id_.edit.tsx
@@ -32,7 +32,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   Divider,
-  Form,
+  ErrorMessage,
   getButtonCn,
   getErrors,
   Modal,
@@ -231,7 +231,7 @@ export default function EditFullTimeOffer() {
           error={errors.additionalNotes}
         />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.offers.full-time.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.$id_.edit.tsx
@@ -5,9 +5,9 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
-  Form as RemixForm,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -175,7 +175,7 @@ export default function EditFullTimeOffer() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <OfferCompanyField
           defaultValue={{
             crunchbaseId: companyCrunchbaseId || '',
@@ -243,7 +243,7 @@ export default function EditFullTimeOffer() {
             Delete
           </Link>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.offers.full-time.add.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.add.tsx
@@ -29,7 +29,7 @@ import {
 import {
   Button,
   Divider,
-  Form,
+  ErrorMessage,
   getErrors,
   Modal,
   validateForm,
@@ -126,7 +126,7 @@ export default function AddFullTimeOffer() {
         <OfferNegotiatedField error={errors.negotiated} />
         <OfferAdditionalNotesField error={errors.additionalNotes} />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Add</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.offers.full-time.add.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.add.tsx
@@ -5,8 +5,8 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
-  Form as RemixForm,
   useActionData,
   useSearchParams,
 } from '@remix-run/react';
@@ -103,7 +103,7 @@ export default function AddFullTimeOffer() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <OfferCompanyField error={errors.companyCrunchbaseId} />
         <OfferRoleField error={errors.role} />
         <OfferLocationField error={errors.location} />
@@ -131,7 +131,7 @@ export default function AddFullTimeOffer() {
         <Button.Group>
           <Button.Submit>Add</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.offers.internships.$id_.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.$id_.delete.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -105,13 +105,13 @@ export default function DeleteInternshipOffer() {
         Are you sure you want to delete this internship offer for {companyName}?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.offers.internships.$id_.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.$id_.delete.tsx
@@ -13,7 +13,7 @@ import {
 
 import { deleteOffer, hasOfferWritePermission } from '@oyster/core/offers';
 import { db } from '@oyster/db';
-import { Button, Form, getErrors, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -106,7 +106,7 @@ export default function DeleteInternshipOffer() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.offers.internships.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.$id_.edit.tsx
@@ -32,7 +32,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   Divider,
-  Form,
+  ErrorMessage,
   getButtonCn,
   getErrors,
   Modal,
@@ -210,7 +210,7 @@ export default function EditInternshipOffer() {
           error={errors.additionalNotes}
         />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.offers.internships.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.$id_.edit.tsx
@@ -5,9 +5,9 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
-  Form as RemixForm,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -169,7 +169,7 @@ export default function EditInternshipOffer() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <OfferCompanyField
           defaultValue={{
             crunchbaseId: companyCrunchbaseId || '',
@@ -222,7 +222,7 @@ export default function EditInternshipOffer() {
             Delete
           </Link>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.offers.internships.add.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.add.tsx
@@ -29,7 +29,7 @@ import {
 import {
   Button,
   Divider,
-  Form,
+  ErrorMessage,
   getErrors,
   Modal,
   validateForm,
@@ -120,7 +120,7 @@ export default function AddInternshipOffer() {
         <OfferNegotiatedField error={errors.negotiated} />
         <OfferAdditionalNotesField error={errors.additionalNotes} />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Add</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.offers.internships.add.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.add.tsx
@@ -5,8 +5,8 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
-  Form as RemixForm,
   useActionData,
   useSearchParams,
 } from '@remix-run/react';
@@ -103,7 +103,7 @@ export default function AddInternshipOffer() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <OfferCompanyField error={errors.companyCrunchbaseId} />
         <OfferRoleField error={errors.role} />
         <OfferLocationField error={errors.location} />
@@ -125,7 +125,7 @@ export default function AddInternshipOffer() {
         <Button.Group>
           <Button.Submit>Add</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.delete.tsx
@@ -16,7 +16,7 @@ import {
   getOpportunity,
   hasOpportunityWritePermission,
 } from '@oyster/core/opportunities';
-import { Button, Form, getErrors, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ensureUserAuthenticated, user } from '@/shared/session.server';
@@ -90,7 +90,7 @@ export default function DeleteOpportunity() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.delete.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -89,13 +89,13 @@ export default function DeleteOpportunity() {
         {opportunity.companyName})?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit color="error">Delete</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
@@ -5,9 +5,9 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
-  Form as RemixForm,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -145,7 +145,7 @@ function EditOpportunityForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         error={errors.companyCrunchbaseId}
         label="Company"
@@ -213,6 +213,6 @@ function EditOpportunityForm() {
           Delete
         </Link>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
@@ -23,6 +23,7 @@ import {
   Button,
   DatePicker,
   Form,
+  FormField,
   getButtonCn,
   getErrors,
   Input,

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
@@ -23,7 +23,7 @@ import {
   Button,
   DatePicker,
   ErrorMessage,
-  FormField,
+  Field,
   getButtonCn,
   getErrors,
   Input,
@@ -146,7 +146,7 @@ function EditOpportunityForm() {
 
   return (
     <Form className="form" method="post">
-      <FormField
+      <Field
         error={errors.companyCrunchbaseId}
         label="Company"
         labelFor="companyCrunchbaseId"
@@ -159,13 +159,13 @@ function EditOpportunityForm() {
           }}
           name="companyCrunchbaseId"
         />
-      </FormField>
+      </Field>
 
-      <FormField error={errors.title} label="Title" labelFor="title" required>
+      <Field error={errors.title} label="Title" labelFor="title" required>
         <Input defaultValue={title} id="title" name="title" required />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.description}
         label="Description"
         labelFor="description"
@@ -179,11 +179,11 @@ function EditOpportunityForm() {
           name="description"
           required
         />
-      </FormField>
+      </Field>
 
       <OpportunityTagsField error={errors.tags} tags={tags || []} />
 
-      <FormField
+      <Field
         description="This is the date that the opportunity will no longer be open."
         error={errors.expiresAt}
         label="Expiration Date"
@@ -197,7 +197,7 @@ function EditOpportunityForm() {
           required
           type="date"
         />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
@@ -22,7 +22,7 @@ import {
 import {
   Button,
   DatePicker,
-  Form,
+  ErrorMessage,
   FormField,
   getButtonCn,
   getErrors,
@@ -199,7 +199,7 @@ function EditOpportunityForm() {
         />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group flexDirection="row-reverse" spacing="between">
         <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
@@ -145,7 +145,7 @@ function EditOpportunityForm() {
 
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         error={errors.companyCrunchbaseId}
         label="Company"
         labelFor="companyCrunchbaseId"
@@ -158,13 +158,13 @@ function EditOpportunityForm() {
           }}
           name="companyCrunchbaseId"
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field error={errors.title} label="Title" labelFor="title" required>
+      <FormField error={errors.title} label="Title" labelFor="title" required>
         <Input defaultValue={title} id="title" name="title" required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.description}
         label="Description"
         labelFor="description"
@@ -178,11 +178,11 @@ function EditOpportunityForm() {
           name="description"
           required
         />
-      </Form.Field>
+      </FormField>
 
       <OpportunityTagsField error={errors.tags} tags={tags || []} />
 
-      <Form.Field
+      <FormField
         description="This is the date that the opportunity will no longer be open."
         error={errors.expiresAt}
         label="Expiration Date"
@@ -196,7 +196,7 @@ function EditOpportunityForm() {
           required
           type="date"
         />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
@@ -23,7 +23,7 @@ import {
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Modal,
   Textarea,
@@ -94,16 +94,16 @@ export default function RefineOpportunity() {
       </Modal.Header>
 
       <Form className="form" data-gap="2rem" method="post">
-        <FormField
+        <Field
           label="Step 1. Open the link that was shared in a new tab."
           required
         >
           <Link className="link line-clamp-1" to={link} target="_blank">
             {link}
           </Link>
-        </FormField>
+        </Field>
 
-        <FormField
+        <Field
           description="You can simply do Ctrl+A and CTRL+C to copy the text content of the page. However, if it is a LinkedIn post, then please only get the actual post content. We'll only use the first 10,000 characters."
           error={errors.content}
           label="Step 2. Paste the website's text content."
@@ -117,7 +117,7 @@ export default function RefineOpportunity() {
             name="content"
             required
           />
-        </FormField>
+        </Field>
 
         <input type="hidden" name="opportunityId" value={id} />
 

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
@@ -22,7 +22,7 @@ import {
 } from '@oyster/core/opportunities';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Modal,
@@ -121,7 +121,7 @@ export default function RefineOpportunity() {
 
         <input type="hidden" name="opportunityId" value={id} />
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
@@ -5,9 +5,9 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
-  Form as RemixForm,
   useActionData,
   useLoaderData,
   useParams,
@@ -93,7 +93,7 @@ export default function RefineOpportunity() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" data-gap="2rem" method="post">
+      <Form className="form" data-gap="2rem" method="post">
         <FormField
           label="Step 1. Open the link that was shared in a new tab."
           required
@@ -128,7 +128,7 @@ export default function RefineOpportunity() {
             Generate <Plus size={16} />
           </Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
@@ -23,6 +23,7 @@ import {
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Modal,
   Textarea,

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.refine.tsx
@@ -93,16 +93,16 @@ export default function RefineOpportunity() {
       </Modal.Header>
 
       <RemixForm className="form" data-gap="2rem" method="post">
-        <Form.Field
+        <FormField
           label="Step 1. Open the link that was shared in a new tab."
           required
         >
           <Link className="link line-clamp-1" to={link} target="_blank">
             {link}
           </Link>
-        </Form.Field>
+        </FormField>
 
-        <Form.Field
+        <FormField
           description="You can simply do Ctrl+A and CTRL+C to copy the text content of the page. However, if it is a LinkedIn post, then please only get the actual post content. We'll only use the first 10,000 characters."
           error={errors.content}
           label="Step 2. Paste the website's text content."
@@ -116,7 +116,7 @@ export default function RefineOpportunity() {
             name="content"
             required
           />
-        </Form.Field>
+        </FormField>
 
         <input type="hidden" name="opportunityId" value={id} />
 

--- a/apps/member-profile/app/routes/_profile.opportunities.tags.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.tags.tsx
@@ -90,7 +90,7 @@ export function OpportunityTagsField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description="To categorize and help others find this opportunity."
       error={error}
       label="Tags"
@@ -177,6 +177,6 @@ export function OpportunityTagsField({
           );
         }}
       </MultiCombobox>
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/member-profile/app/routes/_profile.opportunities.tags.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.tags.tsx
@@ -15,7 +15,7 @@ import {
 import {
   type AccentColor,
   ComboboxPopover,
-  Form,
+  FormField,
   MultiCombobox,
   MultiComboboxDisplay,
   MultiComboboxItem,

--- a/apps/member-profile/app/routes/_profile.opportunities.tags.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.tags.tsx
@@ -15,7 +15,7 @@ import {
 import {
   type AccentColor,
   ComboboxPopover,
-  FormField,
+  Field,
   MultiCombobox,
   MultiComboboxDisplay,
   MultiComboboxItem,
@@ -90,7 +90,7 @@ export function OpportunityTagsField({
   }
 
   return (
-    <FormField
+    <Field
       description="To categorize and help others find this opportunity."
       error={error}
       label="Tags"
@@ -177,6 +177,6 @@ export function OpportunityTagsField({
           );
         }}
       </MultiCombobox>
-    </FormField>
+    </Field>
   );
 }

--- a/apps/member-profile/app/routes/_profile.points.tsx
+++ b/apps/member-profile/app/routes/_profile.points.tsx
@@ -4,8 +4,8 @@ import {
   type SerializeFrom,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
-  Form as RemixForm,
   Link as RemixLink,
   useLoaderData,
   useLocation,
@@ -288,7 +288,7 @@ function TimeframeForm() {
   const submit = useSubmit();
 
   return (
-    <RemixForm
+    <Form
       className="flex min-w-[12rem] items-center gap-4"
       method="get"
       onChange={(e) => submit(e.currentTarget)}
@@ -312,7 +312,7 @@ function TimeframeForm() {
         type="hidden"
         value={searchParams.leaderboardLimit}
       />
-    </RemixForm>
+    </Form>
   );
 }
 
@@ -328,7 +328,7 @@ function PointsLeaderboard({ className }: CardProps) {
       <Card.Header>
         <Card.Title>Points Leaderboard</Card.Title>
 
-        <RemixForm
+        <Form
           className="flex min-w-[8rem]"
           method="get"
           onChange={(e) => submit(e.currentTarget)}
@@ -351,7 +351,7 @@ function PointsLeaderboard({ className }: CardProps) {
             type="hidden"
             value={searchParams.timeframe}
           />
-        </RemixForm>
+        </Form>
       </Card.Header>
 
       <Card.Description>

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.delete.tsx
@@ -13,7 +13,7 @@ import {
 import { deleteEducation } from '@oyster/core/member-profile/server';
 import { type Education } from '@oyster/core/member-profile/ui';
 import { db } from '@oyster/db';
-import { Button, Form, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -96,7 +96,7 @@ export default function DeleteEducationPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
           <Button color="error" type="submit" variant="secondary">

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.delete.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigate,
-} from '@remix-run/react';
+import { Form, useActionData, useNavigate } from '@remix-run/react';
 
 import { deleteEducation } from '@oyster/core/member-profile/server';
 import { type Education } from '@oyster/core/member-profile/ui';
@@ -95,7 +91,7 @@ export default function DeleteEducationPage() {
         Are you sure you want to delete this education?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
@@ -107,7 +103,7 @@ export default function DeleteEducationPage() {
             Back
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
@@ -22,7 +22,13 @@ import {
 } from '@oyster/core/member-profile/ui';
 import { db } from '@oyster/db';
 import { type Major } from '@oyster/types';
-import { Button, Form, getErrors, Modal, validateForm } from '@oyster/ui';
+import {
+  Button,
+  ErrorMessage,
+  getErrors,
+  Modal,
+  validateForm,
+} from '@oyster/ui';
 
 import { EducationForm } from '@/shared/components/education-form';
 import { Route } from '@/shared/constants';
@@ -207,7 +213,7 @@ export default function EditEducationPage() {
           />
         </EducationForm.Context>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit name="action" value="edit">

--- a/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useNavigate,
@@ -174,7 +174,7 @@ export default function EditEducationPage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <EducationForm.Context>
           <EducationForm.SchoolField
             defaultValue={school}
@@ -229,7 +229,7 @@ export default function EditEducationPage() {
             Delete
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.education.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.add.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { type z } from 'zod';
 
@@ -98,7 +98,7 @@ export default function AddEducationPage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <EducationForm.Context>
           <EducationForm.SchoolField
             error={errors.schoolId}
@@ -135,7 +135,7 @@ export default function AddEducationPage() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.education.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.add.tsx
@@ -10,7 +10,13 @@ import { type z } from 'zod';
 
 import { addEducation } from '@oyster/core/member-profile/server';
 import { AddEducationInput } from '@oyster/core/member-profile/ui';
-import { Button, Form, getErrors, Modal, validateForm } from '@oyster/ui';
+import {
+  Button,
+  ErrorMessage,
+  getErrors,
+  Modal,
+  validateForm,
+} from '@oyster/ui';
 
 import { EducationForm } from '@/shared/components/education-form';
 import { Route } from '@/shared/constants';
@@ -124,7 +130,7 @@ export default function AddEducationPage() {
           />
         </EducationForm.Context>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { job } from '@oyster/core/member-profile/server';
@@ -173,7 +169,7 @@ export default function AddEmailPage() {
         profile.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <FormField
           error={errors.code}
           label="Code"
@@ -188,7 +184,7 @@ export default function AddEmailPage() {
         <Button.Group>
           <Button.Submit>Verify</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -20,7 +20,7 @@ import { db } from '@oyster/db';
 import { StudentEmail } from '@oyster/types';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -183,7 +183,7 @@ export default function AddEmailPage() {
           <Input autoFocus id={keys.code} name={keys.code} required />
         </FormField>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Verify</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -21,6 +21,7 @@ import { StudentEmail } from '@oyster/types';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -17,7 +17,7 @@ import { StudentEmail } from '@oyster/types';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -170,14 +170,9 @@ export default function AddEmailPage() {
       </Modal.Description>
 
       <Form className="form" method="post">
-        <FormField
-          error={errors.code}
-          label="Code"
-          labelFor={keys.code}
-          required
-        >
+        <Field error={errors.code} label="Code" labelFor={keys.code} required>
           <Input autoFocus id={keys.code} name={keys.code} required />
-        </FormField>
+        </Field>
 
         <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.finish.tsx
@@ -173,14 +173,14 @@ export default function AddEmailPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.Field
+        <FormField
           error={errors.code}
           label="Code"
           labelFor={keys.code}
           required
         >
           <Input autoFocus id={keys.code} name={keys.code} required />
-        </Form.Field>
+        </FormField>
 
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { job } from '@oyster/core/member-profile/server';
@@ -138,7 +138,7 @@ export default function AddEmailPage() {
         address.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <FormField
           error={errors.email}
           label="Email"
@@ -159,7 +159,7 @@ export default function AddEmailPage() {
         <Button.Group>
           <Button.Submit>Send Code</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -138,7 +138,7 @@ export default function AddEmailPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.Field
+        <FormField
           error={errors.email}
           label="Email"
           labelFor={keys.email}
@@ -151,7 +151,7 @@ export default function AddEmailPage() {
             placeholder="me@gmail.com"
             required
           />
-        </Form.Field>
+        </FormField>
 
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -15,7 +15,7 @@ import {
 import { db } from '@oyster/db';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Input,
@@ -154,7 +154,7 @@ export default function AddEmailPage() {
           />
         </FormField>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Send Code</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -16,7 +16,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Input,
   Modal,
@@ -139,7 +139,7 @@ export default function AddEmailPage() {
       </Modal.Description>
 
       <Form className="form" method="post">
-        <FormField
+        <Field
           error={errors.email}
           label="Email"
           labelFor={keys.email}
@@ -152,7 +152,7 @@ export default function AddEmailPage() {
             placeholder="me@gmail.com"
             required
           />
-        </FormField>
+        </Field>
 
         <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.add.start.tsx
@@ -16,6 +16,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Input,
   Modal,

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -93,7 +93,7 @@ export default function ChangePrimaryEmailPage() {
       <RemixForm className="form" method="post">
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
-        <Form.Field
+        <FormField
           description="If you don't see your email listed here, please add it to your profile first."
           error={errors.email}
           label="Email"
@@ -113,7 +113,7 @@ export default function ChangePrimaryEmailPage() {
               );
             })}
           </Select>
-        </Form.Field>
+        </FormField>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -17,7 +17,7 @@ import {
 import { ChangePrimaryEmailInput } from '@oyster/core/member-profile/ui';
 import {
   Button,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Modal,
@@ -92,7 +92,7 @@ export default function ChangePrimaryEmailPage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <FormField
           description="If you don't see your email listed here, please add it to your profile first."

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -18,6 +18,7 @@ import { ChangePrimaryEmailInput } from '@oyster/core/member-profile/ui';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Modal,
   Select,

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -14,7 +14,7 @@ import { ChangePrimaryEmailInput } from '@oyster/core/member-profile/ui';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Modal,
   Select,
@@ -90,7 +90,7 @@ export default function ChangePrimaryEmailPage() {
       <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
-        <FormField
+        <Field
           description="If you don't see your email listed here, please add it to your profile first."
           error={errors.email}
           label="Email"
@@ -110,7 +110,7 @@ export default function ChangePrimaryEmailPage() {
               );
             })}
           </Select>
-        </FormField>
+        </Field>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.change-primary.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import {
   changePrimaryEmail,
@@ -91,7 +87,7 @@ export default function ChangePrimaryEmailPage() {
         be sent to.
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <FormField
@@ -119,7 +115,7 @@ export default function ChangePrimaryEmailPage() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -183,7 +183,7 @@ function EmailAddressSection() {
         method="post"
         onChange={(e) => submit(e.currentTarget)}
       >
-        <Form.Field
+        <FormField
           description="If you go to school where there is a ColorStack chapter, this will allow that chapter's leaders to reach out to you about local events and opportunities."
           error={errors.allowEmailShare}
           label="Would you like to share your email with chapter leaders?"
@@ -195,7 +195,7 @@ function EmailAddressSection() {
             name={keys.allowEmailShare}
             value="1"
           />
-        </Form.Field>
+        </FormField>
       </RemixForm>
     </ProfileSection>
   );

--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -5,8 +5,8 @@ import {
   type MetaFunction,
 } from '@remix-run/node';
 import {
+  Form,
   Outlet,
-  Form as RemixForm,
   useActionData,
   useLoaderData,
   useNavigate,
@@ -178,7 +178,7 @@ function EmailAddressSection() {
         )}
       </Button.Group>
 
-      <RemixForm
+      <Form
         className="form"
         method="post"
         onChange={(e) => submit(e.currentTarget)}
@@ -196,7 +196,7 @@ function EmailAddressSection() {
             value="1"
           />
         </FormField>
-      </RemixForm>
+      </Form>
     </ProfileSection>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -24,7 +24,7 @@ import {
   Button,
   Checkbox,
   cx,
-  FormField,
+  Field,
   getErrors,
   Text,
   validateForm,
@@ -183,7 +183,7 @@ function EmailAddressSection() {
         method="post"
         onChange={(e) => submit(e.currentTarget)}
       >
-        <FormField
+        <Field
           description="If you go to school where there is a ColorStack chapter, this will allow that chapter's leaders to reach out to you about local events and opportunities."
           error={errors.allowEmailShare}
           label="Would you like to share your email with chapter leaders?"
@@ -195,7 +195,7 @@ function EmailAddressSection() {
             name={keys.allowEmailShare}
             value="1"
           />
-        </FormField>
+        </Field>
       </Form>
     </ProfileSection>
   );

--- a/apps/member-profile/app/routes/_profile.profile.emails.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.emails.tsx
@@ -24,7 +24,7 @@ import {
   Button,
   Checkbox,
   cx,
-  Form,
+  FormField,
   getErrors,
   Text,
   validateForm,

--- a/apps/member-profile/app/routes/_profile.profile.general.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.general.tsx
@@ -3,11 +3,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { type z } from 'zod';
 
 import { updateMember } from '@oyster/core/member-profile/server';
@@ -131,7 +127,7 @@ export default function UpdateGeneralInformationSection() {
         <ProfileTitle>General</ProfileTitle>
       </ProfileHeader>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <InputField
           defaultValue={student.firstName}
           error={errors.firstName}
@@ -194,7 +190,7 @@ export default function UpdateGeneralInformationSection() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </ProfileSection>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.general.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.general.tsx
@@ -16,7 +16,7 @@ import { Student } from '@oyster/types';
 import {
   Button,
   Divider,
-  Form,
+  FormField,
   getErrors,
   InputField,
   PhoneNumberInput,

--- a/apps/member-profile/app/routes/_profile.profile.general.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.general.tsx
@@ -12,7 +12,7 @@ import { Student } from '@oyster/types';
 import {
   Button,
   Divider,
-  FormField,
+  Field,
   getErrors,
   InputField,
   PhoneNumberInput,
@@ -174,7 +174,7 @@ export default function UpdateGeneralInformationSection() {
           longitudeName={keys.currentLocationLongitude}
         />
 
-        <FormField
+        <Field
           description="Enter your 10-digit phone number. We'll use this to send you important ColorStack updates."
           error={errors.phoneNumber}
           label="Phone Number"
@@ -185,7 +185,7 @@ export default function UpdateGeneralInformationSection() {
             id={keys.phoneNumber}
             name={keys.phoneNumber}
           />
-        </FormField>
+        </Field>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.general.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.general.tsx
@@ -178,7 +178,7 @@ export default function UpdateGeneralInformationSection() {
           longitudeName={keys.currentLocationLongitude}
         />
 
-        <Form.Field
+        <FormField
           description="Enter your 10-digit phone number. We'll use this to send you important ColorStack updates."
           error={errors.phoneNumber}
           label="Phone Number"
@@ -189,7 +189,7 @@ export default function UpdateGeneralInformationSection() {
             id={keys.phoneNumber}
             name={keys.phoneNumber}
           />
-        </Form.Field>
+        </FormField>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
@@ -22,7 +22,6 @@ import {
 import { db } from '@oyster/db';
 import {
   Button,
-  Form,
   FormField,
   getErrors,
   Select,

--- a/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
@@ -18,7 +18,7 @@ import {
 import { db } from '@oyster/db';
 import {
   Button,
-  FormField,
+  Field,
   getErrors,
   Select,
   Textarea,
@@ -197,7 +197,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <FormField
+      <Field
         error={errors[promptName]}
         label={label}
         labelFor={promptName}
@@ -220,9 +220,9 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
             );
           })}
         </Select>
-      </FormField>
+      </Field>
 
-      <FormField error={errors[responseName]} labelFor={responseName} required>
+      <Field error={errors[responseName]} labelFor={responseName} required>
         <Textarea
           defaultValue={response?.text || undefined}
           id={responseName}
@@ -232,7 +232,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
           placeholder="Maximum of 280 characters..."
           required
         />
-      </FormField>
+      </Field>
     </div>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
@@ -23,6 +23,7 @@ import { db } from '@oyster/db';
 import {
   Button,
   Form,
+  FormField,
   getErrors,
   Select,
   Textarea,

--- a/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
@@ -3,11 +3,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
 
@@ -145,7 +141,7 @@ export default function UpsertIcebreakerResponsesForm() {
         <ProfileTitle>Icebreakers</ProfileTitle>
       </ProfileHeader>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <IcebreakersProvider icebreakerResponses={icebreakerResponses}>
           <IcebreakerGroup number="1" />
           <IcebreakerGroup number="2" />
@@ -155,7 +151,7 @@ export default function UpsertIcebreakerResponsesForm() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </ProfileSection>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.icebreakers.tsx
@@ -201,7 +201,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <Form.Field
+      <FormField
         error={errors[promptName]}
         label={label}
         labelFor={promptName}
@@ -224,9 +224,9 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
             );
           })}
         </Select>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field error={errors[responseName]} labelFor={responseName} required>
+      <FormField error={errors[responseName]} labelFor={responseName} required>
         <Textarea
           defaultValue={response?.text || undefined}
           id={responseName}
@@ -236,7 +236,7 @@ function IcebreakerGroup({ number }: IcebreakerGroupProps) {
           placeholder="Maximum of 280 characters..."
           required
         />
-      </Form.Field>
+      </FormField>
     </div>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.personal.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.personal.tsx
@@ -3,11 +3,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { sql } from 'kysely';
 import { z } from 'zod';
 
@@ -132,7 +128,7 @@ export default function UpdatePersonalInformationForm() {
         <ProfileTitle>Personal</ProfileTitle>
       </ProfileHeader>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <GenderField
           defaultValue={student.gender}
           error={errors.gender}
@@ -183,7 +179,7 @@ export default function UpdatePersonalInformationForm() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </ProfileSection>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.socials.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.socials.tsx
@@ -3,12 +3,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import {
-  Link,
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, Link, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 
 import { updateMember } from '@oyster/core/member-profile/server';
@@ -104,7 +99,7 @@ export default function UpdateSocialsInformationForm() {
         <ProfileTitle>Socials</ProfileTitle>
       </ProfileHeader>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <InputField
           defaultValue={student.linkedInUrl || undefined}
           error={errors.linkedInUrl}
@@ -157,7 +152,7 @@ export default function UpdateSocialsInformationForm() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </ProfileSection>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.delete.tsx
@@ -14,7 +14,7 @@ import {
   deleteWorkExperience,
   getWorkExperience,
 } from '@oyster/core/member-profile/server';
-import { Button, Form, Modal } from '@oyster/ui';
+import { Button, ErrorMessage, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import {
@@ -86,7 +86,7 @@ export default function DeleteWorkExperiencePage() {
       </Modal.Description>
 
       <RemixForm className="form" method="post">
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
           <Button color="error" type="submit" variant="secondary">

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.delete.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.delete.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useNavigate,
-} from '@remix-run/react';
+import { Form, useActionData, useNavigate } from '@remix-run/react';
 
 import {
   deleteWorkExperience,
@@ -85,7 +81,7 @@ export default function DeleteWorkExperiencePage() {
         Are you sure you want to delete this work experience?
       </Modal.Description>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
@@ -97,7 +93,7 @@ export default function DeleteWorkExperiencePage() {
             Back
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
@@ -5,7 +5,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useNavigate,
@@ -155,7 +155,7 @@ export default function EditWorkExperiencePage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <WorkForm.Context
           defaultValue={{
             isCurrentRole: !workExperience.endDate,
@@ -246,7 +246,7 @@ export default function EditWorkExperiencePage() {
             Delete
           </Button>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.$id.edit.tsx
@@ -28,7 +28,7 @@ import {
 import {
   Address,
   Button,
-  Form,
+  ErrorMessage,
   getErrors,
   Modal,
   validateForm,
@@ -231,7 +231,7 @@ export default function EditWorkExperiencePage() {
           />
         </WorkForm.Context>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit>Update</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.work.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.add.tsx
@@ -16,7 +16,7 @@ import {
 import {
   Address,
   Button,
-  Form,
+  ErrorMessage,
   getErrors,
   Modal,
   validateForm,
@@ -143,7 +143,7 @@ export default function AddWorkExperiencePage() {
           <WorkForm.EndDateField error={errors.endDate} name={keys.endDate} />
         </WorkForm.Context>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.profile.work.add.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.work.add.tsx
@@ -4,7 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 import dayjs from 'dayjs';
 import { z } from 'zod';
 
@@ -99,7 +99,7 @@ export default function AddWorkExperiencePage() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post">
+      <Form className="form" method="post">
         <WorkForm.Context>
           <WorkForm.TitleField error={errors.title} name={keys.title} />
           <WorkForm.EmploymentTypeField
@@ -148,7 +148,7 @@ export default function AddWorkExperiencePage() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
@@ -9,7 +9,7 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -131,7 +131,7 @@ export default function EditResourceModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post" encType="multipart/form-data">
+      <Form className="form" method="post" encType="multipart/form-data">
         <ResourceProvider type={resource.type}>
           <ResourceTitleField
             defaultValue={resource.title || undefined}
@@ -173,7 +173,7 @@ export default function EditResourceModal() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
@@ -20,7 +20,7 @@ import { getResource, updateResource } from '@oyster/core/resources/server';
 import {
   Button,
   Divider,
-  Form,
+  ErrorMessage,
   getErrors,
   Modal,
   validateForm,
@@ -168,7 +168,7 @@ export default function EditResourceModal() {
           />
         </ResourceProvider>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.resources.add.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.add.tsx
@@ -20,7 +20,7 @@ import { addResource } from '@oyster/core/resources/server';
 import {
   Button,
   Divider,
-  Form,
+  ErrorMessage,
   getErrors,
   MB_IN_BYTES,
   Modal,
@@ -140,7 +140,7 @@ export default function AddResourceModal() {
           <ResourceLinkField error={errors.link} name={keys.link} />
         </ResourceProvider>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Group>
           <Button.Submit>Save</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.resources.add.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.add.tsx
@@ -8,11 +8,7 @@ import {
   unstable_parseMultipartFormData as parseMultipartFormData,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useSearchParams,
-} from '@remix-run/react';
+import { Form, useActionData, useSearchParams } from '@remix-run/react';
 
 import { track } from '@oyster/core/mixpanel';
 import { AddResourceInput } from '@oyster/core/resources';
@@ -123,7 +119,7 @@ export default function AddResourceModal() {
         <Modal.CloseButton />
       </Modal.Header>
 
-      <RemixForm className="form" method="post" encType="multipart/form-data">
+      <Form className="form" method="post" encType="multipart/form-data">
         <ResourceProvider>
           <ResourceTitleField error={errors.title} name={keys.title} />
           <ResourceDescriptionField
@@ -145,7 +141,7 @@ export default function AddResourceModal() {
         <Button.Group>
           <Button.Submit>Save</Button.Submit>
         </Button.Group>
-      </RemixForm>
+      </Form>
     </Modal>
   );
 }

--- a/apps/member-profile/app/routes/_profile.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.tsx
@@ -1,8 +1,8 @@
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import {
+  Form,
   Link,
   Outlet,
-  Form as RemixForm,
   useLoaderData,
   useSearchParams,
   useSubmit,
@@ -259,7 +259,7 @@ function SortResourcesForm() {
   const sortKeys = ListResourcesOrderBy._def.innerType.enum;
 
   return (
-    <RemixForm
+    <Form
       className="flex min-w-[12rem] items-center gap-4"
       method="get"
       onChange={(e) => submit(e.currentTarget)}
@@ -277,7 +277,7 @@ function SortResourcesForm() {
       </Select>
 
       <ExistingSearchParams exclude={['orderBy']} />
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
@@ -44,6 +44,7 @@ import {
   Divider,
   FileUploader,
   Form,
+  FormField,
   getErrors,
   Input,
   MB_IN_BYTES,

--- a/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
@@ -43,8 +43,8 @@ import {
   Checkbox,
   Divider,
   ErrorMessage,
+  Field,
   FileUploader,
-  FormField,
   getErrors,
   Input,
   MB_IN_BYTES,
@@ -395,7 +395,7 @@ function ResumeBookForm() {
       method="post"
       encType="multipart/form-data"
     >
-      <FormField
+      <Field
         description={run(() => {
           const emailLink = (
             <Link
@@ -436,9 +436,9 @@ function ResumeBookForm() {
           required
           value="1"
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.firstName}
         label="First Name"
         labelFor={keys.firstName}
@@ -450,9 +450,9 @@ function ResumeBookForm() {
           name={keys.firstName}
           required
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.lastName}
         label="Last Name"
         labelFor={keys.lastName}
@@ -464,9 +464,9 @@ function ResumeBookForm() {
           name={keys.lastName}
           required
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description={
           <Text>
             If you would like to change your primary email, click{' '}
@@ -491,9 +491,9 @@ function ResumeBookForm() {
           name="email"
           required
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description="How do you identify?"
         error={errors.race}
         label="Race & Ethnicity"
@@ -522,9 +522,9 @@ function ResumeBookForm() {
             );
           })}
         </Checkbox.Group>
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.linkedInUrl}
         label="LinkedIn Profile/URL"
         labelFor={keys.linkedInUrl}
@@ -536,9 +536,9 @@ function ResumeBookForm() {
           name={keys.linkedInUrl}
           required
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description="For reference, US and Canadian citizens are always authorized, while non-US citizens may be authorized if their immigration status allows them to work."
         error={errors.workAuthorizationStatus}
         label="Are you authorized to work in the US or Canada?"
@@ -558,7 +558,7 @@ function ResumeBookForm() {
           <option value={WorkAuthorizationStatus.UNAUTHORIZED}>No</option>
           <option value={WorkAuthorizationStatus.UNSURE}>I'm not sure</option>
         </Select>
-      </FormField>
+      </Field>
 
       <HometownField
         defaultLatitude={member.hometownCoordinates?.y}
@@ -571,7 +571,7 @@ function ResumeBookForm() {
         name={keys.hometown}
       />
 
-      <FormField
+      <Field
         description="Companies will use this to determine your graduation date, education level, and university location so be sure it's updated."
         error={errors.educationId}
         label="Select your highest level of education."
@@ -613,11 +613,11 @@ function ResumeBookForm() {
             })}
           </Select>
         </div>
-      </FormField>
+      </Field>
 
       <Divider />
 
-      <FormField
+      <Field
         error={errors.codingLanguages}
         label="Which coding language(s) are you most proficient with?"
         labelFor={keys.codingLanguages}
@@ -637,9 +637,9 @@ function ResumeBookForm() {
             );
           })}
         </Checkbox.Group>
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.preferredRoles}
         label="Which kind of roles are you interested in?"
         labelFor={keys.preferredRoles}
@@ -659,9 +659,9 @@ function ResumeBookForm() {
             );
           })}
         </Checkbox.Group>
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.employmentSearchStatus}
         label="Which is the status of your employment search?"
         labelFor={keys.employmentSearchStatus}
@@ -682,11 +682,11 @@ function ResumeBookForm() {
             );
           })}
         </Radio.Group>
-      </FormField>
+      </Field>
 
       <PreferredSponsorsField />
 
-      <FormField
+      <Field
         description={
           <Text>
             Before you submit your resume, you can get feedback from our{' '}
@@ -720,7 +720,7 @@ function ResumeBookForm() {
             },
           })}
         />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 
@@ -780,7 +780,7 @@ function PreferredSponsorsField() {
   );
 
   return (
-    <FormField
+    <Field
       error={
         errors.preferredCompany1 ||
         errors.preferredCompany2 ||
@@ -830,6 +830,6 @@ function PreferredSponsorsField() {
           {options}
         </Select>
       </div>
-    </FormField>
+    </Field>
   );
 }

--- a/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
@@ -42,8 +42,8 @@ import {
   Button,
   Checkbox,
   Divider,
+  ErrorMessage,
   FileUploader,
-  Form,
   FormField,
   getErrors,
   Input,
@@ -722,7 +722,7 @@ function ResumeBookForm() {
         />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Submit</Button.Submit>

--- a/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
@@ -9,9 +9,9 @@ import {
   redirect,
 } from '@remix-run/node';
 import {
+  Form,
   generatePath,
   Link,
-  Form as RemixForm,
   useActionData,
   useLoaderData,
   useSearchParams,
@@ -389,7 +389,7 @@ function ResumeBookForm() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm
+    <Form
       className="form mt-4"
       data-gap="2rem"
       method="post"
@@ -727,7 +727,7 @@ function ResumeBookForm() {
       <Button.Group>
         <Button.Submit>Submit</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.resume-books.$id.tsx
@@ -394,7 +394,7 @@ function ResumeBookForm() {
       method="post"
       encType="multipart/form-data"
     >
-      <Form.Field
+      <FormField
         description={run(() => {
           const emailLink = (
             <Link
@@ -435,9 +435,9 @@ function ResumeBookForm() {
           required
           value="1"
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.firstName}
         label="First Name"
         labelFor={keys.firstName}
@@ -449,9 +449,9 @@ function ResumeBookForm() {
           name={keys.firstName}
           required
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.lastName}
         label="Last Name"
         labelFor={keys.lastName}
@@ -463,9 +463,9 @@ function ResumeBookForm() {
           name={keys.lastName}
           required
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description={
           <Text>
             If you would like to change your primary email, click{' '}
@@ -490,9 +490,9 @@ function ResumeBookForm() {
           name="email"
           required
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description="How do you identify?"
         error={errors.race}
         label="Race & Ethnicity"
@@ -521,9 +521,9 @@ function ResumeBookForm() {
             );
           })}
         </Checkbox.Group>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.linkedInUrl}
         label="LinkedIn Profile/URL"
         labelFor={keys.linkedInUrl}
@@ -535,9 +535,9 @@ function ResumeBookForm() {
           name={keys.linkedInUrl}
           required
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description="For reference, US and Canadian citizens are always authorized, while non-US citizens may be authorized if their immigration status allows them to work."
         error={errors.workAuthorizationStatus}
         label="Are you authorized to work in the US or Canada?"
@@ -557,7 +557,7 @@ function ResumeBookForm() {
           <option value={WorkAuthorizationStatus.UNAUTHORIZED}>No</option>
           <option value={WorkAuthorizationStatus.UNSURE}>I'm not sure</option>
         </Select>
-      </Form.Field>
+      </FormField>
 
       <HometownField
         defaultLatitude={member.hometownCoordinates?.y}
@@ -570,7 +570,7 @@ function ResumeBookForm() {
         name={keys.hometown}
       />
 
-      <Form.Field
+      <FormField
         description="Companies will use this to determine your graduation date, education level, and university location so be sure it's updated."
         error={errors.educationId}
         label="Select your highest level of education."
@@ -612,11 +612,11 @@ function ResumeBookForm() {
             })}
           </Select>
         </div>
-      </Form.Field>
+      </FormField>
 
       <Divider />
 
-      <Form.Field
+      <FormField
         error={errors.codingLanguages}
         label="Which coding language(s) are you most proficient with?"
         labelFor={keys.codingLanguages}
@@ -636,9 +636,9 @@ function ResumeBookForm() {
             );
           })}
         </Checkbox.Group>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.preferredRoles}
         label="Which kind of roles are you interested in?"
         labelFor={keys.preferredRoles}
@@ -658,9 +658,9 @@ function ResumeBookForm() {
             );
           })}
         </Checkbox.Group>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.employmentSearchStatus}
         label="Which is the status of your employment search?"
         labelFor={keys.employmentSearchStatus}
@@ -681,11 +681,11 @@ function ResumeBookForm() {
             );
           })}
         </Radio.Group>
-      </Form.Field>
+      </FormField>
 
       <PreferredSponsorsField />
 
-      <Form.Field
+      <FormField
         description={
           <Text>
             Before you submit your resume, you can get feedback from our{' '}
@@ -719,7 +719,7 @@ function ResumeBookForm() {
             },
           })}
         />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
@@ -779,7 +779,7 @@ function PreferredSponsorsField() {
   );
 
   return (
-    <Form.Field
+    <FormField
       error={
         errors.preferredCompany1 ||
         errors.preferredCompany2 ||
@@ -829,6 +829,6 @@ function PreferredSponsorsField() {
           {options}
         </Select>
       </div>
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/member-profile/app/routes/_profile.resume.review.tsx
+++ b/apps/member-profile/app/routes/_profile.resume.review.tsx
@@ -146,7 +146,7 @@ function UploadForm() {
       encType="multipart/form-data"
       method="post"
     >
-      <Form.Field required>
+      <FormField required>
         <FileUploader
           accept={['application/pdf']}
           id="resume"
@@ -154,7 +154,7 @@ function UploadForm() {
           name="resume"
           required
         />
-      </Form.Field>
+      </FormField>
 
       {actionData && !actionData.ok && (
         <Form.ErrorMessage>{actionData.error}</Form.ErrorMessage>

--- a/apps/member-profile/app/routes/_profile.resume.review.tsx
+++ b/apps/member-profile/app/routes/_profile.resume.review.tsx
@@ -9,7 +9,7 @@ import {
   unstable_parseMultipartFormData as parseMultipartFormData,
 } from '@remix-run/node';
 import {
-  Form as RemixForm,
+  Form,
   useActionData,
   useLoaderData,
   useNavigation,
@@ -141,7 +141,7 @@ function UploadForm() {
   const actionData = useActionData<typeof action>();
 
   return (
-    <RemixForm
+    <Form
       className="form"
       data-gap="2rem"
       encType="multipart/form-data"
@@ -164,7 +164,7 @@ function UploadForm() {
       <Button.Group>
         <Button.Submit>Get Feedback</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.resume.review.tsx
+++ b/apps/member-profile/app/routes/_profile.resume.review.tsx
@@ -28,8 +28,8 @@ import {
 import {
   Button,
   cx,
+  ErrorMessage,
   FileUploader,
-  Form,
   FormField,
   MB_IN_BYTES,
   Text,
@@ -158,7 +158,7 @@ function UploadForm() {
       </FormField>
 
       {actionData && !actionData.ok && (
-        <Form.ErrorMessage>{actionData.error}</Form.ErrorMessage>
+        <ErrorMessage>{actionData.error}</ErrorMessage>
       )}
 
       <Button.Group>

--- a/apps/member-profile/app/routes/_profile.resume.review.tsx
+++ b/apps/member-profile/app/routes/_profile.resume.review.tsx
@@ -30,6 +30,7 @@ import {
   cx,
   FileUploader,
   Form,
+  FormField,
   MB_IN_BYTES,
   Text,
   validateForm,

--- a/apps/member-profile/app/routes/_profile.resume.review.tsx
+++ b/apps/member-profile/app/routes/_profile.resume.review.tsx
@@ -29,8 +29,8 @@ import {
   Button,
   cx,
   ErrorMessage,
+  Field,
   FileUploader,
-  FormField,
   MB_IN_BYTES,
   Text,
   validateForm,
@@ -147,7 +147,7 @@ function UploadForm() {
       encType="multipart/form-data"
       method="post"
     >
-      <FormField required>
+      <Field required>
         <FileUploader
           accept={['application/pdf']}
           id="resume"
@@ -155,7 +155,7 @@ function UploadForm() {
           name="resume"
           required
         />
-      </FormField>
+      </Field>
 
       {actionData && !actionData.ok && (
         <ErrorMessage>{actionData.error}</ErrorMessage>

--- a/apps/member-profile/app/routes/_public.apply._index.tsx
+++ b/apps/member-profile/app/routes/_public.apply._index.tsx
@@ -18,7 +18,7 @@ import { buildMeta } from '@oyster/core/remix';
 import {
   Button,
   Checkbox,
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   Link,
@@ -189,7 +189,7 @@ export default function ApplicationPage() {
           />
         </FormField>
 
-        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+        <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Submit fill>Apply</Button.Submit>
       </RemixForm>

--- a/apps/member-profile/app/routes/_public.apply._index.tsx
+++ b/apps/member-profile/app/routes/_public.apply._index.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   Checkbox,
   Form,
+  FormField,
   getErrors,
   Link,
   Text,

--- a/apps/member-profile/app/routes/_public.apply._index.tsx
+++ b/apps/member-profile/app/routes/_public.apply._index.tsx
@@ -5,11 +5,7 @@ import {
   type MetaFunction,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { apply } from '@oyster/core/applications';
 import { Application, ApplyInput } from '@oyster/core/applications/ui';
@@ -119,7 +115,7 @@ export default function ApplicationPage() {
         racial diversity in tech. Thank you for joining us.
       </Text>
 
-      <RemixForm className="form" data-gap="2rem" method="post">
+      <Form className="form" data-gap="2rem" method="post">
         <Application readOnly={false}>
           <Application.FirstNameField
             defaultValue={firstName}
@@ -192,7 +188,7 @@ export default function ApplicationPage() {
         <ErrorMessage>{error}</ErrorMessage>
 
         <Button.Submit fill>Apply</Button.Submit>
-      </RemixForm>
+      </Form>
     </>
   );
 }

--- a/apps/member-profile/app/routes/_public.apply._index.tsx
+++ b/apps/member-profile/app/routes/_public.apply._index.tsx
@@ -15,7 +15,7 @@ import {
   Button,
   Checkbox,
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   Link,
   Text,
@@ -170,7 +170,7 @@ export default function ApplicationPage() {
           />
         </Application>
 
-        <FormField
+        <Field
           description={<CodeOfConductDescription />}
           labelFor={keys.codeOfConduct}
           label="Code of Conduct"
@@ -183,7 +183,7 @@ export default function ApplicationPage() {
             required
             value="1"
           />
-        </FormField>
+        </Field>
 
         <ErrorMessage>{error}</ErrorMessage>
 

--- a/apps/member-profile/app/routes/_public.apply._index.tsx
+++ b/apps/member-profile/app/routes/_public.apply._index.tsx
@@ -173,7 +173,7 @@ export default function ApplicationPage() {
           />
         </Application>
 
-        <Form.Field
+        <FormField
           description={<CodeOfConductDescription />}
           labelFor={keys.codeOfConduct}
           label="Code of Conduct"
@@ -186,7 +186,7 @@ export default function ApplicationPage() {
             required
             value="1"
           />
-        </Form.Field>
+        </FormField>
 
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/apps/member-profile/app/routes/_public.login._index.tsx
+++ b/apps/member-profile/app/routes/_public.login._index.tsx
@@ -5,7 +5,7 @@ import {
   getGoogleAuthUri,
   getSlackAuthUri,
 } from '@oyster/core/member-profile/server';
-import { Form, Login } from '@oyster/ui';
+import { ErrorMessage, Login } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ENV } from '@/shared/constants.server';
@@ -53,7 +53,7 @@ export default function LoginPage() {
 
       {error && (
         <div className="mt-4">
-          <Form.ErrorMessage>{error}</Form.ErrorMessage>
+          <ErrorMessage>{error}</ErrorMessage>
         </div>
       )}
     </Login.ButtonGroup>

--- a/apps/member-profile/app/routes/_public.login.otp.send.tsx
+++ b/apps/member-profile/app/routes/_public.login.otp.send.tsx
@@ -1,5 +1,5 @@
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form as RemixForm, useActionData } from '@remix-run/react';
+import { Form, useActionData } from '@remix-run/react';
 
 import { sendOneTimeCode } from '@oyster/core/member-profile/server';
 import {
@@ -43,10 +43,10 @@ export default function SendOneTimeCodePage() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <OneTimeCodeForm.EmailField error={errors.email} name={keys.email} />
       <ErrorMessage>{error}</ErrorMessage>
       <Button.Submit fill>Send Code</Button.Submit>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/member-profile/app/routes/_public.login.otp.send.tsx
+++ b/apps/member-profile/app/routes/_public.login.otp.send.tsx
@@ -6,7 +6,7 @@ import {
   OneTimeCodeForm,
   SendOneTimeCodeInput,
 } from '@oyster/core/member-profile/ui';
-import { Button, Form, getErrors, validateForm } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, validateForm } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { oneTimeCodeIdCookie } from '@/shared/cookies.server';
@@ -45,7 +45,7 @@ export default function SendOneTimeCodePage() {
   return (
     <RemixForm className="form" method="post">
       <OneTimeCodeForm.EmailField error={errors.email} name={keys.email} />
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
       <Button.Submit fill>Send Code</Button.Submit>
     </RemixForm>
   );

--- a/apps/member-profile/app/routes/_public.login.otp.verify.tsx
+++ b/apps/member-profile/app/routes/_public.login.otp.verify.tsx
@@ -4,11 +4,7 @@ import {
   type LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node';
-import {
-  Form as RemixForm,
-  useActionData,
-  useLoaderData,
-} from '@remix-run/react';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { verifyOneTimeCode } from '@oyster/core/member-profile/server';
 import {
@@ -98,7 +94,7 @@ export default function VerifyOneTimeCodePage() {
   const { error, errors } = getErrors(useActionData<typeof action>());
 
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <OneTimeCodeForm.CodeField
         description={description}
         error={errors.value}
@@ -108,6 +104,6 @@ export default function VerifyOneTimeCodePage() {
       <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Submit fill>Verify Code</Button.Submit>
-    </RemixForm>
+    </Form>
   );
 }

--- a/apps/member-profile/app/routes/_public.login.otp.verify.tsx
+++ b/apps/member-profile/app/routes/_public.login.otp.verify.tsx
@@ -16,7 +16,7 @@ import {
   VerifyOneTimeCodeInput,
 } from '@oyster/core/member-profile/ui';
 import { track } from '@oyster/core/mixpanel';
-import { Button, Form, getErrors, validateForm } from '@oyster/ui';
+import { Button, ErrorMessage, getErrors, validateForm } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ENV } from '@/shared/constants.server';
@@ -105,7 +105,7 @@ export default function VerifyOneTimeCodePage() {
         name={keys.value}
       />
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Submit fill>Verify Code</Button.Submit>
     </RemixForm>

--- a/apps/member-profile/app/shared/components/education-form.tsx
+++ b/apps/member-profile/app/shared/components/education-form.tsx
@@ -12,7 +12,7 @@ import {
   type School,
 } from '@oyster/core/member-profile/ui';
 import { type Major } from '@oyster/types';
-import { DatePicker, Form, Input, Select } from '@oyster/ui';
+import { DatePicker, FormField, Input, Select } from '@oyster/ui';
 import { toTitleCase } from '@oyster/utils';
 
 const EducationFormContext = React.createContext({

--- a/apps/member-profile/app/shared/components/education-form.tsx
+++ b/apps/member-profile/app/shared/components/education-form.tsx
@@ -56,7 +56,7 @@ EducationForm.DegreeTypeField = function DegreeTypeField({
   name,
 }: EducationFieldProps<DegreeType>) {
   return (
-    <Form.Field error={error} label="Degree Type" labelFor={name} required>
+    <FormField error={error} label="Degree Type" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {DEGREE_TYPES.map((degreeType) => {
           return (
@@ -66,7 +66,7 @@ EducationForm.DegreeTypeField = function DegreeTypeField({
           );
         })}
       </Select>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -76,7 +76,7 @@ EducationForm.EndDateField = ({
   name,
 }: EducationFieldProps<string>) => {
   return (
-    <Form.Field
+    <FormField
       description="If you haven't graduated yet, please select the date you expect to graduate."
       error={error}
       label="End Date"
@@ -90,7 +90,7 @@ EducationForm.EndDateField = ({
         required
         type="month"
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -102,7 +102,7 @@ EducationForm.FieldOfStudyField = function FieldOfStudyField({
   const { setIsOtherFieldOfStudy } = useContext(EducationFormContext);
 
   return (
-    <Form.Field error={error} label="Field of Study" labelFor={name} required>
+    <FormField error={error} label="Field of Study" labelFor={name} required>
       <MajorCombobox
         defaultDisplayValue={defaultValue && toTitleCase(defaultValue)}
         defaultValue={defaultValue}
@@ -111,7 +111,7 @@ EducationForm.FieldOfStudyField = function FieldOfStudyField({
           setIsOtherFieldOfStudy(e.currentTarget.value === 'other');
         }}
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -132,9 +132,9 @@ EducationForm.OtherFieldOfStudyField = ({
   }
 
   return (
-    <Form.Field error={error} label="Field of Study" labelFor={name} required>
+    <FormField error={error} label="Field of Study" labelFor={name} required>
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -154,9 +154,9 @@ EducationForm.OtherSchoolField = function OtherSchoolField({
   }
 
   return (
-    <Form.Field error={error} label="Other School" labelFor={name} required>
+    <FormField error={error} label="Other School" labelFor={name} required>
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -170,13 +170,13 @@ EducationForm.SchoolField = function SchoolField({
   const { setIsOtherSchool } = useContext(EducationFormContext);
 
   return (
-    <Form.Field error={error} label="School" labelFor={name} required>
+    <FormField error={error} label="School" labelFor={name} required>
       <SchoolCombobox
         defaultValue={defaultValue}
         name={name}
         onSelect={(e) => setIsOtherSchool(e.currentTarget.value === 'other')}
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -186,7 +186,7 @@ EducationForm.StartDateField = function StartDateField({
   name,
 }: EducationFieldProps<string>) {
   return (
-    <Form.Field
+    <FormField
       description="Example: August 2020"
       error={error}
       label="Start Date"
@@ -200,6 +200,6 @@ EducationForm.StartDateField = function StartDateField({
         required
         type="month"
       />
-    </Form.Field>
+    </FormField>
   );
 };

--- a/apps/member-profile/app/shared/components/education-form.tsx
+++ b/apps/member-profile/app/shared/components/education-form.tsx
@@ -12,7 +12,7 @@ import {
   type School,
 } from '@oyster/core/member-profile/ui';
 import { type Major } from '@oyster/types';
-import { DatePicker, FormField, Input, Select } from '@oyster/ui';
+import { DatePicker, Field, Input, Select } from '@oyster/ui';
 import { toTitleCase } from '@oyster/utils';
 
 const EducationFormContext = React.createContext({
@@ -56,7 +56,7 @@ EducationForm.DegreeTypeField = function DegreeTypeField({
   name,
 }: EducationFieldProps<DegreeType>) {
   return (
-    <FormField error={error} label="Degree Type" labelFor={name} required>
+    <Field error={error} label="Degree Type" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {DEGREE_TYPES.map((degreeType) => {
           return (
@@ -66,7 +66,7 @@ EducationForm.DegreeTypeField = function DegreeTypeField({
           );
         })}
       </Select>
-    </FormField>
+    </Field>
   );
 };
 
@@ -76,7 +76,7 @@ EducationForm.EndDateField = ({
   name,
 }: EducationFieldProps<string>) => {
   return (
-    <FormField
+    <Field
       description="If you haven't graduated yet, please select the date you expect to graduate."
       error={error}
       label="End Date"
@@ -90,7 +90,7 @@ EducationForm.EndDateField = ({
         required
         type="month"
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -102,7 +102,7 @@ EducationForm.FieldOfStudyField = function FieldOfStudyField({
   const { setIsOtherFieldOfStudy } = useContext(EducationFormContext);
 
   return (
-    <FormField error={error} label="Field of Study" labelFor={name} required>
+    <Field error={error} label="Field of Study" labelFor={name} required>
       <MajorCombobox
         defaultDisplayValue={defaultValue && toTitleCase(defaultValue)}
         defaultValue={defaultValue}
@@ -111,7 +111,7 @@ EducationForm.FieldOfStudyField = function FieldOfStudyField({
           setIsOtherFieldOfStudy(e.currentTarget.value === 'other');
         }}
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -132,9 +132,9 @@ EducationForm.OtherFieldOfStudyField = ({
   }
 
   return (
-    <FormField error={error} label="Field of Study" labelFor={name} required>
+    <Field error={error} label="Field of Study" labelFor={name} required>
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </FormField>
+    </Field>
   );
 };
 
@@ -154,9 +154,9 @@ EducationForm.OtherSchoolField = function OtherSchoolField({
   }
 
   return (
-    <FormField error={error} label="Other School" labelFor={name} required>
+    <Field error={error} label="Other School" labelFor={name} required>
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </FormField>
+    </Field>
   );
 };
 
@@ -170,13 +170,13 @@ EducationForm.SchoolField = function SchoolField({
   const { setIsOtherSchool } = useContext(EducationFormContext);
 
   return (
-    <FormField error={error} label="School" labelFor={name} required>
+    <Field error={error} label="School" labelFor={name} required>
       <SchoolCombobox
         defaultValue={defaultValue}
         name={name}
         onSelect={(e) => setIsOtherSchool(e.currentTarget.value === 'other')}
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -186,7 +186,7 @@ EducationForm.StartDateField = function StartDateField({
   name,
 }: EducationFieldProps<string>) {
   return (
-    <FormField
+    <Field
       description="Example: August 2020"
       error={error}
       label="Start Date"
@@ -200,6 +200,6 @@ EducationForm.StartDateField = function StartDateField({
         required
         type="month"
       />
-    </FormField>
+    </Field>
   );
 };

--- a/apps/member-profile/app/shared/components/profile.general.tsx
+++ b/apps/member-profile/app/shared/components/profile.general.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { CityCombobox, type CityComboboxProps } from '@oyster/core/location/ui';
-import { type FieldProps, FormField, Input, Text } from '@oyster/ui';
+import { Field, type FieldProps, Input, Text } from '@oyster/ui';
 
 export function CurrentLocationField({
   defaultValue,
@@ -13,7 +13,7 @@ export function CurrentLocationField({
   name,
 }: FieldProps<string> & Omit<CityComboboxProps, 'required'>) {
   return (
-    <FormField
+    <Field
       description="We'll use this to connect you to ColorStack members and events in your area."
       error={error}
       labelFor={name}
@@ -29,7 +29,7 @@ export function CurrentLocationField({
         longitudeName={longitudeName}
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -46,7 +46,7 @@ export function PreferredNameField({
   const [value, setValue] = useState(defaultValue);
 
   return (
-    <FormField error={error} label="Preferred Name" labelFor={name}>
+    <Field error={error} label="Preferred Name" labelFor={name}>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -59,6 +59,6 @@ export function PreferredNameField({
           Your full name will appear as "{firstName} ({value}) {lastName}".
         </Text>
       )}
-    </FormField>
+    </Field>
   );
 }

--- a/apps/member-profile/app/shared/components/profile.general.tsx
+++ b/apps/member-profile/app/shared/components/profile.general.tsx
@@ -13,7 +13,7 @@ export function CurrentLocationField({
   name,
 }: FieldProps<string> & Omit<CityComboboxProps, 'required'>) {
   return (
-    <Form.Field
+    <FormField
       description="We'll use this to connect you to ColorStack members and events in your area."
       error={error}
       labelFor={name}
@@ -29,7 +29,7 @@ export function CurrentLocationField({
         longitudeName={longitudeName}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -46,7 +46,7 @@ export function PreferredNameField({
   const [value, setValue] = useState(defaultValue);
 
   return (
-    <Form.Field error={error} label="Preferred Name" labelFor={name}>
+    <FormField error={error} label="Preferred Name" labelFor={name}>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -59,6 +59,6 @@ export function PreferredNameField({
           Your full name will appear as "{firstName} ({value}) {lastName}".
         </Text>
       )}
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/member-profile/app/shared/components/profile.general.tsx
+++ b/apps/member-profile/app/shared/components/profile.general.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { CityCombobox, type CityComboboxProps } from '@oyster/core/location/ui';
-import { type FieldProps, Form, Input, Text } from '@oyster/ui';
+import { type FieldProps, FormField, Input, Text } from '@oyster/ui';
 
 export function CurrentLocationField({
   defaultValue,

--- a/apps/member-profile/app/shared/components/profile.personal.tsx
+++ b/apps/member-profile/app/shared/components/profile.personal.tsx
@@ -4,8 +4,8 @@ import { FORMATTED_GENDER, type Gender } from '@oyster/types';
 import {
   Checkbox,
   DatePicker,
+  Field,
   type FieldProps,
-  FormField,
   Select,
 } from '@oyster/ui';
 
@@ -17,7 +17,7 @@ export function BirthdateNotificationField({
   name,
 }: FieldProps<boolean>) {
   return (
-    <FormField error={error}>
+    <Field error={error}>
       <Checkbox
         color="gold-100"
         defaultChecked={defaultValue}
@@ -25,7 +25,7 @@ export function BirthdateNotificationField({
         name={name}
         value="1"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -35,7 +35,7 @@ export function BirthdateField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField
+    <Field
       description="We'll wish you a happy birthday in the #birthdays Slack channel!"
       error={error}
       label="Birthdate"
@@ -47,7 +47,7 @@ export function BirthdateField({
         name={name}
         type="date"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -57,7 +57,7 @@ export function EthnicityField({
   name,
 }: FieldProps<Pick<Country, 'code' | 'demonym' | 'flagEmoji'>[]>) {
   return (
-    <FormField error={error} labelFor={name} label="Ethnicity">
+    <Field error={error} labelFor={name} label="Ethnicity">
       <EthnicityMultiCombobox
         defaultValues={defaultValue.map((ethnicity) => {
           return {
@@ -67,7 +67,7 @@ export function EthnicityField({
         })}
         name={name}
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -82,7 +82,7 @@ const GENDERS_IN_ORDER: Gender[] = [
 
 export function GenderField({ defaultValue, error, name }: FieldProps<string>) {
   return (
-    <FormField error={error} label="Gender" labelFor={name} required>
+    <Field error={error} label="Gender" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {GENDERS_IN_ORDER.map((value) => {
           return (
@@ -92,7 +92,7 @@ export function GenderField({ defaultValue, error, name }: FieldProps<string>) {
           );
         })}
       </Select>
-    </FormField>
+    </Field>
   );
 }
 
@@ -108,7 +108,7 @@ export function HometownField({
 }: FieldProps<string> &
   Omit<CityComboboxProps, 'required'> & { description?: string }) {
   return (
-    <FormField
+    <Field
       description={description}
       error={error}
       labelFor={name}
@@ -124,6 +124,6 @@ export function HometownField({
         longitudeName={longitudeName}
         required
       />
-    </FormField>
+    </Field>
   );
 }

--- a/apps/member-profile/app/shared/components/profile.personal.tsx
+++ b/apps/member-profile/app/shared/components/profile.personal.tsx
@@ -17,7 +17,7 @@ export function BirthdateNotificationField({
   name,
 }: FieldProps<boolean>) {
   return (
-    <Form.Field error={error}>
+    <FormField error={error}>
       <Checkbox
         color="gold-100"
         defaultChecked={defaultValue}
@@ -25,7 +25,7 @@ export function BirthdateNotificationField({
         name={name}
         value="1"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -35,7 +35,7 @@ export function BirthdateField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field
+    <FormField
       description="We'll wish you a happy birthday in the #birthdays Slack channel!"
       error={error}
       label="Birthdate"
@@ -47,7 +47,7 @@ export function BirthdateField({
         name={name}
         type="date"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -57,7 +57,7 @@ export function EthnicityField({
   name,
 }: FieldProps<Pick<Country, 'code' | 'demonym' | 'flagEmoji'>[]>) {
   return (
-    <Form.Field error={error} labelFor={name} label="Ethnicity">
+    <FormField error={error} labelFor={name} label="Ethnicity">
       <EthnicityMultiCombobox
         defaultValues={defaultValue.map((ethnicity) => {
           return {
@@ -67,7 +67,7 @@ export function EthnicityField({
         })}
         name={name}
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -82,7 +82,7 @@ const GENDERS_IN_ORDER: Gender[] = [
 
 export function GenderField({ defaultValue, error, name }: FieldProps<string>) {
   return (
-    <Form.Field error={error} label="Gender" labelFor={name} required>
+    <FormField error={error} label="Gender" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {GENDERS_IN_ORDER.map((value) => {
           return (
@@ -92,7 +92,7 @@ export function GenderField({ defaultValue, error, name }: FieldProps<string>) {
           );
         })}
       </Select>
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -108,7 +108,7 @@ export function HometownField({
 }: FieldProps<string> &
   Omit<CityComboboxProps, 'required'> & { description?: string }) {
   return (
-    <Form.Field
+    <FormField
       description={description}
       error={error}
       labelFor={name}
@@ -124,6 +124,6 @@ export function HometownField({
         longitudeName={longitudeName}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/member-profile/app/shared/components/profile.personal.tsx
+++ b/apps/member-profile/app/shared/components/profile.personal.tsx
@@ -5,7 +5,7 @@ import {
   Checkbox,
   DatePicker,
   type FieldProps,
-  Form,
+  FormField,
   Select,
 } from '@oyster/ui';
 

--- a/apps/member-profile/app/shared/components/resource-form.tsx
+++ b/apps/member-profile/app/shared/components/resource-form.tsx
@@ -9,9 +9,9 @@ import React, {
 import { ResourceType } from '@oyster/core/resources';
 import {
   ComboboxPopover,
+  Field,
   type FieldProps,
   FileUploader,
-  FormField,
   Input,
   MB_IN_BYTES,
   MultiCombobox,
@@ -63,7 +63,7 @@ export function ResourceAttachmentField({
   }
 
   return (
-    <FormField
+    <Field
       description="Please choose the file you want to upload."
       error={error}
       label="Attachment"
@@ -85,7 +85,7 @@ export function ResourceAttachmentField({
           },
         })}
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -95,7 +95,7 @@ export function ResourceDescriptionField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField
+    <Field
       description="Must be less than 160 characters."
       error={error}
       label="Description"
@@ -110,7 +110,7 @@ export function ResourceDescriptionField({
         name={name}
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -126,7 +126,7 @@ export function ResourceLinkField({
   }
 
   return (
-    <FormField
+    <Field
       description="Please include the full URL."
       error={error}
       label="URL"
@@ -134,7 +134,7 @@ export function ResourceLinkField({
       required
     >
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </FormField>
+    </Field>
   );
 }
 
@@ -160,7 +160,7 @@ export function ResourceTagsField({
   }
 
   return (
-    <FormField
+    <Field
       description="To categorize and help others find this resource."
       error={error}
       label="Tags"
@@ -237,7 +237,7 @@ export function ResourceTagsField({
           );
         }}
       </MultiCombobox>
-    </FormField>
+    </Field>
   );
 }
 
@@ -247,9 +247,9 @@ export function ResourceTitleField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField error={error} label="Title" labelFor={name} required>
+    <Field error={error} label="Title" labelFor={name} required>
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </FormField>
+    </Field>
   );
 }
 
@@ -261,7 +261,7 @@ export function ResourceTypeField({
   const { setType } = useContext(ResourceFormContext);
 
   return (
-    <FormField
+    <Field
       description="What kind of type is this resource?"
       error={error}
       label="Type"
@@ -280,6 +280,6 @@ export function ResourceTypeField({
         <option value={ResourceType.FILE}>File</option>
         <option value={ResourceType.URL}>URL</option>
       </Select>
-    </FormField>
+    </Field>
   );
 }

--- a/apps/member-profile/app/shared/components/resource-form.tsx
+++ b/apps/member-profile/app/shared/components/resource-form.tsx
@@ -63,7 +63,7 @@ export function ResourceAttachmentField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description="Please choose the file you want to upload."
       error={error}
       label="Attachment"
@@ -85,7 +85,7 @@ export function ResourceAttachmentField({
           },
         })}
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -95,7 +95,7 @@ export function ResourceDescriptionField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field
+    <FormField
       description="Must be less than 160 characters."
       error={error}
       label="Description"
@@ -110,7 +110,7 @@ export function ResourceDescriptionField({
         name={name}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -126,7 +126,7 @@ export function ResourceLinkField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description="Please include the full URL."
       error={error}
       label="URL"
@@ -134,7 +134,7 @@ export function ResourceLinkField({
       required
     >
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -160,7 +160,7 @@ export function ResourceTagsField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description="To categorize and help others find this resource."
       error={error}
       label="Tags"
@@ -237,7 +237,7 @@ export function ResourceTagsField({
           );
         }}
       </MultiCombobox>
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -247,9 +247,9 @@ export function ResourceTitleField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field error={error} label="Title" labelFor={name} required>
+    <FormField error={error} label="Title" labelFor={name} required>
       <Input defaultValue={defaultValue} id={name} name={name} required />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -261,7 +261,7 @@ export function ResourceTypeField({
   const { setType } = useContext(ResourceFormContext);
 
   return (
-    <Form.Field
+    <FormField
       description="What kind of type is this resource?"
       error={error}
       label="Type"
@@ -280,6 +280,6 @@ export function ResourceTypeField({
         <option value={ResourceType.FILE}>File</option>
         <option value={ResourceType.URL}>URL</option>
       </Select>
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/member-profile/app/shared/components/resource-form.tsx
+++ b/apps/member-profile/app/shared/components/resource-form.tsx
@@ -11,7 +11,7 @@ import {
   ComboboxPopover,
   type FieldProps,
   FileUploader,
-  Form,
+  FormField,
   Input,
   MB_IN_BYTES,
   MultiCombobox,

--- a/apps/member-profile/app/shared/components/review-form.tsx
+++ b/apps/member-profile/app/shared/components/review-form.tsx
@@ -108,7 +108,7 @@ export function EditReviewForm({ error, errors, review }: EditReviewFormProps) {
 
 function AnonymousField({ defaultValue, error, name }: FieldProps<boolean>) {
   return (
-    <Form.Field
+    <FormField
       description="Your name will not be visible to the public."
       error={error}
       label="Would you like to post this review anonymously?"
@@ -122,7 +122,7 @@ function AnonymousField({ defaultValue, error, name }: FieldProps<boolean>) {
         name={name}
         value="1"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -136,7 +136,7 @@ function ExperienceField({ defaultValue, error, name }: FieldProps<string>) {
   const experiences = fetcher.data?.experiences || [];
 
   return (
-    <Form.Field
+    <FormField
       description={
         <Text>
           If you can't find the work experience you're looking for, you'll need
@@ -165,7 +165,7 @@ function ExperienceField({ defaultValue, error, name }: FieldProps<string>) {
           );
         })}
       </Select>
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -177,7 +177,7 @@ function RatingField({ defaultValue, error, name }: FieldProps<number>) {
   );
 
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="On a scale from 1-10, how would you rate this experience?"
       labelFor={name}
@@ -216,13 +216,13 @@ function RatingField({ defaultValue, error, name }: FieldProps<number>) {
       </div>
 
       <input name={name} type="hidden" value={selectedRating || ''} />
-    </Form.Field>
+    </FormField>
   );
 }
 
 function RecommendField({ defaultValue, error, name }: FieldProps<boolean>) {
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="Would you recommend this company to another ColorStack member?"
       labelFor={name}
@@ -248,13 +248,13 @@ function RecommendField({ defaultValue, error, name }: FieldProps<boolean>) {
           value="0"
         />
       </Radio.Group>
-    </Form.Field>
+    </FormField>
   );
 }
 
 function TextField({ defaultValue, error, name }: FieldProps<string>) {
   return (
-    <Form.Field
+    <FormField
       description={
         <div>
           Should be at least 750 characters. Feel free to use these guiding
@@ -290,6 +290,6 @@ function TextField({ defaultValue, error, name }: FieldProps<string>) {
         name={name}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }

--- a/apps/member-profile/app/shared/components/review-form.tsx
+++ b/apps/member-profile/app/shared/components/review-form.tsx
@@ -1,4 +1,4 @@
-import { Form as RemixForm } from '@remix-run/react';
+import { Form } from '@remix-run/react';
 import { Link, useFetcher } from '@remix-run/react';
 import { useEffect, useState } from 'react';
 import { Star } from 'react-feather';
@@ -40,7 +40,7 @@ export function AddReviewForm({
   showExperienceField,
 }: AddReviewFormProps) {
   return (
-    <RemixForm className="form" data-gap="2rem" method="post">
+    <Form className="form" data-gap="2rem" method="post">
       {showExperienceField && (
         <ExperienceField
           error={errors.workExperienceId}
@@ -58,7 +58,7 @@ export function AddReviewForm({
       <Button.Group>
         <Button.Submit>Save</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 
@@ -71,7 +71,7 @@ type EditReviewFormProps = Omit<AddReviewFormProps, 'showExperienceField'> & {
 
 export function EditReviewForm({ error, errors, review }: EditReviewFormProps) {
   return (
-    <RemixForm className="form" data-gap="2rem" method="post">
+    <Form className="form" data-gap="2rem" method="post">
       <TextField
         defaultValue={review.text}
         error={errors.text}
@@ -101,7 +101,7 @@ export function EditReviewForm({ error, errors, review }: EditReviewFormProps) {
       <Button.Group>
         <Button.Submit>Save</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/apps/member-profile/app/shared/components/review-form.tsx
+++ b/apps/member-profile/app/shared/components/review-form.tsx
@@ -13,8 +13,8 @@ import {
   cx,
   Divider,
   ErrorMessage,
+  Field,
   type FieldProps,
-  FormField,
   Radio,
   Select,
   Text,
@@ -109,7 +109,7 @@ export function EditReviewForm({ error, errors, review }: EditReviewFormProps) {
 
 function AnonymousField({ defaultValue, error, name }: FieldProps<boolean>) {
   return (
-    <FormField
+    <Field
       description="Your name will not be visible to the public."
       error={error}
       label="Would you like to post this review anonymously?"
@@ -123,7 +123,7 @@ function AnonymousField({ defaultValue, error, name }: FieldProps<boolean>) {
         name={name}
         value="1"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -137,7 +137,7 @@ function ExperienceField({ defaultValue, error, name }: FieldProps<string>) {
   const experiences = fetcher.data?.experiences || [];
 
   return (
-    <FormField
+    <Field
       description={
         <Text>
           If you can't find the work experience you're looking for, you'll need
@@ -166,7 +166,7 @@ function ExperienceField({ defaultValue, error, name }: FieldProps<string>) {
           );
         })}
       </Select>
-    </FormField>
+    </Field>
   );
 }
 
@@ -178,7 +178,7 @@ function RatingField({ defaultValue, error, name }: FieldProps<number>) {
   );
 
   return (
-    <FormField
+    <Field
       error={error}
       label="On a scale from 1-10, how would you rate this experience?"
       labelFor={name}
@@ -217,13 +217,13 @@ function RatingField({ defaultValue, error, name }: FieldProps<number>) {
       </div>
 
       <input name={name} type="hidden" value={selectedRating || ''} />
-    </FormField>
+    </Field>
   );
 }
 
 function RecommendField({ defaultValue, error, name }: FieldProps<boolean>) {
   return (
-    <FormField
+    <Field
       error={error}
       label="Would you recommend this company to another ColorStack member?"
       labelFor={name}
@@ -249,13 +249,13 @@ function RecommendField({ defaultValue, error, name }: FieldProps<boolean>) {
           value="0"
         />
       </Radio.Group>
-    </FormField>
+    </Field>
   );
 }
 
 function TextField({ defaultValue, error, name }: FieldProps<string>) {
   return (
-    <FormField
+    <Field
       description={
         <div>
           Should be at least 750 characters. Feel free to use these guiding
@@ -291,6 +291,6 @@ function TextField({ defaultValue, error, name }: FieldProps<string>) {
         name={name}
         required
       />
-    </FormField>
+    </Field>
   );
 }

--- a/apps/member-profile/app/shared/components/review-form.tsx
+++ b/apps/member-profile/app/shared/components/review-form.tsx
@@ -14,6 +14,7 @@ import {
   Divider,
   type FieldProps,
   Form,
+  FormField,
   Radio,
   Select,
   Text,

--- a/apps/member-profile/app/shared/components/review-form.tsx
+++ b/apps/member-profile/app/shared/components/review-form.tsx
@@ -12,8 +12,8 @@ import {
   Checkbox,
   cx,
   Divider,
+  ErrorMessage,
   type FieldProps,
-  Form,
   FormField,
   Radio,
   Select,
@@ -53,7 +53,7 @@ export function AddReviewForm({
       <RatingField error={errors.rating} name={keys.rating} />
       <RecommendField error={errors.recommend} name={keys.recommend} />
       <AnonymousField error={errors.anonymous} name={keys.anonymous} />
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Save</Button.Submit>
@@ -96,7 +96,7 @@ export function EditReviewForm({ error, errors, review }: EditReviewFormProps) {
         name={keys.anonymous}
       />
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Save</Button.Submit>

--- a/packages/core/src/modules/admin/admin.ui.tsx
+++ b/packages/core/src/modules/admin/admin.ui.tsx
@@ -29,44 +29,39 @@ type AdminFormProps = {
 export function AdminForm({ error, errors }: AdminFormProps) {
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         error={errors.firstName}
         label="First Name"
         labelFor={keys.firstName}
         required
       >
         <Input id={keys.firstName} name={keys.firstName} required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.lastName}
         label="Last Name"
         labelFor={keys.lastName}
         required
       >
         <Input id={keys.lastName} name={keys.lastName} required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.email}
         label="Email"
         labelFor={keys.email}
         required
       >
         <Input id={keys.email} name={keys.email} required />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
-        error={errors.role}
-        label="Role"
-        labelFor={keys.role}
-        required
-      >
+      <FormField error={errors.role} label="Role" labelFor={keys.role} required>
         <Select id={keys.role} name={keys.role} required>
           <option value={AdminRole.ADMIN}>Admin</option>
           <option value={AdminRole.AMBASSADOR}>Ambassador</option>
         </Select>
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/packages/core/src/modules/admin/admin.ui.tsx
+++ b/packages/core/src/modules/admin/admin.ui.tsx
@@ -8,7 +8,7 @@ import {
   Button,
   Dropdown,
   ErrorMessage,
-  FormField,
+  Field,
   Input,
   Pill,
   Select,
@@ -30,39 +30,34 @@ type AdminFormProps = {
 export function AdminForm({ error, errors }: AdminFormProps) {
   return (
     <Form className="form" method="post">
-      <FormField
+      <Field
         error={errors.firstName}
         label="First Name"
         labelFor={keys.firstName}
         required
       >
         <Input id={keys.firstName} name={keys.firstName} required />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.lastName}
         label="Last Name"
         labelFor={keys.lastName}
         required
       >
         <Input id={keys.lastName} name={keys.lastName} required />
-      </FormField>
+      </Field>
 
-      <FormField
-        error={errors.email}
-        label="Email"
-        labelFor={keys.email}
-        required
-      >
+      <Field error={errors.email} label="Email" labelFor={keys.email} required>
         <Input id={keys.email} name={keys.email} required />
-      </FormField>
+      </Field>
 
-      <FormField error={errors.role} label="Role" labelFor={keys.role} required>
+      <Field error={errors.role} label="Role" labelFor={keys.role} required>
         <Select id={keys.role} name={keys.role} required>
           <option value={AdminRole.ADMIN}>Admin</option>
           <option value={AdminRole.AMBASSADOR}>Ambassador</option>
         </Select>
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/packages/core/src/modules/admin/admin.ui.tsx
+++ b/packages/core/src/modules/admin/admin.ui.tsx
@@ -1,4 +1,4 @@
-import { generatePath, Link, Form as RemixForm } from '@remix-run/react';
+import { Form, generatePath, Link } from '@remix-run/react';
 import { useState } from 'react';
 import { Trash } from 'react-feather';
 import { match } from 'ts-pattern';
@@ -29,7 +29,7 @@ type AdminFormProps = {
 
 export function AdminForm({ error, errors }: AdminFormProps) {
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         error={errors.firstName}
         label="First Name"
@@ -69,7 +69,7 @@ export function AdminForm({ error, errors }: AdminFormProps) {
       <Button.Group>
         <Button.Submit>Add</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }
 

--- a/packages/core/src/modules/admin/admin.ui.tsx
+++ b/packages/core/src/modules/admin/admin.ui.tsx
@@ -7,7 +7,7 @@ import { type DB } from '@oyster/db';
 import {
   Button,
   Dropdown,
-  Form,
+  ErrorMessage,
   FormField,
   Input,
   Pill,
@@ -64,7 +64,7 @@ export function AdminForm({ error, errors }: AdminFormProps) {
         </Select>
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Add</Button.Submit>

--- a/packages/core/src/modules/admin/admin.ui.tsx
+++ b/packages/core/src/modules/admin/admin.ui.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Dropdown,
   Form,
+  FormField,
   Input,
   Pill,
   Select,

--- a/packages/core/src/modules/application/application.ui.tsx
+++ b/packages/core/src/modules/application/application.ui.tsx
@@ -76,7 +76,7 @@ Application.ContributionField = function ContributionField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field
+    <FormField
       description="As a member, you'll be able to take advantage of the opportunities and services we offer, but we are exclusively interested in welcoming students that will make the community stronger."
       error={error}
       label="How do you plan to contribute to the community?"
@@ -90,7 +90,7 @@ Application.ContributionField = function ContributionField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -109,7 +109,7 @@ Application.EducationLevelField = function EducationLevelField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field error={error} label="Education Level" labelFor={name} required>
+    <FormField error={error} label="Education Level" labelFor={name} required>
       <Radio.Group>
         {EDUCATION_LEVELS_IN_ORDER.map((value: EducationLevel) => {
           return (
@@ -126,7 +126,7 @@ Application.EducationLevelField = function EducationLevelField({
           );
         })}
       </Radio.Group>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -138,7 +138,7 @@ Application.EmailField = function EmailField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field
+    <FormField
       description="Must be a valid .edu email. If your email is invalid, your application will automatically be rejected. Please make sure to check for typos!"
       error={error}
       label="Email"
@@ -153,7 +153,7 @@ Application.EmailField = function EmailField({
         required
         type="email"
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -165,7 +165,7 @@ Application.FirstNameField = function FirstNameField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field error={error} label="First Name" labelFor={name} required>
+    <FormField error={error} label="First Name" labelFor={name} required>
       <Input
         autoFocus={!readOnly}
         defaultValue={defaultValue}
@@ -174,7 +174,7 @@ Application.FirstNameField = function FirstNameField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -195,7 +195,7 @@ Application.GenderField = function GenderField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field error={error} label="Gender" labelFor={name} required>
+    <FormField error={error} label="Gender" labelFor={name} required>
       <Radio.Group>
         {GENDERS_IN_ORDER.map((value: Gender) => {
           return (
@@ -212,7 +212,7 @@ Application.GenderField = function GenderField({
           );
         })}
       </Radio.Group>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -224,7 +224,7 @@ Application.GoalsField = function GoalsField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="What are your short and long-term goals? Name 1 thing ColorStack can do to help you achieve them."
       labelFor={name}
@@ -237,7 +237,7 @@ Application.GoalsField = function GoalsField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -261,7 +261,7 @@ Application.GraduationYearField = function GraduationYearField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="Expected Graduation Year"
       labelFor={name}
@@ -283,7 +283,7 @@ Application.GraduationYearField = function GraduationYearField({
           );
         })}
       </Radio.Group>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -295,7 +295,7 @@ Application.LastNameField = function LastNameField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field error={error} label="Last Name" labelFor={name} required>
+    <FormField error={error} label="Last Name" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -303,7 +303,7 @@ Application.LastNameField = function LastNameField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -315,7 +315,7 @@ Application.LinkedInField = function LinkedInField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field
+    <FormField
       description={<LinkedInDescription />}
       error={error}
       label="LinkedIn Profile/URL"
@@ -330,7 +330,7 @@ Application.LinkedInField = function LinkedInField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -362,7 +362,7 @@ Application.MajorField = function MajorField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description="Please choose the option closest to your major. If your minor is more relevant to this community, please select that instead. If your major/minor is not listed, this might not be the right community for you."
       error={error}
       label="Major"
@@ -376,7 +376,7 @@ Application.MajorField = function MajorField({
         onSelect={onSelect}
         readOnly={readOnly}
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -399,7 +399,7 @@ Application.OtherDemographicsField = function OtherDemographicsField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field error={error} label="Quality of Life" labelFor={name} required>
+    <FormField error={error} label="Quality of Life" labelFor={name} required>
       <Checkbox.Group>
         {DEMOGRAPHICS_IN_ORDER.map((value: Demographic) => {
           return (
@@ -429,7 +429,7 @@ Application.OtherDemographicsField = function OtherDemographicsField({
           );
         })}
       </Checkbox.Group>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -445,7 +445,7 @@ Application.OtherMajorField = function OtherMajorField({
   }
 
   return (
-    <Form.Field error={error} label="Other Major" labelFor={name} required>
+    <FormField error={error} label="Other Major" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -453,7 +453,7 @@ Application.OtherMajorField = function OtherMajorField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -469,7 +469,7 @@ Application.OtherSchoolField = function OtherSchoolField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description="Please use the full name of your school."
       error={error}
       label="Other School"
@@ -483,7 +483,7 @@ Application.OtherSchoolField = function OtherSchoolField({
         readOnly={readOnly}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -505,7 +505,7 @@ Application.RaceField = function RaceField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <Form.Field
+    <FormField
       description="Our community is designed to support racially underrepresented students in tech. "
       error={error}
       label="Race & Ethnicity"
@@ -527,7 +527,7 @@ Application.RaceField = function RaceField({
           );
         })}
       </Checkbox.Group>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -543,7 +543,7 @@ Application.SchoolField = function SchoolField({
   }
 
   return (
-    <Form.Field
+    <FormField
       description='If you do not see your school listed, please choose the "Other" option.'
       error={error}
       label="School"
@@ -556,6 +556,6 @@ Application.SchoolField = function SchoolField({
         onSelect={onSelect}
         readOnly={readOnly}
       />
-    </Form.Field>
+    </FormField>
   );
 };

--- a/packages/core/src/modules/application/application.ui.tsx
+++ b/packages/core/src/modules/application/application.ui.tsx
@@ -14,7 +14,7 @@ import {
 import {
   Checkbox,
   type FieldProps,
-  Form,
+  FormField,
   Input,
   Link,
   Radio,

--- a/packages/core/src/modules/application/application.ui.tsx
+++ b/packages/core/src/modules/application/application.ui.tsx
@@ -13,8 +13,8 @@ import {
 } from '@oyster/types';
 import {
   Checkbox,
+  Field,
   type FieldProps,
-  FormField,
   Input,
   Link,
   Radio,
@@ -76,7 +76,7 @@ Application.ContributionField = function ContributionField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField
+    <Field
       description="As a member, you'll be able to take advantage of the opportunities and services we offer, but we are exclusively interested in welcoming students that will make the community stronger."
       error={error}
       label="How do you plan to contribute to the community?"
@@ -90,7 +90,7 @@ Application.ContributionField = function ContributionField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -109,7 +109,7 @@ Application.EducationLevelField = function EducationLevelField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField error={error} label="Education Level" labelFor={name} required>
+    <Field error={error} label="Education Level" labelFor={name} required>
       <Radio.Group>
         {EDUCATION_LEVELS_IN_ORDER.map((value: EducationLevel) => {
           return (
@@ -126,7 +126,7 @@ Application.EducationLevelField = function EducationLevelField({
           );
         })}
       </Radio.Group>
-    </FormField>
+    </Field>
   );
 };
 
@@ -138,7 +138,7 @@ Application.EmailField = function EmailField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField
+    <Field
       description="Must be a valid .edu email. If your email is invalid, your application will automatically be rejected. Please make sure to check for typos!"
       error={error}
       label="Email"
@@ -153,7 +153,7 @@ Application.EmailField = function EmailField({
         required
         type="email"
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -165,7 +165,7 @@ Application.FirstNameField = function FirstNameField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField error={error} label="First Name" labelFor={name} required>
+    <Field error={error} label="First Name" labelFor={name} required>
       <Input
         autoFocus={!readOnly}
         defaultValue={defaultValue}
@@ -174,7 +174,7 @@ Application.FirstNameField = function FirstNameField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -195,7 +195,7 @@ Application.GenderField = function GenderField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField error={error} label="Gender" labelFor={name} required>
+    <Field error={error} label="Gender" labelFor={name} required>
       <Radio.Group>
         {GENDERS_IN_ORDER.map((value: Gender) => {
           return (
@@ -212,7 +212,7 @@ Application.GenderField = function GenderField({
           );
         })}
       </Radio.Group>
-    </FormField>
+    </Field>
   );
 };
 
@@ -224,7 +224,7 @@ Application.GoalsField = function GoalsField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField
+    <Field
       error={error}
       label="What are your short and long-term goals? Name 1 thing ColorStack can do to help you achieve them."
       labelFor={name}
@@ -237,7 +237,7 @@ Application.GoalsField = function GoalsField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -261,7 +261,7 @@ Application.GraduationYearField = function GraduationYearField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField
+    <Field
       error={error}
       label="Expected Graduation Year"
       labelFor={name}
@@ -283,7 +283,7 @@ Application.GraduationYearField = function GraduationYearField({
           );
         })}
       </Radio.Group>
-    </FormField>
+    </Field>
   );
 };
 
@@ -295,7 +295,7 @@ Application.LastNameField = function LastNameField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField error={error} label="Last Name" labelFor={name} required>
+    <Field error={error} label="Last Name" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -303,7 +303,7 @@ Application.LastNameField = function LastNameField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -315,7 +315,7 @@ Application.LinkedInField = function LinkedInField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField
+    <Field
       description={<LinkedInDescription />}
       error={error}
       label="LinkedIn Profile/URL"
@@ -330,7 +330,7 @@ Application.LinkedInField = function LinkedInField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -362,7 +362,7 @@ Application.MajorField = function MajorField({
   }
 
   return (
-    <FormField
+    <Field
       description="Please choose the option closest to your major. If your minor is more relevant to this community, please select that instead. If your major/minor is not listed, this might not be the right community for you."
       error={error}
       label="Major"
@@ -376,7 +376,7 @@ Application.MajorField = function MajorField({
         onSelect={onSelect}
         readOnly={readOnly}
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -399,7 +399,7 @@ Application.OtherDemographicsField = function OtherDemographicsField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField error={error} label="Quality of Life" labelFor={name} required>
+    <Field error={error} label="Quality of Life" labelFor={name} required>
       <Checkbox.Group>
         {DEMOGRAPHICS_IN_ORDER.map((value: Demographic) => {
           return (
@@ -429,7 +429,7 @@ Application.OtherDemographicsField = function OtherDemographicsField({
           );
         })}
       </Checkbox.Group>
-    </FormField>
+    </Field>
   );
 };
 
@@ -445,7 +445,7 @@ Application.OtherMajorField = function OtherMajorField({
   }
 
   return (
-    <FormField error={error} label="Other Major" labelFor={name} required>
+    <Field error={error} label="Other Major" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -453,7 +453,7 @@ Application.OtherMajorField = function OtherMajorField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -469,7 +469,7 @@ Application.OtherSchoolField = function OtherSchoolField({
   }
 
   return (
-    <FormField
+    <Field
       description="Please use the full name of your school."
       error={error}
       label="Other School"
@@ -483,7 +483,7 @@ Application.OtherSchoolField = function OtherSchoolField({
         readOnly={readOnly}
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -505,7 +505,7 @@ Application.RaceField = function RaceField({
   const { readOnly } = useContext(ApplicationContext);
 
   return (
-    <FormField
+    <Field
       description="Our community is designed to support racially underrepresented students in tech. "
       error={error}
       label="Race & Ethnicity"
@@ -527,7 +527,7 @@ Application.RaceField = function RaceField({
           );
         })}
       </Checkbox.Group>
-    </FormField>
+    </Field>
   );
 };
 
@@ -543,7 +543,7 @@ Application.SchoolField = function SchoolField({
   }
 
   return (
-    <FormField
+    <Field
       description='If you do not see your school listed, please choose the "Other" option.'
       error={error}
       label="School"
@@ -556,6 +556,6 @@ Application.SchoolField = function SchoolField({
         onSelect={onSelect}
         readOnly={readOnly}
       />
-    </FormField>
+    </Field>
   );
 };

--- a/packages/core/src/modules/authentication/ui/one-time-code-form.tsx
+++ b/packages/core/src/modules/authentication/ui/one-time-code-form.tsx
@@ -1,4 +1,4 @@
-import { type FieldProps, FormField, Input } from '@oyster/ui';
+import { Field, type FieldProps, Input } from '@oyster/ui';
 
 export const OneTimeCodeForm = () => {};
 
@@ -8,9 +8,9 @@ OneTimeCodeForm.CodeField = function CodeField({
   name,
 }: FieldProps<string> & { description?: string }) {
   return (
-    <FormField description={description} error={error} labelFor={name} required>
+    <Field description={description} error={error} labelFor={name} required>
       <Input autoFocus id={name} name={name} required />
-    </FormField>
+    </Field>
   );
 };
 
@@ -19,13 +19,13 @@ OneTimeCodeForm.EmailField = function EmailField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField
+    <Field
       description="Please input your email in order to receive a one-time passcode."
       error={error}
       labelFor={name}
       required
     >
       <Input autoFocus id={name} name={name} required />
-    </FormField>
+    </Field>
   );
 };

--- a/packages/core/src/modules/authentication/ui/one-time-code-form.tsx
+++ b/packages/core/src/modules/authentication/ui/one-time-code-form.tsx
@@ -1,4 +1,4 @@
-import { type FieldProps, Form, Input } from '@oyster/ui';
+import { type FieldProps, FormField, Input } from '@oyster/ui';
 
 export const OneTimeCodeForm = () => {};
 

--- a/packages/core/src/modules/authentication/ui/one-time-code-form.tsx
+++ b/packages/core/src/modules/authentication/ui/one-time-code-form.tsx
@@ -8,14 +8,9 @@ OneTimeCodeForm.CodeField = function CodeField({
   name,
 }: FieldProps<string> & { description?: string }) {
   return (
-    <Form.Field
-      description={description}
-      error={error}
-      labelFor={name}
-      required
-    >
+    <FormField description={description} error={error} labelFor={name} required>
       <Input autoFocus id={name} name={name} required />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -24,13 +19,13 @@ OneTimeCodeForm.EmailField = function EmailField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field
+    <FormField
       description="Please input your email in order to receive a one-time passcode."
       error={error}
       labelFor={name}
       required
     >
       <Input autoFocus id={name} name={name} required />
-    </Form.Field>
+    </FormField>
   );
 };

--- a/packages/core/src/modules/compensation/offers.ui.tsx
+++ b/packages/core/src/modules/compensation/offers.ui.tsx
@@ -15,7 +15,7 @@ export function OfferAdditionalNotesField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="Any additional notes about this offer?"
       error={error}
       label="Additional Notes"
@@ -27,7 +27,7 @@ export function OfferAdditionalNotesField({
         minRows={2}
         name="additionalNotes"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -36,19 +36,14 @@ export function OfferBaseSalaryField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
-      error={error}
-      label="Base Salary"
-      labelFor="baseSalary"
-      required
-    >
+    <FormField error={error} label="Base Salary" labelFor="baseSalary" required>
       <DollarInput
         defaultValue={defaultValue}
         id="baseSalary"
         name="baseSalary"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -57,7 +52,7 @@ export function OfferBenefitsField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="Does this job offer any benefits? (e.g. health insurance, 401k, etc.)"
       error={error}
       label="Benefits"
@@ -69,7 +64,7 @@ export function OfferBenefitsField({
         minRows={2}
         name="benefits"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -78,7 +73,7 @@ export function OfferCompanyField({
   error,
 }: Omit<FieldProps<{ crunchbaseId: string; name: string }>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="Company"
       labelFor="companyCrunchbaseId"
@@ -90,7 +85,7 @@ export function OfferCompanyField({
         name="companyCrunchbaseId"
         showDescription={false}
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -99,19 +94,14 @@ export function OfferHourlyRateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
-      error={error}
-      label="Hourly Rate"
-      labelFor="hourlyRate"
-      required
-    >
+    <FormField error={error} label="Hourly Rate" labelFor="hourlyRate" required>
       <DollarInput
         defaultValue={defaultValue}
         id="hourlyRate"
         name="hourlyRate"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -122,7 +112,7 @@ export function OfferLocationField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description='Please format the location as "City, State".'
       error={error}
       label="Location"
@@ -136,7 +126,7 @@ export function OfferLocationField({
         placeholder="San Francisco, CA"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -145,14 +135,14 @@ export function OfferNegotiatedField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="Did you negotiate, and if so, what was the result?"
       error={error}
       label="Negotiated"
       labelFor="negotiated"
     >
       <Input defaultValue={defaultValue} id="negotiated" name="negotiated" />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -161,7 +151,7 @@ export function OfferPastExperienceField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="How many years of experience and/or internships do you have?"
       error={error}
       label="Past Experience"
@@ -172,7 +162,7 @@ export function OfferPastExperienceField({
         id="pastExperience"
         name="pastExperience"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -181,7 +171,7 @@ export function OfferPerformanceBonusField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="The maximum performance/annual bonus you can receive."
       error={error}
       label="Performance Bonus"
@@ -192,7 +182,7 @@ export function OfferPerformanceBonusField({
         id="performanceBonus"
         name="performanceBonus"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -201,14 +191,14 @@ export function OfferRelocationField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="Does this offer anything for relocation and/or housing?"
       error={error}
       label="Relocation / Housing"
       labelFor="relocation"
     >
       <Input defaultValue={defaultValue} id="relocation" name="relocation" />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -217,7 +207,7 @@ export function OfferRoleField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field error={error} label="Role" labelFor="role" required>
+    <FormField error={error} label="Role" labelFor="role" required>
       <Input
         defaultValue={defaultValue}
         id="role"
@@ -225,7 +215,7 @@ export function OfferRoleField({
         placeholder="Software Engineer Intern"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -234,7 +224,7 @@ export function OfferSignOnBonusField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="The amount of money you will receive upfront."
       error={error}
       label="Sign-On Bonus"
@@ -245,7 +235,7 @@ export function OfferSignOnBonusField({
         id="signOnBonus"
         name="signOnBonus"
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -254,12 +244,12 @@ export function OfferTotalStockField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field error={error} label="Total Stock" labelFor="totalStock">
+    <FormField error={error} label="Total Stock" labelFor="totalStock">
       <DollarInput
         defaultValue={defaultValue}
         id="totalStock"
         name="totalStock"
       />
-    </Form.Field>
+    </FormField>
   );
 }

--- a/packages/core/src/modules/compensation/offers.ui.tsx
+++ b/packages/core/src/modules/compensation/offers.ui.tsx
@@ -1,7 +1,7 @@
 import {
   DollarInput,
+  Field,
   type FieldProps,
-  FormField,
   Input,
   Textarea,
 } from '@oyster/ui';
@@ -15,7 +15,7 @@ export function OfferAdditionalNotesField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="Any additional notes about this offer?"
       error={error}
       label="Additional Notes"
@@ -27,7 +27,7 @@ export function OfferAdditionalNotesField({
         minRows={2}
         name="additionalNotes"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -36,14 +36,14 @@ export function OfferBaseSalaryField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField error={error} label="Base Salary" labelFor="baseSalary" required>
+    <Field error={error} label="Base Salary" labelFor="baseSalary" required>
       <DollarInput
         defaultValue={defaultValue}
         id="baseSalary"
         name="baseSalary"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -52,7 +52,7 @@ export function OfferBenefitsField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="Does this job offer any benefits? (e.g. health insurance, 401k, etc.)"
       error={error}
       label="Benefits"
@@ -64,7 +64,7 @@ export function OfferBenefitsField({
         minRows={2}
         name="benefits"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -73,7 +73,7 @@ export function OfferCompanyField({
   error,
 }: Omit<FieldProps<{ crunchbaseId: string; name: string }>, 'name'>) {
   return (
-    <FormField
+    <Field
       error={error}
       label="Company"
       labelFor="companyCrunchbaseId"
@@ -85,7 +85,7 @@ export function OfferCompanyField({
         name="companyCrunchbaseId"
         showDescription={false}
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -94,14 +94,14 @@ export function OfferHourlyRateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField error={error} label="Hourly Rate" labelFor="hourlyRate" required>
+    <Field error={error} label="Hourly Rate" labelFor="hourlyRate" required>
       <DollarInput
         defaultValue={defaultValue}
         id="hourlyRate"
         name="hourlyRate"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -112,7 +112,7 @@ export function OfferLocationField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description='Please format the location as "City, State".'
       error={error}
       label="Location"
@@ -126,7 +126,7 @@ export function OfferLocationField({
         placeholder="San Francisco, CA"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -135,14 +135,14 @@ export function OfferNegotiatedField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="Did you negotiate, and if so, what was the result?"
       error={error}
       label="Negotiated"
       labelFor="negotiated"
     >
       <Input defaultValue={defaultValue} id="negotiated" name="negotiated" />
-    </FormField>
+    </Field>
   );
 }
 
@@ -151,7 +151,7 @@ export function OfferPastExperienceField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="How many years of experience and/or internships do you have?"
       error={error}
       label="Past Experience"
@@ -162,7 +162,7 @@ export function OfferPastExperienceField({
         id="pastExperience"
         name="pastExperience"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -171,7 +171,7 @@ export function OfferPerformanceBonusField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="The maximum performance/annual bonus you can receive."
       error={error}
       label="Performance Bonus"
@@ -182,7 +182,7 @@ export function OfferPerformanceBonusField({
         id="performanceBonus"
         name="performanceBonus"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -191,14 +191,14 @@ export function OfferRelocationField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="Does this offer anything for relocation and/or housing?"
       error={error}
       label="Relocation / Housing"
       labelFor="relocation"
     >
       <Input defaultValue={defaultValue} id="relocation" name="relocation" />
-    </FormField>
+    </Field>
   );
 }
 
@@ -207,7 +207,7 @@ export function OfferRoleField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField error={error} label="Role" labelFor="role" required>
+    <Field error={error} label="Role" labelFor="role" required>
       <Input
         defaultValue={defaultValue}
         id="role"
@@ -215,7 +215,7 @@ export function OfferRoleField({
         placeholder="Software Engineer Intern"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -224,7 +224,7 @@ export function OfferSignOnBonusField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="The amount of money you will receive upfront."
       error={error}
       label="Sign-On Bonus"
@@ -235,7 +235,7 @@ export function OfferSignOnBonusField({
         id="signOnBonus"
         name="signOnBonus"
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -244,12 +244,12 @@ export function OfferTotalStockField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField error={error} label="Total Stock" labelFor="totalStock">
+    <Field error={error} label="Total Stock" labelFor="totalStock">
       <DollarInput
         defaultValue={defaultValue}
         id="totalStock"
         name="totalStock"
       />
-    </FormField>
+    </Field>
   );
 }

--- a/packages/core/src/modules/compensation/offers.ui.tsx
+++ b/packages/core/src/modules/compensation/offers.ui.tsx
@@ -1,7 +1,7 @@
 import {
   DollarInput,
   type FieldProps,
-  Form,
+  FormField,
   Input,
   Textarea,
 } from '@oyster/ui';

--- a/packages/core/src/modules/education/education.ui.tsx
+++ b/packages/core/src/modules/education/education.ui.tsx
@@ -9,7 +9,7 @@ import {
   ComboboxPopover,
   type ComboboxProps,
   type FieldProps,
-  Form,
+  FormField,
   Input,
   type InputProps,
   Select,

--- a/packages/core/src/modules/education/education.ui.tsx
+++ b/packages/core/src/modules/education/education.ui.tsx
@@ -8,8 +8,8 @@ import {
   ComboboxItem,
   ComboboxPopover,
   type ComboboxProps,
+  Field,
   type FieldProps,
-  FormField,
   Input,
   type InputProps,
   Select,
@@ -28,7 +28,7 @@ export function SchoolCityField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       error={error}
       label="City"
       labelFor={schoolKeys.addressCity}
@@ -41,7 +41,7 @@ export function SchoolCityField({
         placeholder="Los Angeles"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -50,7 +50,7 @@ export function SchoolNameField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField error={error} label="Name" labelFor={schoolKeys.name} required>
+    <Field error={error} label="Name" labelFor={schoolKeys.name} required>
       <Input
         defaultValue={defaultValue}
         id={schoolKeys.name}
@@ -58,7 +58,7 @@ export function SchoolNameField({
         placeholder="University of California, Los Angeles"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -67,7 +67,7 @@ export function SchoolStateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="Please use the two-letter abbreviation."
       error={error}
       label="State"
@@ -81,7 +81,7 @@ export function SchoolStateField({
         placeholder="CA"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -95,7 +95,7 @@ export function SchoolTagsField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="Is this school an HBCU or HSI?"
       error={error}
       label="Tag(s)"
@@ -114,7 +114,7 @@ export function SchoolTagsField({
           );
         })}
       </Select>
-    </FormField>
+    </Field>
   );
 }
 
@@ -123,7 +123,7 @@ export function SchoolZipField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       error={error}
       label="Zip Code"
       labelFor={schoolKeys.addressZip}
@@ -136,7 +136,7 @@ export function SchoolZipField({
         placeholder="90210"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 

--- a/packages/core/src/modules/education/education.ui.tsx
+++ b/packages/core/src/modules/education/education.ui.tsx
@@ -28,7 +28,7 @@ export function SchoolCityField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="City"
       labelFor={schoolKeys.addressCity}
@@ -41,7 +41,7 @@ export function SchoolCityField({
         placeholder="Los Angeles"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -50,7 +50,7 @@ export function SchoolNameField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field error={error} label="Name" labelFor={schoolKeys.name} required>
+    <FormField error={error} label="Name" labelFor={schoolKeys.name} required>
       <Input
         defaultValue={defaultValue}
         id={schoolKeys.name}
@@ -58,7 +58,7 @@ export function SchoolNameField({
         placeholder="University of California, Los Angeles"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -67,7 +67,7 @@ export function SchoolStateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="Please use the two-letter abbreviation."
       error={error}
       label="State"
@@ -81,7 +81,7 @@ export function SchoolStateField({
         placeholder="CA"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -95,7 +95,7 @@ export function SchoolTagsField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="Is this school an HBCU or HSI?"
       error={error}
       label="Tag(s)"
@@ -114,7 +114,7 @@ export function SchoolTagsField({
           );
         })}
       </Select>
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -123,7 +123,7 @@ export function SchoolZipField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       error={error}
       label="Zip Code"
       labelFor={schoolKeys.addressZip}
@@ -136,7 +136,7 @@ export function SchoolZipField({
         placeholder="90210"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 

--- a/packages/core/src/modules/employment/ui/work-form.tsx
+++ b/packages/core/src/modules/employment/ui/work-form.tsx
@@ -14,8 +14,8 @@ import {
   ComboboxItem,
   ComboboxPopover,
   DatePicker,
+  Field,
   type FieldProps,
-  FormField,
   Input,
   Select,
   useDelayedValue,
@@ -81,9 +81,9 @@ WorkForm.CityField = function CityField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField error={error} label="City" labelFor={name}>
+    <Field error={error} label="City" labelFor={name}>
       <Address.City defaultValue={defaultValue} id={name} name={name} />
-    </FormField>
+    </Field>
   );
 };
 
@@ -115,7 +115,7 @@ WorkForm.CompanyField = function CompanyField({
   const companies = fetcher.data?.companies || [];
 
   return (
-    <FormField error={error} label="Organization" labelFor={name} required>
+    <Field error={error} label="Organization" labelFor={name} required>
       <Combobox
         defaultDisplayValue={defaultValue.name}
         defaultValue={defaultValue.crunchbaseId}
@@ -157,7 +157,7 @@ WorkForm.CompanyField = function CompanyField({
           </ul>
         </ComboboxPopover>
       </Combobox>
-    </FormField>
+    </Field>
   );
 };
 
@@ -173,7 +173,7 @@ WorkForm.CurrentRoleField = function CurrentRoleField({
   }
 
   return (
-    <FormField error={error} labelFor={name} required>
+    <Field error={error} labelFor={name} required>
       <Checkbox
         color="gold-100"
         defaultChecked={isCurrentRole || !!defaultValue}
@@ -182,7 +182,7 @@ WorkForm.CurrentRoleField = function CurrentRoleField({
         name={name}
         onChange={onChange}
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -198,7 +198,7 @@ WorkForm.EndDateField = function EndDateField({
   }
 
   return (
-    <FormField
+    <Field
       error={error}
       description="Example: August 2022"
       label="End Date"
@@ -212,7 +212,7 @@ WorkForm.EndDateField = function EndDateField({
         required
         type="month"
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -233,7 +233,7 @@ WorkForm.EmploymentTypeField = function EmploymentTypeField({
   name,
 }: FieldProps<EmploymentType>) {
   return (
-    <FormField error={error} label="Employment Type" labelFor={name} required>
+    <Field error={error} label="Employment Type" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {ORDERED_EMPLOYMENT_TYPES.map((employmentType) => {
           return (
@@ -243,7 +243,7 @@ WorkForm.EmploymentTypeField = function EmploymentTypeField({
           );
         })}
       </Select>
-    </FormField>
+    </Field>
   );
 };
 
@@ -261,7 +261,7 @@ WorkForm.LocationTypeField = function LocationTypeField({
   name,
 }: FieldProps<LocationType>) {
   return (
-    <FormField error={error} label="Location Type" labelFor={name} required>
+    <Field error={error} label="Location Type" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {ORDERED_LOCATION_TYPES.map((locationType) => {
           return (
@@ -271,7 +271,7 @@ WorkForm.LocationTypeField = function LocationTypeField({
           );
         })}
       </Select>
-    </FormField>
+    </Field>
   );
 };
 
@@ -287,7 +287,7 @@ WorkForm.OtherCompanyField = function OtherCompanyField({
   }
 
   return (
-    <FormField error={error} label="Organization" labelFor={name} required>
+    <Field error={error} label="Organization" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -295,7 +295,7 @@ WorkForm.OtherCompanyField = function OtherCompanyField({
         placeholder="Google"
         required
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -305,7 +305,7 @@ WorkForm.StartDateField = function StartDateField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField
+    <Field
       error={error}
       description="Example: August 2020"
       label="Start Date"
@@ -319,7 +319,7 @@ WorkForm.StartDateField = function StartDateField({
         required
         type="month"
       />
-    </FormField>
+    </Field>
   );
 };
 
@@ -329,9 +329,9 @@ WorkForm.StateField = function StateField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField error={error} label="State" labelFor={name}>
+    <Field error={error} label="State" labelFor={name}>
       <Address.State defaultValue={defaultValue} id={name} name={name} />
-    </FormField>
+    </Field>
   );
 };
 
@@ -341,7 +341,7 @@ WorkForm.TitleField = function TitleField({
   name,
 }: FieldProps<string>) {
   return (
-    <FormField error={error} label="Title" labelFor={name} required>
+    <Field error={error} label="Title" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -349,6 +349,6 @@ WorkForm.TitleField = function TitleField({
         placeholder="Software Engineering Intern"
         required
       />
-    </FormField>
+    </Field>
   );
 };

--- a/packages/core/src/modules/employment/ui/work-form.tsx
+++ b/packages/core/src/modules/employment/ui/work-form.tsx
@@ -81,9 +81,9 @@ WorkForm.CityField = function CityField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field error={error} label="City" labelFor={name}>
+    <FormField error={error} label="City" labelFor={name}>
       <Address.City defaultValue={defaultValue} id={name} name={name} />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -115,7 +115,7 @@ WorkForm.CompanyField = function CompanyField({
   const companies = fetcher.data?.companies || [];
 
   return (
-    <Form.Field error={error} label="Organization" labelFor={name} required>
+    <FormField error={error} label="Organization" labelFor={name} required>
       <Combobox
         defaultDisplayValue={defaultValue.name}
         defaultValue={defaultValue.crunchbaseId}
@@ -157,7 +157,7 @@ WorkForm.CompanyField = function CompanyField({
           </ul>
         </ComboboxPopover>
       </Combobox>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -173,7 +173,7 @@ WorkForm.CurrentRoleField = function CurrentRoleField({
   }
 
   return (
-    <Form.Field error={error} labelFor={name} required>
+    <FormField error={error} labelFor={name} required>
       <Checkbox
         color="gold-100"
         defaultChecked={isCurrentRole || !!defaultValue}
@@ -182,7 +182,7 @@ WorkForm.CurrentRoleField = function CurrentRoleField({
         name={name}
         onChange={onChange}
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -198,7 +198,7 @@ WorkForm.EndDateField = function EndDateField({
   }
 
   return (
-    <Form.Field
+    <FormField
       error={error}
       description="Example: August 2022"
       label="End Date"
@@ -212,7 +212,7 @@ WorkForm.EndDateField = function EndDateField({
         required
         type="month"
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -233,7 +233,7 @@ WorkForm.EmploymentTypeField = function EmploymentTypeField({
   name,
 }: FieldProps<EmploymentType>) {
   return (
-    <Form.Field error={error} label="Employment Type" labelFor={name} required>
+    <FormField error={error} label="Employment Type" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {ORDERED_EMPLOYMENT_TYPES.map((employmentType) => {
           return (
@@ -243,7 +243,7 @@ WorkForm.EmploymentTypeField = function EmploymentTypeField({
           );
         })}
       </Select>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -261,7 +261,7 @@ WorkForm.LocationTypeField = function LocationTypeField({
   name,
 }: FieldProps<LocationType>) {
   return (
-    <Form.Field error={error} label="Location Type" labelFor={name} required>
+    <FormField error={error} label="Location Type" labelFor={name} required>
       <Select defaultValue={defaultValue} id={name} name={name} required>
         {ORDERED_LOCATION_TYPES.map((locationType) => {
           return (
@@ -271,7 +271,7 @@ WorkForm.LocationTypeField = function LocationTypeField({
           );
         })}
       </Select>
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -287,7 +287,7 @@ WorkForm.OtherCompanyField = function OtherCompanyField({
   }
 
   return (
-    <Form.Field error={error} label="Organization" labelFor={name} required>
+    <FormField error={error} label="Organization" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -295,7 +295,7 @@ WorkForm.OtherCompanyField = function OtherCompanyField({
         placeholder="Google"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -305,7 +305,7 @@ WorkForm.StartDateField = function StartDateField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field
+    <FormField
       error={error}
       description="Example: August 2020"
       label="Start Date"
@@ -319,7 +319,7 @@ WorkForm.StartDateField = function StartDateField({
         required
         type="month"
       />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -329,9 +329,9 @@ WorkForm.StateField = function StateField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field error={error} label="State" labelFor={name}>
+    <FormField error={error} label="State" labelFor={name}>
       <Address.State defaultValue={defaultValue} id={name} name={name} />
-    </Form.Field>
+    </FormField>
   );
 };
 
@@ -341,7 +341,7 @@ WorkForm.TitleField = function TitleField({
   name,
 }: FieldProps<string>) {
   return (
-    <Form.Field error={error} label="Title" labelFor={name} required>
+    <FormField error={error} label="Title" labelFor={name} required>
       <Input
         defaultValue={defaultValue}
         id={name}
@@ -349,6 +349,6 @@ WorkForm.TitleField = function TitleField({
         placeholder="Software Engineering Intern"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 };

--- a/packages/core/src/modules/employment/ui/work-form.tsx
+++ b/packages/core/src/modules/employment/ui/work-form.tsx
@@ -15,7 +15,7 @@ import {
   ComboboxPopover,
   DatePicker,
   type FieldProps,
-  Form,
+  FormField,
   Input,
   Select,
   useDelayedValue,

--- a/packages/core/src/modules/gamification/gamification.ui.tsx
+++ b/packages/core/src/modules/gamification/gamification.ui.tsx
@@ -1,6 +1,6 @@
 import { Form as RemixForm } from '@remix-run/react';
 
-import { Button, Form, Input, Select, Textarea } from '@oyster/ui';
+import { Button, Form, FormField, Input, Select, Textarea } from '@oyster/ui';
 import { toTitleCase } from '@oyster/utils';
 
 import {

--- a/packages/core/src/modules/gamification/gamification.ui.tsx
+++ b/packages/core/src/modules/gamification/gamification.ui.tsx
@@ -1,6 +1,13 @@
 import { Form as RemixForm } from '@remix-run/react';
 
-import { Button, Form, FormField, Input, Select, Textarea } from '@oyster/ui';
+import {
+  Button,
+  ErrorMessage,
+  FormField,
+  Input,
+  Select,
+  Textarea,
+} from '@oyster/ui';
 import { toTitleCase } from '@oyster/utils';
 
 import {
@@ -108,7 +115,7 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
         />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Add</Button.Submit>

--- a/packages/core/src/modules/gamification/gamification.ui.tsx
+++ b/packages/core/src/modules/gamification/gamification.ui.tsx
@@ -1,4 +1,4 @@
-import { Form as RemixForm } from '@remix-run/react';
+import { Form } from '@remix-run/react';
 
 import {
   Button,
@@ -31,7 +31,7 @@ const ACTIVITY_TYPES = Object.values(ActivityType);
 
 export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <FormField
         description="This will be visible to members."
         error={errors.name}
@@ -120,6 +120,6 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
       <Button.Group>
         <Button.Submit>Add</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/packages/core/src/modules/gamification/gamification.ui.tsx
+++ b/packages/core/src/modules/gamification/gamification.ui.tsx
@@ -3,7 +3,7 @@ import { Form } from '@remix-run/react';
 import {
   Button,
   ErrorMessage,
-  FormField,
+  Field,
   Input,
   Select,
   Textarea,
@@ -32,7 +32,7 @@ const ACTIVITY_TYPES = Object.values(ActivityType);
 export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
   return (
     <Form className="form" method="post">
-      <FormField
+      <Field
         description="This will be visible to members."
         error={errors.name}
         label="Name"
@@ -45,9 +45,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
           name={keys.name}
           required
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         error={errors.description}
         label="Description"
         labelFor={keys.description}
@@ -57,9 +57,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
           id={keys.description}
           name={keys.description}
         />
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description="This tells our system to associate certain activities with certain events."
         error={errors.type}
         label="Type"
@@ -78,9 +78,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
             </option>
           ))}
         </Select>
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description="This is the period of time that a member has to wait before completing this activity again."
         error={errors.period}
         label="Period"
@@ -97,9 +97,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
             </option>
           ))}
         </Select>
-      </FormField>
+      </Field>
 
-      <FormField
+      <Field
         description="How many points will this activity be worth?"
         error={errors.points}
         label="Points"
@@ -113,7 +113,7 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
           required
           type="number"
         />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/packages/core/src/modules/gamification/gamification.ui.tsx
+++ b/packages/core/src/modules/gamification/gamification.ui.tsx
@@ -25,7 +25,7 @@ const ACTIVITY_TYPES = Object.values(ActivityType);
 export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
   return (
     <RemixForm className="form" method="post">
-      <Form.Field
+      <FormField
         description="This will be visible to members."
         error={errors.name}
         label="Name"
@@ -38,9 +38,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
           name={keys.name}
           required
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         error={errors.description}
         label="Description"
         labelFor={keys.description}
@@ -50,9 +50,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
           id={keys.description}
           name={keys.description}
         />
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description="This tells our system to associate certain activities with certain events."
         error={errors.type}
         label="Type"
@@ -71,9 +71,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
             </option>
           ))}
         </Select>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description="This is the period of time that a member has to wait before completing this activity again."
         error={errors.period}
         label="Period"
@@ -90,9 +90,9 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
             </option>
           ))}
         </Select>
-      </Form.Field>
+      </FormField>
 
-      <Form.Field
+      <FormField
         description="How many points will this activity be worth?"
         error={errors.points}
         label="Points"
@@ -106,7 +106,7 @@ export function ActivityForm({ activity, error, errors }: ActivityFormProps) {
           required
           type="number"
         />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/packages/core/src/modules/referral/referral.ui.tsx
+++ b/packages/core/src/modules/referral/referral.ui.tsx
@@ -1,6 +1,6 @@
 import { Form as RemixForm } from '@remix-run/react';
 
-import { Button, Form, FormField, Input } from '@oyster/ui';
+import { Button, ErrorMessage, FormField, Input } from '@oyster/ui';
 
 import { ReferFriendInput } from '@/modules/referral/referral.types';
 
@@ -45,7 +45,7 @@ export function ReferFriendForm({ error, errors }: ReferFriendFormProps) {
         <Input id={keys.email} name={keys.email} required type="email" />
       </FormField>
 
-      <Form.ErrorMessage>{error}</Form.ErrorMessage>
+      <ErrorMessage>{error}</ErrorMessage>
 
       <Button.Group>
         <Button.Submit>Refer</Button.Submit>

--- a/packages/core/src/modules/referral/referral.ui.tsx
+++ b/packages/core/src/modules/referral/referral.ui.tsx
@@ -1,6 +1,6 @@
 import { Form as RemixForm } from '@remix-run/react';
 
-import { Button, Form, Input } from '@oyster/ui';
+import { Button, Form, FormField, Input } from '@oyster/ui';
 
 import { ReferFriendInput } from '@/modules/referral/referral.types';
 

--- a/packages/core/src/modules/referral/referral.ui.tsx
+++ b/packages/core/src/modules/referral/referral.ui.tsx
@@ -1,6 +1,6 @@
 import { Form } from '@remix-run/react';
 
-import { Button, ErrorMessage, FormField, Input } from '@oyster/ui';
+import { Button, ErrorMessage, Field, Input } from '@oyster/ui';
 
 import { ReferFriendInput } from '@/modules/referral/referral.types';
 
@@ -17,33 +17,28 @@ export function ReferFriendForm({ error, errors }: ReferFriendFormProps) {
   return (
     <Form className="form" method="post">
       <div className="flex gap-4">
-        <FormField
+        <Field
           error={errors.firstName}
           label="First Name"
           labelFor={keys.firstName}
           required
         >
           <Input id={keys.firstName} name={keys.firstName} required />
-        </FormField>
+        </Field>
 
-        <FormField
+        <Field
           error={errors.lastName}
           label="Last Name"
           labelFor={keys.lastName}
           required
         >
           <Input id={keys.lastName} name={keys.lastName} required />
-        </FormField>
+        </Field>
       </div>
 
-      <FormField
-        error={errors.email}
-        label="Email"
-        labelFor={keys.email}
-        required
-      >
+      <Field error={errors.email} label="Email" labelFor={keys.email} required>
         <Input id={keys.email} name={keys.email} required type="email" />
-      </FormField>
+      </Field>
 
       <ErrorMessage>{error}</ErrorMessage>
 

--- a/packages/core/src/modules/referral/referral.ui.tsx
+++ b/packages/core/src/modules/referral/referral.ui.tsx
@@ -1,4 +1,4 @@
-import { Form as RemixForm } from '@remix-run/react';
+import { Form } from '@remix-run/react';
 
 import { Button, ErrorMessage, FormField, Input } from '@oyster/ui';
 
@@ -15,7 +15,7 @@ type ReferFriendFormProps = {
 
 export function ReferFriendForm({ error, errors }: ReferFriendFormProps) {
   return (
-    <RemixForm className="form" method="post">
+    <Form className="form" method="post">
       <div className="flex gap-4">
         <FormField
           error={errors.firstName}
@@ -50,6 +50,6 @@ export function ReferFriendForm({ error, errors }: ReferFriendFormProps) {
       <Button.Group>
         <Button.Submit>Refer</Button.Submit>
       </Button.Group>
-    </RemixForm>
+    </Form>
   );
 }

--- a/packages/core/src/modules/referral/referral.ui.tsx
+++ b/packages/core/src/modules/referral/referral.ui.tsx
@@ -17,33 +17,33 @@ export function ReferFriendForm({ error, errors }: ReferFriendFormProps) {
   return (
     <RemixForm className="form" method="post">
       <div className="flex gap-4">
-        <Form.Field
+        <FormField
           error={errors.firstName}
           label="First Name"
           labelFor={keys.firstName}
           required
         >
           <Input id={keys.firstName} name={keys.firstName} required />
-        </Form.Field>
+        </FormField>
 
-        <Form.Field
+        <FormField
           error={errors.lastName}
           label="Last Name"
           labelFor={keys.lastName}
           required
         >
           <Input id={keys.lastName} name={keys.lastName} required />
-        </Form.Field>
+        </FormField>
       </div>
 
-      <Form.Field
+      <FormField
         error={errors.email}
         label="Email"
         labelFor={keys.email}
         required
       >
         <Input id={keys.email} name={keys.email} required type="email" />
-      </Form.Field>
+      </FormField>
 
       <Form.ErrorMessage>{error}</Form.ErrorMessage>
 

--- a/packages/core/src/modules/resume-book/resume-book.ui.tsx
+++ b/packages/core/src/modules/resume-book/resume-book.ui.tsx
@@ -1,10 +1,4 @@
-import {
-  DatePicker,
-  type FieldProps,
-  FormField,
-  Input,
-  Radio,
-} from '@oyster/ui';
+import { DatePicker, Field, type FieldProps, Input, Radio } from '@oyster/ui';
 
 import { ResumeBook } from '@/modules/resume-book/resume-book.types';
 
@@ -15,7 +9,7 @@ export function ResumeBookEndDateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="The date that the resume book should stop accepting responses."
       error={error}
       label="End Date"
@@ -29,7 +23,7 @@ export function ResumeBookEndDateField({
         type="date"
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -38,7 +32,7 @@ export function ResumeBookHiddenField({
   error,
 }: Omit<FieldProps<boolean>, 'name'>) {
   return (
-    <FormField
+    <Field
       description='If you choose "Hidden", the resume book will only be accessible to members who have the link. If you choose "Visible", the resume book will be accessible in the Member Profile navigation to all members.'
       error={error}
       label="Visibility"
@@ -65,7 +59,7 @@ export function ResumeBookHiddenField({
           value="0"
         />
       </Radio.Group>
-    </FormField>
+    </Field>
   );
 }
 
@@ -74,7 +68,7 @@ export function ResumeBookNameField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description={`Please don't add "Resume Book" to the title. Example: Spring '24`}
       error={error}
       label="Name"
@@ -87,7 +81,7 @@ export function ResumeBookNameField({
         name={keys.name}
         required
       />
-    </FormField>
+    </Field>
   );
 }
 
@@ -96,7 +90,7 @@ export function ResumeBookStartDateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <FormField
+    <Field
       description="The date that the resume book should start accepting responses."
       error={error}
       label="Start Date"
@@ -110,6 +104,6 @@ export function ResumeBookStartDateField({
         type="date"
         required
       />
-    </FormField>
+    </Field>
   );
 }

--- a/packages/core/src/modules/resume-book/resume-book.ui.tsx
+++ b/packages/core/src/modules/resume-book/resume-book.ui.tsx
@@ -1,4 +1,10 @@
-import { DatePicker, type FieldProps, Form, Input, Radio } from '@oyster/ui';
+import {
+  DatePicker,
+  type FieldProps,
+  FormField,
+  Input,
+  Radio,
+} from '@oyster/ui';
 
 import { ResumeBook } from '@/modules/resume-book/resume-book.types';
 

--- a/packages/core/src/modules/resume-book/resume-book.ui.tsx
+++ b/packages/core/src/modules/resume-book/resume-book.ui.tsx
@@ -9,7 +9,7 @@ export function ResumeBookEndDateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="The date that the resume book should stop accepting responses."
       error={error}
       label="End Date"
@@ -23,7 +23,7 @@ export function ResumeBookEndDateField({
         type="date"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -32,7 +32,7 @@ export function ResumeBookHiddenField({
   error,
 }: Omit<FieldProps<boolean>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description='If you choose "Hidden", the resume book will only be accessible to members who have the link. If you choose "Visible", the resume book will be accessible in the Member Profile navigation to all members.'
       error={error}
       label="Visibility"
@@ -59,7 +59,7 @@ export function ResumeBookHiddenField({
           value="0"
         />
       </Radio.Group>
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -68,7 +68,7 @@ export function ResumeBookNameField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description={`Please don't add "Resume Book" to the title. Example: Spring '24`}
       error={error}
       label="Name"
@@ -81,7 +81,7 @@ export function ResumeBookNameField({
         name={keys.name}
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }
 
@@ -90,7 +90,7 @@ export function ResumeBookStartDateField({
   error,
 }: Omit<FieldProps<string>, 'name'>) {
   return (
-    <Form.Field
+    <FormField
       description="The date that the resume book should start accepting responses."
       error={error}
       label="Start Date"
@@ -104,6 +104,6 @@ export function ResumeBookStartDateField({
         type="date"
         required
       />
-    </Form.Field>
+    </FormField>
   );
 }

--- a/packages/ui/src/components/dashboard.tsx
+++ b/packages/ui/src/components/dashboard.tsx
@@ -1,8 +1,8 @@
 import {
+  Form,
   Link,
   type LinkProps,
   NavLink,
-  Form as RemixForm,
   useSubmit,
 } from '@remix-run/react';
 import React, {
@@ -87,12 +87,12 @@ const itemClassName = cx(
 
 Dashboard.LogoutForm = function LogoutForm() {
   return (
-    <RemixForm action="/logout" className="mt-auto w-full" method="post">
+    <Form action="/logout" className="mt-auto w-full" method="post">
       <button className={cx(itemClassName, 'hover:text-primary')} type="submit">
         <LogOut />
         Log Out
       </button>
-    </RemixForm>
+    </Form>
   );
 };
 
@@ -203,7 +203,7 @@ Dashboard.SearchForm = function SearchForm({
   }, [delayedSearch]);
 
   return (
-    <RemixForm className="w-full sm:w-auto" method="get">
+    <Form className="w-full sm:w-auto" method="get">
       <SearchBar
         defaultValue={searchParams.search}
         name="search"
@@ -211,7 +211,7 @@ Dashboard.SearchForm = function SearchForm({
         {...rest}
       />
       {children}
-    </RemixForm>
+    </Form>
   );
 };
 

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -25,7 +25,7 @@ type FormFieldProps = {
   required?: boolean;
 };
 
-Form.Field = function FormField({
+export function FormField({
   children,
   description,
   error,
@@ -65,7 +65,7 @@ Form.Field = function FormField({
       {error && <p className="mt-2 text-red-600">{error}</p>}
     </div>
   );
-};
+}
 
 // Common Fields
 
@@ -74,7 +74,7 @@ type InputFieldProps = FieldProps<string> &
   Pick<InputProps, 'disabled' | 'placeholder'>;
 
 /**
- * @deprecated Instead, just compose the `Form.Field` and `Input` together.
+ * @deprecated Instead, just compose the `FormField` and `Input` together.
  */
 export function InputField({
   defaultValue,
@@ -87,7 +87,7 @@ export function InputField({
   required,
 }: InputFieldProps) {
   return (
-    <Form.Field
+    <FormField
       description={description}
       error={error}
       label={label}
@@ -102,7 +102,7 @@ export function InputField({
         placeholder={placeholder}
         required={required}
       />
-    </Form.Field>
+    </FormField>
   );
 }
 

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -23,7 +23,7 @@ type FormFieldProps = {
   required?: boolean;
 };
 
-export function FormField({
+export function Field({
   children,
   description,
   error,
@@ -72,7 +72,7 @@ type InputFieldProps = FieldProps<string> &
   Pick<InputProps, 'disabled' | 'placeholder'>;
 
 /**
- * @deprecated Instead, just compose the `FormField` and `Input` together.
+ * @deprecated Instead, just compose the `Field` and `Input` together.
  */
 export function InputField({
   defaultValue,
@@ -85,7 +85,7 @@ export function InputField({
   required,
 }: InputFieldProps) {
   return (
-    <FormField
+    <Field
       description={description}
       error={error}
       label={label}
@@ -100,7 +100,7 @@ export function InputField({
         placeholder={placeholder}
         required={required}
       />
-    </FormField>
+    </Field>
   );
 }
 

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -6,15 +6,13 @@ import { Text } from './text';
 import { cx } from '../utils/cx';
 import { zodErrorMap } from '../utils/zod';
 
-export const Form = () => {};
-
-Form.ErrorMessage = function FormErrorMessage({ children }: PropsWithChildren) {
+export function ErrorMessage({ children }: PropsWithChildren) {
   return children ? (
     <Text className="whitespace-pre-wrap" color="error">
       {children}
     </Text>
   ) : null;
-};
+}
 
 type FormFieldProps = {
   children: React.ReactNode;

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -185,10 +185,6 @@ export async function validateForm<T extends z.AnyZodObject>(
 
 // Type Utilities
 
-export type DescriptionProps = {
-  description?: string | React.ReactElement;
-};
-
 export type FieldProps<T> = {
   defaultValue?: T;
   error?: string;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,7 +11,7 @@ export { Dropdown } from './components/dropdown';
 export { ExistingSearchParams } from './components/existing-search-params';
 export { MB_IN_BYTES, FileUploader } from './components/file-uploader';
 export {
-  Form,
+  ErrorMessage,
   FormField,
   getErrors,
   InputField,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,7 +12,7 @@ export { ExistingSearchParams } from './components/existing-search-params';
 export { MB_IN_BYTES, FileUploader } from './components/file-uploader';
 export {
   ErrorMessage,
-  FormField,
+  Field,
   getErrors,
   InputField,
   validateForm,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,7 +17,7 @@ export {
   InputField,
   validateForm,
 } from './components/form';
-export type { DescriptionProps, FieldProps } from './components/form';
+export type { FieldProps } from './components/form';
 export { IconButton, getIconButtonCn } from './components/icon-button';
 export {
   DollarInput,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,7 +10,13 @@ export { Divider } from './components/divider';
 export { Dropdown } from './components/dropdown';
 export { ExistingSearchParams } from './components/existing-search-params';
 export { MB_IN_BYTES, FileUploader } from './components/file-uploader';
-export { Form, getErrors, InputField, validateForm } from './components/form';
+export {
+  Form,
+  FormField,
+  getErrors,
+  InputField,
+  validateForm,
+} from './components/form';
 export type { DescriptionProps, FieldProps } from './components/form';
 export { IconButton, getIconButtonCn } from './components/icon-button';
 export {


### PR DESCRIPTION
## Description ✏️

This PR moves the `Form.Field` and `Form.ErrorMessage` components outside of the `Form` namespace so that we no longer have to rename the `Form` component that comes from Remix.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
