### PR TITLE
fix: slow companies query ❗️

### DIFF
--- a/packages/core/src/modules/employment/queries/list-companies.ts
+++ b/packages/core/src/modules/employment/queries/list-companies.ts
@@ -68,10 +68,7 @@ export async function listCompanies<
             .as('employees');
         },
         ({ fn }) => {
-          return fn
-            .count<string>('opportunities.id')
-            .filterWhere('opportunities.expiresAt', '>', new Date())
-            .as('opportunities');
+          return fn.count<string>('opportunities.id').as('opportunities');
         },
         ({ fn }) => {
           return fn.count<string>('companyReviews.id').as('reviews');

--- a/packages/core/src/modules/employment/queries/list-companies.ts
+++ b/packages/core/src/modules/employment/queries/list-companies.ts
@@ -21,22 +21,23 @@ export async function listCompanies<
 >({ orderBy, pagination, select, where }: ListCompaniesOptions<Selection>) {
   const query = db
     .selectFrom('companies')
+    .leftJoin('opportunities', (join) => {
+      return join
+        .onRef('opportunities.companyId', '=', 'companies.id')
+        .on('opportunities.expiresAt', '>', new Date());
+    })
+    .leftJoin('workExperiences', 'workExperiences.companyId', 'companies.id')
+    .leftJoin(
+      'companyReviews',
+      'companyReviews.workExperienceId',
+      'workExperiences.id'
+    )
     .where((eb) => {
       // We only want to return companies that have at least one employee (past
       // or present) or opportunity.
       return eb.or([
-        eb.exists(() => {
-          return eb
-            .selectFrom('workExperiences')
-            .whereRef('workExperiences.companyId', '=', 'companies.id');
-        }),
-
-        eb.exists(() => {
-          return eb
-            .selectFrom('opportunities')
-            .whereRef('opportunities.companyId', '=', 'companies.id')
-            .where('opportunities.expiresAt', '>', new Date());
-        }),
+        eb('opportunities.companyId', 'is not', null),
+        eb('workExperiences.companyId', 'is not', null),
       ]);
     })
     .$if(!!where.search, (qb) => {
@@ -52,59 +53,28 @@ export async function listCompanies<
 
   const [companies, { count }] = await Promise.all([
     query
+      .groupBy('companies.id')
       .select([
         ...select,
-
-        (eb) => {
-          return eb
-            .selectFrom('workExperiences')
-            .select((eb) => {
-              return eb.fn
-                .count<string>('workExperiences.studentId')
-                .distinct()
-                .as('count');
-            })
-            .whereRef('workExperiences.companyId', '=', 'companies.id')
+        ({ fn }) => {
+          return fn<string>('round', [fn.avg('rating'), sql.lit(1)]).as(
+            'averageRating'
+          );
+        },
+        ({ fn }) => {
+          return fn
+            .count<string>('workExperiences.studentId')
+            .distinct()
             .as('employees');
         },
-
-        (eb) => {
-          return eb
-            .selectFrom('companyReviews')
-            .leftJoin(
-              'workExperiences',
-              'workExperiences.id',
-              'companyReviews.workExperienceId'
-            )
-            .select((eb) => {
-              return eb
-                .fn<string>('round', [eb.fn.avg('rating'), sql.lit(1)])
-                .as('rating');
-            })
-            .whereRef('workExperiences.companyId', '=', 'companies.id')
-            .as('averageRating');
-        },
-
-        (eb) => {
-          return eb
-            .selectFrom('opportunities')
-            .select(eb.fn.countAll<string>().as('count'))
-            .whereRef('opportunities.companyId', '=', 'companies.id')
-            .where('opportunities.expiresAt', '>', new Date())
+        ({ fn }) => {
+          return fn
+            .count<string>('opportunities.id')
+            .filterWhere('opportunities.expiresAt', '>', new Date())
             .as('opportunities');
         },
-
-        (eb) => {
-          return eb
-            .selectFrom('companyReviews')
-            .leftJoin(
-              'workExperiences',
-              'workExperiences.id',
-              'companyReviews.workExperienceId'
-            )
-            .select(eb.fn.countAll<string>().as('count'))
-            .whereRef('workExperiences.companyId', '=', 'companies.id')
-            .as('reviews');
+        ({ fn }) => {
+          return fn.count<string>('companyReviews.id').as('reviews');
         },
       ])
       .$if(!!where.search, (qb) => {
@@ -131,19 +101,8 @@ export async function listCompanies<
           })
           .with('most_recently_reviewed', () => {
             return qb
-              .select((eb) => {
-                return eb
-                  .selectFrom('companyReviews')
-                  .leftJoin(
-                    'workExperiences',
-                    'workExperiences.id',
-                    'companyReviews.workExperienceId'
-                  )
-                  .select('companyReviews.createdAt')
-                  .whereRef('workExperiences.companyId', '=', 'companies.id')
-                  .orderBy('companyReviews.createdAt', 'desc')
-                  .limit(1)
-                  .as('lastReviewedAt');
+              .select(({ fn }) => {
+                return fn.max('companyReviews.createdAt').as('lastReviewedAt');
               })
               .orderBy('lastReviewedAt', sql`desc nulls last`);
           })
@@ -154,7 +113,9 @@ export async function listCompanies<
       .execute(),
 
     query
-      .select((eb) => eb.fn.countAll<string>().as('count'))
+      .select(({ fn }) => {
+        return fn.count<string>('companies.id').distinct().as('count');
+      })
       .executeTakeFirstOrThrow(),
   ]);
 

--- a/packages/core/src/modules/employment/queries/list-companies.ts
+++ b/packages/core/src/modules/employment/queries/list-companies.ts
@@ -53,7 +53,6 @@ export async function listCompanies<
 
   const [companies, { count }] = await Promise.all([
     query
-      .groupBy('companies.id')
       .select([
         ...select,
         ({ fn }) => {
@@ -68,12 +67,16 @@ export async function listCompanies<
             .as('employees');
         },
         ({ fn }) => {
-          return fn.count<string>('opportunities.id').as('opportunities');
+          return fn
+            .count<string>('opportunities.id')
+            .distinct()
+            .as('opportunities');
         },
         ({ fn }) => {
-          return fn.count<string>('companyReviews.id').as('reviews');
+          return fn.count<string>('companyReviews.id').distinct().as('reviews');
         },
       ])
+      .groupBy('companies.id')
       .$if(!!where.search, (qb) => {
         // If we have a search term, we want to order by the similarity of the
         // company name to the search term.

--- a/packages/core/src/modules/slack/use-cases/add-slack-message.ts
+++ b/packages/core/src/modules/slack/use-cases/add-slack-message.ts
@@ -209,7 +209,7 @@ async function notifyBusySlackThreadIfNecessary({
 
   const count = Number(row.count);
 
-  if (count !== 100 && count !== 500) {
+  if (count !== 250 && count !== 500) {
     return;
   }
 
@@ -218,10 +218,10 @@ async function notifyBusySlackThreadIfNecessary({
     message_ts: threadId,
   });
 
-  if (count === 100) {
+  if (count === 250) {
     job('notification.slack.send', {
       channel: SLACK_FEED_CHANNEL_ID,
-      message: `This <${permalink}|thread> hit 100 replies! 👀`,
+      message: `This <${permalink}|thread> hit 250 replies! 👀`,
       workspace: 'regular',
     });
 


### PR DESCRIPTION
## Description ✏️

Closes CS-194.

Converts the `listCompanies` query to use joins instead of subqueries.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
