### PR TITLE
fix: use thread id for busy thread notification ❗️

### DIFF
--- a/packages/core/src/modules/slack/use-cases/add-slack-message.ts
+++ b/packages/core/src/modules/slack/use-cases/add-slack-message.ts
@@ -63,7 +63,6 @@ export async function addSlackMessage(data: AddSlackMessageInput) {
   // We don't need to await this since it's not a critical path.
   notifyBusySlackThreadIfNecessary({
     channelId: data.channelId,
-    id: data.id,
     threadId: data.threadId,
   });
 
@@ -194,9 +193,8 @@ async function ensureThreadExistsIfNecessary(data: AddSlackMessageInput) {
  */
 async function notifyBusySlackThreadIfNecessary({
   channelId,
-  id,
   threadId,
-}: Pick<AddSlackMessageInput, 'channelId' | 'id' | 'threadId'>) {
+}: Pick<AddSlackMessageInput, 'channelId' | 'threadId'>) {
   // We only need to check the # of replies if this is a reply itself.
   if (!threadId) {
     return;
@@ -217,7 +215,7 @@ async function notifyBusySlackThreadIfNecessary({
 
   const { permalink } = await slack.chat.getPermalink({
     channel: channelId,
-    message_ts: id,
+    message_ts: threadId,
   });
 
   if (count === 100) {


### PR DESCRIPTION
## Description ✏️

This PR fixes a small bug that uses the ID of the reply for the "busy thread notification" instead of the ID of the thread.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
