### PR TITLE
chore: support popover `side` prop 📦

### DIFF
--- a/packages/ui/src/components/combobox-popover.tsx
+++ b/packages/ui/src/components/combobox-popover.tsx
@@ -47,7 +47,14 @@ export function ComboboxPopoverProvider({ children }: PropsWithChildren) {
   );
 }
 
-export function ComboboxPopover({ children }: PropsWithChildren) {
+type ComboboxPopoverProps = PropsWithChildren & {
+  side?: 'bottom' | 'top';
+};
+
+export function ComboboxPopover({
+  children,
+  side = 'bottom',
+}: ComboboxPopoverProps) {
   const { popoverOpen, ref } = useComboboxPopover();
 
   const scroll = useScrollFromModal();
@@ -64,8 +71,13 @@ export function ComboboxPopover({ children }: PropsWithChildren) {
   return (
     <div
       className={cx(
-        'z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-gray-300 bg-white',
-        position === 'fixed' ? 'fixed' : 'absolute top-full w-full',
+        'z-10 max-h-60 overflow-auto rounded-lg border border-gray-300 bg-white',
+        position === 'absolute' && 'absolute w-full',
+        position === 'fixed' && 'fixed',
+        side === 'bottom' && 'mt-1',
+        side === 'bottom' && position === 'absolute' && 'top-full',
+        side === 'top' && 'mb-1',
+        side === 'top' && position === 'absolute' && 'bottom-full',
         !popoverOpen && 'hidden'
       )}
       style={{


### PR DESCRIPTION
## Description ✏️

This PR supports displaying a combobox popover's `side` positioning (ie: top or bottom).

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
