### PR TITLE
fix: don't process google form posting as opportunities ❗️

### DIFF
--- a/packages/core/src/modules/opportunities.ts
+++ b/packages/core/src/modules/opportunities.ts
@@ -146,11 +146,12 @@ async function createOpportunity({
     return success({});
   }
 
-  const isLinkedInURL = link.includes('linkedin.com');
+  const isProtectedURL =
+    link.includes('docs.google.com') || link.includes('linkedin.com');
 
   let websiteContent = '';
 
-  if (!isLinkedInURL) {
+  if (!isProtectedURL) {
     websiteContent = await getPageContent(link);
   }
 
@@ -170,10 +171,10 @@ async function createOpportunity({
     .onConflict((oc) => oc.doNothing())
     .executeTakeFirstOrThrow();
 
-  // If the link is NOT a LinkedIn job posting, we'll scrape the website content
+  // If the link is NOT a protected URL, we'll scrape the website content
   // using puppeteer, create a new "empty" opportunity, and then refine it with
   // AI using that website content.
-  if (!isLinkedInURL) {
+  if (!isProtectedURL) {
     return refineOpportunity({
       content: websiteContent.slice(0, 10_000),
       opportunityId: opportunity.id,


### PR DESCRIPTION
## Description ✏️

This PR adds `docs.google.com` to the no-list for reading the opportunity's site content w/ puppeteer.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
