### PR TITLE
feat: add `last_expiration_check` field to opportunities 🚀

### DIFF
--- a/apps/member-profile/app/routes/_profile.opportunities.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id.tsx
@@ -14,6 +14,7 @@ import { getOpportunityDetails } from '@oyster/core/opportunities';
 import { getIconButtonCn, Modal, Pill, Text } from '@oyster/ui';
 import { run } from '@oyster/utils';
 
+import { job } from '@/infrastructure/bull';
 import {
   BookmarkButton,
   BookmarkForm,
@@ -40,6 +41,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       statusText: 'The opportunity you are looking for does not exist.',
     });
   }
+
+  job('opportunity.check_expired', {
+    opportunityId,
+  });
 
   Object.assign(opportunity, {
     createdAt: dayjs().to(opportunity.createdAt),

--- a/apps/member-profile/app/routes/_profile.opportunities.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.$id.tsx
@@ -14,7 +14,6 @@ import { getOpportunityDetails } from '@oyster/core/opportunities';
 import { getIconButtonCn, Modal, Pill, Text } from '@oyster/ui';
 import { run } from '@oyster/utils';
 
-import { job } from '@/infrastructure/bull';
 import {
   BookmarkButton,
   BookmarkForm,
@@ -41,10 +40,6 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       statusText: 'The opportunity you are looking for does not exist.',
     });
   }
-
-  job('opportunity.check_expired', {
-    opportunityId,
-  });
 
   Object.assign(opportunity, {
     createdAt: dayjs().to(opportunity.createdAt),

--- a/packages/core/src/infrastructure/bull.types.ts
+++ b/packages/core/src/infrastructure/bull.types.ts
@@ -381,7 +381,13 @@ export const OpportunityBullJob = z.discriminatedUnion('name', [
   z.object({
     name: z.literal('opportunity.check_expired'),
     data: z.object({
-      opportunityId: z.string().trim().min(1).optional(),
+      opportunityId: z.string().trim().min(1),
+    }),
+  }),
+  z.object({
+    name: z.literal('opportunity.check_expired.all'),
+    data: z.object({
+      limit: z.coerce.number().catch(100),
     }),
   }),
   z.object({

--- a/packages/db/src/migrations/20250226180740_opportunity_expiration_check.ts
+++ b/packages/db/src/migrations/20250226180740_opportunity_expiration_check.ts
@@ -1,0 +1,15 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('opportunities')
+    .addColumn('last_expiration_check', 'timestamptz')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('opportunities')
+    .dropColumn('last_expiration_check')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR updates the way we do expiration checks by looking at the `last_expiration_check` field. This also separates the expiration job into 2 (one for an individual check and one for querying all opportunities). The latter now just emits an individual job instead of running the logic in its own job.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
