### PR TITLE
fix: attempt to escape bot detection on workday 🤖

### DIFF
--- a/packages/core/src/infrastructure/puppeteer.ts
+++ b/packages/core/src/infrastructure/puppeteer.ts
@@ -58,7 +58,7 @@ async function withBrowser<T>(
 
   const page = await browser.newPage();
 
-  page.setUserAgent(getUserAgent());
+  await escapeBotDetection(page);
 
   try {
     const result = await fn(browser, page);
@@ -70,6 +70,23 @@ async function withBrowser<T>(
       console.log('Closed Puppeteer browser.');
     }
   }
+}
+
+async function escapeBotDetection(page: Page) {
+  await page.setViewport({
+    deviceScaleFactor: 1,
+    height: 1080,
+    width: 1920,
+  });
+
+  await page.setUserAgent(getUserAgent());
+
+  // Add random mouse movements.
+  await page.mouse.move(
+    100 + Math.random() * 100, // x
+    100 + Math.random() * 100, // y
+    { steps: 10 }
+  );
 }
 
 const USER_AGENTS = [


### PR DESCRIPTION
## Description ✏️

This PR _potentially_ fixes an issue with bot detection when reading a webpage's content using puppeteer. Not sure if this will work in production since our IP address might have been blacklisted.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
