### PR TITLE
refactor: use `Slot` component instead of `getButtonCn` 🔄

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
@@ -10,9 +10,9 @@ import { generatePath } from 'react-router';
 
 import { listFeatureFlags } from '@oyster/core/admin-dashboard/server';
 import {
+  Button,
   Dashboard,
   Dropdown,
-  getButtonCn,
   Pill,
   Table,
   type TableColumnProps,
@@ -39,9 +39,11 @@ export default function FeatureFlagsPage() {
       <div className="flex items-center justify-between gap-4">
         <Dashboard.Title>Feature Flags</Dashboard.Title>
 
-        <Link className={getButtonCn({})} to={Route['/feature-flags/create']}>
-          <Plus size={16} /> Create Flag
-        </Link>
+        <Button.Slot>
+          <Link to={Route['/feature-flags/create']}>
+            <Plus size={16} /> Create Flag
+          </Link>
+        </Button.Slot>
       </div>
 
       <FeatureFlagsTable />

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
@@ -15,9 +15,9 @@ import { ListSearchParams } from '@oyster/core/admin-dashboard/ui';
 import { db } from '@oyster/db';
 import {
   ACCENT_COLORS,
+  Button,
   Dashboard,
   Dropdown,
-  getButtonCn,
   Pagination,
   Pill,
   type PillProps,
@@ -139,12 +139,11 @@ export default function OnboardingSessionsPage() {
 
 function UploadOnboardingSessionButton() {
   return (
-    <Link
-      to={Route['/onboarding-sessions/upload']}
-      className={getButtonCn({ variant: 'primary' })}
-    >
-      <Plus size={16} /> Upload Session
-    </Link>
+    <Button.Slot variant="primary">
+      <Link to={Route['/onboarding-sessions/upload']}>
+        <Plus size={16} /> Upload Session
+      </Link>
+    </Button.Slot>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.companies.tsx
+++ b/apps/member-profile/app/routes/_profile.companies.tsx
@@ -21,10 +21,10 @@ import {
 import { listCompanies } from '@oyster/core/employment/server';
 import { track } from '@oyster/core/mixpanel';
 import {
+  Button,
   cx,
   Dashboard,
   ExistingSearchParams,
-  getButtonCn,
   getTextCn,
   Pagination,
   Select,
@@ -111,15 +111,16 @@ function AddReviewLink() {
   const [searchParams] = useSearchParams();
 
   return (
-    <Link
-      className={getButtonCn({ size: 'small' })}
-      to={{
-        pathname: Route['/companies/reviews/add'],
-        search: searchParams.toString(),
-      }}
-    >
-      <Plus size={20} /> Add Review
-    </Link>
+    <Button.Slot size="small">
+      <Link
+        to={{
+          pathname: Route['/companies/reviews/add'],
+          search: searchParams.toString(),
+        }}
+      >
+        <Plus size={20} /> Add Review
+      </Link>
+    </Button.Slot>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -7,7 +7,7 @@ import { generatePath, Link, Outlet, useLoaderData } from '@remix-run/react';
 import { ExternalLink } from 'react-feather';
 
 import { getCompany } from '@oyster/core/employment/server';
-import { getButtonCn, Text } from '@oyster/ui';
+import { Button, Text } from '@oyster/ui';
 import {
   Tooltip,
   TooltipContent,
@@ -196,15 +196,16 @@ function OpportunitiesAlert() {
           : `${opportunities} open opportunities found.`}
       </Text>
 
-      <Link
-        className={getButtonCn({ size: 'small' })}
-        to={{
-          pathname: Route['/opportunities'],
-          search: `?company=${company.id}`,
-        }}
-      >
-        View
-      </Link>
+      <Button.Slot size="small">
+        <Link
+          to={{
+            pathname: Route['/opportunities'],
+            search: `?company=${company.id}`,
+          }}
+        >
+          View
+        </Link>
+      </Button.Slot>
     </div>
   );
 }

--- a/apps/member-profile/app/routes/_profile.directory.join._index.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join._index.tsx
@@ -2,7 +2,7 @@ import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Link } from '@remix-run/react';
 import { ArrowRight } from 'react-feather';
 
-import { Button, getButtonCn, Modal } from '@oyster/ui';
+import { Button, Modal } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ensureUserAuthenticated } from '@/shared/session.server';
@@ -24,12 +24,11 @@ export default function JoinDirectoryIntroduction() {
       </Modal.Description>
 
       <Button.Group>
-        <Link
-          className={getButtonCn({ variant: 'primary' })}
-          to={Route['/directory/join/1']}
-        >
-          Get Started <ArrowRight size={20} />
-        </Link>
+        <Button.Slot variant="primary">
+          <Link to={Route['/directory/join/1']}>
+            Get Started <ArrowRight size={20} />
+          </Link>
+        </Button.Slot>
       </Button.Group>
     </>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.finish.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.finish.tsx
@@ -2,7 +2,7 @@ import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { generatePath, Link, useLoaderData } from '@remix-run/react';
 import { ArrowRight, Eye } from 'react-feather';
 
-import { Button, getButtonCn, Text } from '@oyster/ui';
+import { Button, Text } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ensureUserAuthenticated, user } from '@/shared/session.server';
@@ -30,19 +30,17 @@ export default function DirectoryJoinedConfirmation() {
       </div>
 
       <Button.Group spacing="center">
-        <Link
-          className={getButtonCn({ variant: 'secondary' })}
-          to={Route['/directory']}
-        >
-          <ArrowRight size={20} /> Explore the Directory
-        </Link>
+        <Button.Slot variant="secondary">
+          <Link to={Route['/directory']}>
+            <ArrowRight size={20} /> Explore the Directory
+          </Link>
+        </Button.Slot>
 
-        <Link
-          className={getButtonCn({ variant: 'primary' })}
-          to={generatePath(Route['/directory/:id'], { id: memberId })}
-        >
-          <Eye size={20} /> Preview My Profile
-        </Link>
+        <Button.Slot variant="primary">
+          <Link to={generatePath(Route['/directory/:id'], { id: memberId })}>
+            <Eye size={20} /> Preview My Profile
+          </Link>
+        </Button.Slot>
       </Button.Group>
     </div>
   );

--- a/apps/member-profile/app/routes/_profile.directory.join.tsx
+++ b/apps/member-profile/app/routes/_profile.directory.join.tsx
@@ -4,7 +4,7 @@ import { type PropsWithChildren } from 'react';
 import { ArrowLeft, ArrowRight, Check } from 'react-feather';
 import { match } from 'ts-pattern';
 
-import { Button, cx, getButtonCn, Modal, Text } from '@oyster/ui';
+import { Button, cx, Modal, Text } from '@oyster/ui';
 
 import { Route } from '@/shared/constants';
 import { ensureUserAuthenticated } from '@/shared/session.server';
@@ -123,9 +123,11 @@ export function JoinDirectoryBackButton({
     | (typeof Route)['/directory/join/3'];
 }>) {
   return (
-    <Link to={to} className={getButtonCn({ variant: 'secondary' })}>
-      <ArrowLeft size={20} /> {children}
-    </Link>
+    <Button.Slot variant="secondary">
+      <Link to={to}>
+        <ArrowLeft size={20} /> {children}
+      </Link>
+    </Button.Slot>
   );
 }
 

--- a/apps/member-profile/app/routes/_profile.directory_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.directory_.$id.tsx
@@ -15,13 +15,7 @@ import {
 } from '@oyster/core/member-profile/server';
 import { WorkExperienceItem } from '@oyster/core/member-profile/ui';
 import { type MixpanelEvent } from '@oyster/core/mixpanel';
-import {
-  cx,
-  getButtonCn,
-  ProfilePicture,
-  Text,
-  type TextProps,
-} from '@oyster/ui';
+import { Button, cx, ProfilePicture, Text, type TextProps } from '@oyster/ui';
 
 import { Card } from '@/shared/components/card';
 import { EducationExperienceItem } from '@/shared/components/education-experience';
@@ -198,23 +192,24 @@ function MemberHeader() {
       />
 
       {!!member.slackUrl && (
-        <a
-          // TODO: Move this button style to `ui`.
-          className={cx(
-            getButtonCn({ size: 'small', variant: 'secondary' }),
-            'border-gray-300 text-black hover:bg-gray-100 active:bg-gray-200'
-          )}
-          href={member.slackUrl}
-          onClick={() => {
-            trackFromClient({
-              event: 'Directory - CTA Clicked',
-              properties: { CTA: 'Slack' },
-            });
-          }}
+        <Button.Slot
+          className="border-gray-300 text-black hover:bg-gray-100 active:bg-gray-200"
+          size="small"
+          variant="secondary"
         >
-          <img alt="Slack Logo" className="h-5 w-5" src="/images/slack.svg" />{' '}
-          DM on Slack
-        </a>
+          <a
+            href={member.slackUrl}
+            onClick={() => {
+              trackFromClient({
+                event: 'Directory - CTA Clicked',
+                properties: { CTA: 'Slack' },
+              });
+            }}
+          >
+            <img alt="Slack Logo" className="h-5 w-5" src="/images/slack.svg" />{' '}
+            DM on Slack
+          </a>
+        </Button.Slot>
       )}
     </header>
   );

--- a/apps/member-profile/app/routes/_profile.events.past.tsx
+++ b/apps/member-profile/app/routes/_profile.events.past.tsx
@@ -8,7 +8,7 @@ import { sql } from 'kysely';
 import { Video } from 'react-feather';
 
 import { db } from '@oyster/db';
-import { cx, getButtonCn, ProfilePicture } from '@oyster/ui';
+import { Button, ProfilePicture } from '@oyster/ui';
 
 import {
   EventDate,
@@ -147,16 +147,16 @@ function PastEventItem({ event }: PastEventItemProps) {
           />
         )}
 
-        <a
-          className={cx(
-            getButtonCn({ fill: true, size: 'small', variant: 'secondary' }),
-            !event.recordingLink && 'invisible'
-          )}
-          href={event.recordingLink || undefined}
-          target="_blank"
+        <Button.Slot
+          className={!event.recordingLink && 'invisible'}
+          fill
+          size="small"
+          variant="secondary"
         >
-          View Recording <Video />
-        </a>
+          <a href={event.recordingLink || undefined} target="_blank">
+            View Recording <Video />
+          </a>
+        </Button.Slot>
       </div>
     </li>
   );

--- a/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
+++ b/apps/member-profile/app/routes/_profile.events.upcoming.$id.register.tsx
@@ -10,7 +10,7 @@ import { Calendar, Check, ExternalLink } from 'react-feather';
 import { job } from '@oyster/core/bull';
 import { getEvent } from '@oyster/core/member-profile/server';
 import { db } from '@oyster/db';
-import { Button, getButtonCn, Modal, Text } from '@oyster/ui';
+import { Button, Modal, Text } from '@oyster/ui';
 
 import { formatEventDate } from '@/shared/components/event';
 import { Route } from '@/shared/constants';
@@ -144,13 +144,11 @@ export default function EventRegisterPage() {
       <Form className="form" method="post">
         <Button.Group>
           {event.externalLink && (
-            <a
-              className={getButtonCn({ variant: 'secondary' })}
-              href={event.externalLink}
-              target="_blank"
-            >
-              <ExternalLink className="h-5 w-5" /> See Details
-            </a>
+            <Button.Slot variant="secondary">
+              <a href={event.externalLink} target="_blank">
+                <ExternalLink className="h-5 w-5" /> See Details
+              </a>
+            </Button.Slot>
           )}
 
           {!event.isRegistered && (

--- a/apps/member-profile/app/routes/_profile.events.upcoming.tsx
+++ b/apps/member-profile/app/routes/_profile.events.upcoming.tsx
@@ -9,7 +9,7 @@ import { Check, CheckCircle, ExternalLink } from 'react-feather';
 import { generatePath } from 'react-router';
 
 import { db } from '@oyster/db';
-import { Button, getButtonCn, ProfilePicture, Text } from '@oyster/ui';
+import { Button, ProfilePicture, Text } from '@oyster/ui';
 
 import {
   EventDate,
@@ -177,17 +177,11 @@ function UpcomingEventItem({ event }: UpcomingEventItemProps) {
 
         <Button.Group fill>
           {event.externalLink && (
-            <a
-              className={getButtonCn({
-                fill: true,
-                size: 'small',
-                variant: 'secondary',
-              })}
-              href={event.externalLink}
-              target="_blank"
-            >
-              <ExternalLink className="h-5 w-5 text-primary" /> See Details
-            </a>
+            <Button.Slot fill size="small" variant="secondary">
+              <a href={event.externalLink} target="_blank">
+                <ExternalLink className="h-5 w-5 text-primary" /> See Details
+              </a>
+            </Button.Slot>
           )}
 
           {!event.isRegistered && <RegisterButton id={event.id} />}
@@ -244,11 +238,10 @@ function RegisteredStatus({ registered }: { registered: boolean }) {
 
 function RegisterButton({ id }: Pick<UpcomingEvent, 'id'>) {
   return (
-    <Link
-      className={getButtonCn({ fill: true, size: 'small' })}
-      to={generatePath(Route['/events/upcoming/:id/register'], { id })}
-    >
-      <Check className="h-5 w-5 text-white" /> Register
-    </Link>
+    <Button.Slot fill size="small">
+      <Link to={generatePath(Route['/events/upcoming/:id/register'], { id })}>
+        <Check size={20} /> Register
+      </Link>
+    </Button.Slot>
   );
 }

--- a/apps/member-profile/app/routes/_profile.home.tsx
+++ b/apps/member-profile/app/routes/_profile.home.tsx
@@ -26,7 +26,7 @@ import {
   StudentActiveStatus,
   Timezone,
 } from '@oyster/types';
-import { Button, cx, Divider, getButtonCn, Text } from '@oyster/ui';
+import { Button, cx, Divider, Text } from '@oyster/ui';
 import { toTitleCase } from '@oyster/utils';
 
 import { Card, type CardProps } from '@/shared/components/card';
@@ -365,13 +365,14 @@ function OnboardingSessionCard() {
       </Card.Description>
 
       <Button.Group>
-        <a
-          className={getButtonCn({ size: 'small', variant: 'primary' })}
-          href="https://calendly.com/colorstack-onboarding-ambassador/onboarding"
-          target="_blank"
-        >
-          Book Onboarding Session <ExternalLink size={20} />
-        </a>
+        <Button.Slot size="small" variant="primary">
+          <Link
+            target="_blank"
+            to="https://calendly.com/colorstack-onboarding-ambassador/onboarding"
+          >
+            Book Onboarding Session <ExternalLink size={20} />
+          </Link>
+        </Button.Slot>
       </Button.Group>
     </Card>
   );
@@ -392,12 +393,9 @@ function ActivationCard() {
       </Card.Description>
 
       <Button.Group>
-        <Link
-          className={getButtonCn({ size: 'small', variant: 'primary' })}
-          to={Route['/home/activation']}
-        >
-          See Progress
-        </Link>
+        <Button.Slot size="small" variant="primary">
+          <Link to={Route['/home/activation']}>See Progress</Link>
+        </Button.Slot>
       </Button.Group>
     </Card>
   );
@@ -637,13 +635,11 @@ function MerchStoreCard() {
       </ul>
 
       <Button.Group>
-        <a
-          href="https://colorstackmerch.org"
-          target="_blank"
-          className={getButtonCn({ variant: 'primary' })}
-        >
-          Shop Now <ExternalLink size={20} />
-        </a>
+        <Button.Slot variant="primary">
+          <a href="https://colorstackmerch.org" target="_blank">
+            Shop Now <ExternalLink size={20} />
+          </a>
+        </Button.Slot>
       </Button.Group>
     </Card>
   );

--- a/apps/member-profile/app/routes/_profile.offers.full-time.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.full-time.$id_.edit.tsx
@@ -33,7 +33,6 @@ import {
   Button,
   Divider,
   ErrorMessage,
-  getButtonCn,
   getErrors,
   Modal,
   validateForm,
@@ -236,12 +235,13 @@ export default function EditFullTimeOffer() {
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit>Save</Button.Submit>
 
-          <Link
-            className={getButtonCn({ color: 'error', variant: 'secondary' })}
-            to={generatePath(Route['/offers/full-time/:id/delete'], { id })}
-          >
-            Delete
-          </Link>
+          <Button.Slot color="error" variant="secondary">
+            <Link
+              to={generatePath(Route['/offers/full-time/:id/delete'], { id })}
+            >
+              Delete
+            </Link>
+          </Button.Slot>
         </Button.Group>
       </Form>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.offers.internships.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.offers.internships.$id_.edit.tsx
@@ -33,7 +33,6 @@ import {
   Button,
   Divider,
   ErrorMessage,
-  getButtonCn,
   getErrors,
   Modal,
   validateForm,
@@ -215,12 +214,13 @@ export default function EditInternshipOffer() {
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit>Save</Button.Submit>
 
-          <Link
-            className={getButtonCn({ color: 'error', variant: 'secondary' })}
-            to={generatePath(Route['/offers/internships/:id/delete'], { id })}
-          >
-            Delete
-          </Link>
+          <Button.Slot color="error" variant="secondary">
+            <Link
+              to={generatePath(Route['/offers/internships/:id/delete'], { id })}
+            >
+              Delete
+            </Link>
+          </Button.Slot>
         </Button.Group>
       </Form>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id_.edit.tsx
@@ -24,7 +24,6 @@ import {
   DatePicker,
   ErrorMessage,
   Field,
-  getButtonCn,
   getErrors,
   Input,
   Modal,
@@ -204,14 +203,15 @@ function EditOpportunityForm() {
       <Button.Group flexDirection="row-reverse" spacing="between">
         <Button.Submit>Save</Button.Submit>
 
-        <Link
-          className={getButtonCn({ color: 'error', variant: 'secondary' })}
-          to={generatePath(Route['/opportunities/:id/delete'], {
-            id: id as string,
-          })}
-        >
-          Delete
-        </Link>
+        <Button.Slot color="error" variant="secondary">
+          <Link
+            to={generatePath(Route['/opportunities/:id/delete'], {
+              id: id as string,
+            })}
+          >
+            Delete
+          </Link>
+        </Button.Slot>
       </Button.Group>
     </Form>
   );

--- a/apps/member-profile/app/routes/_profile.opportunities.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.tsx
@@ -19,8 +19,8 @@ import { track } from '@oyster/core/mixpanel';
 import { db } from '@oyster/db';
 import {
   type AccentColor,
+  Button,
   Dashboard,
-  getButtonCn,
   Pagination,
   Pill,
   ProfilePicture,
@@ -463,15 +463,16 @@ function TagsColumn({ id, tags }: OpportunityInView) {
 
   if (!tags.length) {
     return (
-      <Link
-        className={getButtonCn({ size: 'xs', variant: 'secondary' })}
-        to={{
-          pathname: generatePath(Route['/opportunities/:id/refine'], { id }),
-          search: searchParams.toString(),
-        }}
-      >
-        Generate Tags <Zap size={16} />
-      </Link>
+      <Button.Slot size="xs" variant="secondary">
+        <Link
+          to={{
+            pathname: generatePath(Route['/opportunities/:id/refine'], { id }),
+            search: searchParams.toString(),
+          }}
+        >
+          Generate Tags <Zap size={16} />
+        </Link>
+      </Button.Slot>
     );
   }
 

--- a/apps/member-profile/app/routes/_profile.points.tsx
+++ b/apps/member-profile/app/routes/_profile.points.tsx
@@ -28,7 +28,6 @@ import { db } from '@oyster/db';
 import {
   Button,
   cx,
-  getButtonCn,
   Link,
   Pill,
   Select,
@@ -439,15 +438,14 @@ function ActivityHistory() {
           </ul>
 
           {completedActivities.length < totalActivitiesCompleted && (
-            <RemixLink
-              className={cx(
-                getButtonCn({ variant: 'secondary' }),
-                'mx-auto mt-8 w-[50%] min-w-[10rem]'
-              )}
-              to={{ search: searchParams.toString() }}
+            <Button.Slot
+              className="mx-auto mt-8 w-[50%] min-w-[10rem]"
+              variant="secondary"
             >
-              Show {increaseLimitBy} More
-            </RemixLink>
+              <RemixLink to={{ search: searchParams.toString() }}>
+                Show {increaseLimitBy} More
+              </RemixLink>
+            </Button.Slot>
           )}
         </>
       ) : (
@@ -466,19 +464,17 @@ function ActivityHistory() {
                   </Text>
 
                   <Button.Group>
-                    <RemixLink
-                      to={Route['/profile/education/add']}
-                      className={getButtonCn({ variant: 'secondary' })}
-                    >
-                      <Plus /> Add Education
-                    </RemixLink>
+                    <Button.Slot variant="secondary">
+                      <RemixLink to={Route['/profile/education/add']}>
+                        <Plus /> Add Education
+                      </RemixLink>
+                    </Button.Slot>
 
-                    <RemixLink
-                      to={Route['/profile/work/add']}
-                      className={getButtonCn({ variant: 'secondary' })}
-                    >
-                      <Plus /> Add Work Experience
-                    </RemixLink>
+                    <Button.Slot variant="secondary">
+                      <RemixLink to={Route['/profile/work/add']}>
+                        <Plus /> Add Work Experience
+                      </RemixLink>
+                    </Button.Slot>
                   </Button.Group>
                 </>
               );

--- a/apps/member-profile/app/routes/_profile.profile.referrals.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.referrals.tsx
@@ -6,7 +6,7 @@ import { match } from 'ts-pattern';
 import { ApplicationRejectionReason } from '@oyster/core/applications/types';
 import { listReferrals } from '@oyster/core/referrals';
 import { type ReferralStatus } from '@oyster/core/referrals/ui';
-import { Button, getButtonCn, Pill, Text } from '@oyster/ui';
+import { Button, Pill, Text } from '@oyster/ui';
 import {
   Tooltip,
   TooltipContent,
@@ -99,12 +99,11 @@ export default function Referrals() {
 
           {!!referrals.length && (
             <Button.Group>
-              <Link
-                className={getButtonCn({ size: 'small' })}
-                to={Route['/profile/referrals/add']}
-              >
-                <Send size={20} /> Refer a Friend
-              </Link>
+              <Button.Slot size="small">
+                <Link to={Route['/profile/referrals/add']}>
+                  <Send size={20} /> Refer a Friend
+                </Link>
+              </Button.Slot>
             </Button.Group>
           )}
         </ProfileHeader>
@@ -155,12 +154,9 @@ export default function Referrals() {
               accepted. You'll also earn points for each successful referral!
             </ProfileDescription>
 
-            <Link
-              className={getButtonCn({ fill: true, size: 'small' })}
-              to={Route['/profile/referrals/add']}
-            >
-              Refer a Friend
-            </Link>
+            <Button.Slot fill size="small">
+              <Link to={Route['/profile/referrals/add']}>Refer a Friend</Link>
+            </Button.Slot>
           </EmptyStateContainer>
         )}
       </ProfileSection>

--- a/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
@@ -23,7 +23,6 @@ import {
   Button,
   Divider,
   ErrorMessage,
-  getButtonCn,
   getErrors,
   Modal,
   validateForm,
@@ -177,14 +176,15 @@ export default function EditResourceModal() {
         <Button.Group flexDirection="row-reverse" spacing="between">
           <Button.Submit>Save</Button.Submit>
 
-          <Link
-            className={getButtonCn({ color: 'error', variant: 'secondary' })}
-            to={generatePath(Route['/resources/:id/delete'], {
-              id: resource.id,
-            })}
-          >
-            Delete
-          </Link>
+          <Button.Slot color="error" variant="secondary">
+            <Link
+              to={generatePath(Route['/resources/:id/delete'], {
+                id: resource.id,
+              })}
+            >
+              Delete
+            </Link>
+          </Button.Slot>
         </Button.Group>
       </Form>
     </Modal>

--- a/apps/member-profile/app/routes/_profile.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.tsx
@@ -22,9 +22,9 @@ import { listResources, listTags } from '@oyster/core/resources/server';
 import { getPresignedURL } from '@oyster/core/s3';
 import { ISO8601Date } from '@oyster/types';
 import {
+  Button,
   Dashboard,
   ExistingSearchParams,
-  getButtonCn,
   Pagination,
   Pill,
   Select,
@@ -240,15 +240,16 @@ function AddResourceLink() {
   const [searchParams] = useSearchParams();
 
   return (
-    <Link
-      className={getButtonCn({ size: 'small' })}
-      to={{
-        pathname: Route['/resources/add'],
-        search: searchParams.toString(),
-      }}
-    >
-      <Plus size={20} /> Add Resource
-    </Link>
+    <Button.Slot size="small">
+      <Link
+        to={{
+          pathname: Route['/resources/add'],
+          search: searchParams.toString(),
+        }}
+      >
+        <Plus size={20} /> Add Resource
+      </Link>
+    </Button.Slot>
   );
 }
 

--- a/apps/member-profile/app/shared/components/offer.tsx
+++ b/apps/member-profile/app/shared/components/offer.tsx
@@ -2,7 +2,7 @@ import { Link, useLocation, useSearchParams } from '@remix-run/react';
 import { type PropsWithChildren } from 'react';
 import { Edit, Info, Plus } from 'react-feather';
 
-import { getButtonCn, getIconButtonCn, Text } from '@oyster/ui';
+import { Button, getIconButtonCn, Text } from '@oyster/ui';
 import {
   Tooltip,
   TooltipContent,
@@ -24,15 +24,16 @@ export function AddOfferButton() {
     : Route['/offers/full-time/add'];
 
   return (
-    <Link
-      className={getButtonCn({ size: 'small' })}
-      to={{
-        pathname,
-        search: searchParams.toString(),
-      }}
-    >
-      <Plus size={20} /> Add Offer
-    </Link>
+    <Button.Slot size="small">
+      <Link
+        to={{
+          pathname,
+          search: searchParams.toString(),
+        }}
+      >
+        <Plus size={20} /> Add Offer
+      </Link>
+    </Button.Slot>
   );
 }
 

--- a/apps/member-profile/app/shared/components/slack-message.tsx
+++ b/apps/member-profile/app/shared/components/slack-message.tsx
@@ -3,13 +3,7 @@ import React from 'react';
 import parseSlackMessage, { type Node, NodeType } from 'slack-message-parser';
 import { match } from 'ts-pattern';
 
-import {
-  cx,
-  getButtonCn,
-  ProfilePicture,
-  Text,
-  type TextProps,
-} from '@oyster/ui';
+import { Button, cx, ProfilePicture, Text, type TextProps } from '@oyster/ui';
 
 import { Card } from '@/shared/components/card';
 
@@ -56,17 +50,23 @@ export function SlackMessageCard({
         </div>
 
         {channelId && messageId && (
-          <Link
-            className={cx(
-              getButtonCn({ size: 'small', variant: 'secondary' }),
-              'border-gray-300 text-black hover:bg-gray-100 active:bg-gray-200'
-            )}
-            target="_blank"
-            to={SLACK_WORKSPACE_URL + `/archives/${channelId}/p${messageId}`}
+          <Button.Slot
+            className="border-gray-300 text-black hover:bg-gray-100 active:bg-gray-200"
+            size="small"
+            variant="secondary"
           >
-            <img alt="Slack Logo" className="h-5 w-5" src="/images/slack.svg" />{' '}
-            View in Slack
-          </Link>
+            <Link
+              target="_blank"
+              to={SLACK_WORKSPACE_URL + `/archives/${channelId}/p${messageId}`}
+            >
+              <img
+                alt="Slack Logo"
+                className="h-5 w-5"
+                src="/images/slack.svg"
+              />{' '}
+              View in Slack
+            </Link>
+          </Button.Slot>
         )}
       </header>
 
@@ -186,16 +186,18 @@ export function ViewInSlackButton({
   }
 
   return (
-    <Link
-      className={cx(
-        getButtonCn({ size: 'small', variant: 'secondary' }),
-        'border-gray-300 text-black hover:bg-gray-100 active:bg-gray-200'
-      )}
-      target="_blank"
-      to={SLACK_WORKSPACE_URL + `/archives/${channelId}/p${messageId}`}
+    <Button.Slot
+      className="border-gray-300 text-black hover:bg-gray-100 active:bg-gray-200"
+      size="small"
+      variant="secondary"
     >
-      <img alt="Slack Logo" className="h-5 w-5" src="/images/slack.svg" /> View
-      in Slack
-    </Link>
+      <Link
+        target="_blank"
+        to={SLACK_WORKSPACE_URL + `/archives/${channelId}/p${messageId}`}
+      >
+        <img alt="Slack Logo" className="h-5 w-5" src="/images/slack.svg" />{' '}
+        View in Slack
+      </Link>
+    </Button.Slot>
   );
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.1.2",
+    "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.0.7"
   },
   "devDependencies": {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -4,7 +4,7 @@ import React, { type PropsWithChildren } from 'react';
 import { match } from 'ts-pattern';
 
 import { Spinner } from './spinner';
-import { cx } from '../utils/cx';
+import { type ClassName, cx } from '../utils/cx';
 
 type ButtonProps = Pick<
   React.HTMLProps<HTMLButtonElement>,
@@ -42,15 +42,25 @@ export const Button = ({
   );
 };
 
+type ButtonSlotProps = Pick<
+  ButtonProps,
+  'children' | 'color' | 'fill' | 'size' | 'variant'
+> & {
+  className?: ClassName;
+};
+
 Button.Slot = function ButtonSlot({
   children,
+  className,
   color,
   fill,
   size,
   variant,
-}: Pick<ButtonProps, 'children' | 'color' | 'fill' | 'size' | 'variant'>) {
+}: ButtonSlotProps) {
   return (
-    <Slot className={getButtonCn({ color, fill, size, variant })}>
+    <Slot
+      className={cx(getButtonCn({ color, fill, size, variant }), className)}
+    >
       {children}
     </Slot>
   );
@@ -74,7 +84,7 @@ Button.Submit = function SubmitButton(
   );
 };
 
-export function getButtonCn({
+function getButtonCn({
   color = 'primary',
   fill = false,
   size = 'regular',

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,3 +1,4 @@
+import { Slot } from '@radix-ui/react-slot';
 import { useNavigation } from '@remix-run/react';
 import React, { type PropsWithChildren } from 'react';
 import { match } from 'ts-pattern';
@@ -38,6 +39,20 @@ export const Button = ({
       {children}
       {submitting && <Spinner color={color} />}
     </button>
+  );
+};
+
+Button.Slot = function ButtonSlot({
+  children,
+  color,
+  fill,
+  size,
+  variant,
+}: Pick<ButtonProps, 'children' | 'color' | 'fill' | 'size' | 'variant'>) {
+  return (
+    <Slot className={getButtonCn({ color, fill, size, variant })}>
+      {children}
+    </Slot>
   );
 };
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,5 @@
 export { Address } from './components/address';
-export { Button, getButtonCn } from './components/button';
+export { Button } from './components/button';
 export { Checkbox } from './components/checkbox';
 export { Combobox, ComboboxInput, ComboboxItem } from './components/combobox';
 export type { ComboboxProps } from './components/combobox';

--- a/packages/ui/src/utils/cx.ts
+++ b/packages/ui/src/utils/cx.ts
@@ -1,6 +1,6 @@
 import { twMerge } from 'tailwind-merge';
 
-type ClassName = string | boolean | null | undefined;
+export type ClassName = string | boolean | null | undefined;
 
 /**
  * Returns the class names combined into one string.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2312,7 +2312,7 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
 
-"@radix-ui/react-slot@1.1.0":
+"@radix-ui/react-slot@1.1.0", "@radix-ui/react-slot@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.0.tgz#7c5e48c36ef5496d97b08f1357bb26ed7c714b84"
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==


### PR DESCRIPTION
## Description ✏️

This PR creates a `Button.Slot` component which uses Radix's utility `Slot` component to merge props onto the child. This means that we can be more declarative when trying to apply button styling to an anchor element.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
