### PR TITLE
fix: don't show unrefined (empty) opportunities 🫣

### DIFF
--- a/apps/member-profile/app/routes/_profile.opportunities.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id.tsx
@@ -184,11 +184,11 @@ function OpportunityDescription() {
 
 function OpportunitySlackMessage() {
   const {
-    id,
     posterFirstName,
     posterLastName,
     posterProfilePicture,
     slackMessageChannelId,
+    slackMessageId,
     slackMessagePostedAt,
     slackMessageText,
   } = useLoaderData<typeof loader>();
@@ -196,7 +196,7 @@ function OpportunitySlackMessage() {
   return (
     <SlackMessageCard
       channelId={slackMessageChannelId || ''}
-      messageId={id}
+      messageId={slackMessageId || ''}
       postedAt={slackMessagePostedAt || ''}
       posterFirstName={posterFirstName || ''}
       posterLastName={posterLastName || ''}

--- a/apps/member-profile/app/routes/_profile.opportunities.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.tsx
@@ -187,6 +187,7 @@ async function listOpportunities(
     .selectFrom('opportunities')
     .leftJoin('companies', 'companies.id', 'opportunities.companyId')
     .where('opportunities.expiresAt', '>', new Date())
+    .where('opportunities.refinedAt', 'is not', null)
     .$if(!!bookmarked, (qb) => {
       return qb.where((eb) => {
         return eb.exists(() => {

--- a/apps/member-profile/app/shared/components/index.tsx
+++ b/apps/member-profile/app/shared/components/index.tsx
@@ -58,10 +58,10 @@ export function CompanyLink({
       target="_blank"
       to={generatePath(Route['/companies/:id'], { id: companyId })}
     >
-      <div className="h-8 w-8 rounded-lg border border-gray-200 p-1">
+      <div className="aspect-square h-8 w-8 rounded-lg border border-gray-200 p-1">
         <img
           alt={companyName}
-          className="aspect-square h-full w-full rounded-md object-contain"
+          className="h-full w-full rounded-md object-contain"
           src={companyLogo as string}
         />
       </div>


### PR DESCRIPTION
## Description ✏️

The opportunities board has a lot of unrefined opportunities because we are unable to parse the website and nobody has manually helped with that. In order to prevent this "empty" look, we'll just not show any opportunities that we can't refine.

This PR also fixes 2 bugs:
- The linking of the opportunity to a Slack message.
- The aspect ratio of the company logo when there is a large title.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
