### PR TITLE
feat: notify feed channel when thread hits 100 replies 💬

### DIFF
--- a/packages/core/src/modules/slack/use-cases/add-slack-message.ts
+++ b/packages/core/src/modules/slack/use-cases/add-slack-message.ts
@@ -9,6 +9,12 @@ import { ErrorWithContext } from '@/shared/errors';
 import { retryWithBackoff } from '@/shared/utils/core';
 import { getSlackMessage } from '../services/slack-message.service';
 
+// Environment Variables
+
+const SLACK_FEED_CHANNEL_ID = process.env.SLACK_FEED_CHANNEL_ID as string;
+
+// Core
+
 type AddSlackMessageInput = GetBullJobData<'slack.message.add'>;
 
 export async function addSlackMessage(data: AddSlackMessageInput) {
@@ -205,8 +211,7 @@ async function notifyBusySlackThreadIfNecessary({
 
   const count = Number(row.count);
 
-  // We will only notify if the thread has exactly 100 replies.
-  if (count !== 100) {
+  if (count !== 100 && count !== 500) {
     return;
   }
 
@@ -215,8 +220,22 @@ async function notifyBusySlackThreadIfNecessary({
     message_ts: id,
   });
 
-  job('notification.slack.send', {
-    message: `🚨 Heads up! This <${permalink}|thread> has over 💯 replies!`,
-    workspace: 'internal',
-  });
+  if (count === 100) {
+    job('notification.slack.send', {
+      channel: SLACK_FEED_CHANNEL_ID,
+      message: `This <${permalink}|thread> hit 100 replies! 👀`,
+      workspace: 'regular',
+    });
+
+    return;
+  }
+
+  if (count === 500) {
+    job('notification.slack.send', {
+      message: `This <${permalink}|thread> hit 500 replies! 🚨`,
+      workspace: 'internal',
+    });
+
+    return;
+  }
 }


### PR DESCRIPTION
## Description ✏️

This PR:
- Sends a notification to the `#feed` channel when a thread hits 100 replies.
- Updates the internal notification when a thread hits 500 replies.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
