### PR TITLE
fix: scroll filter item into view when using keyboard 🎹

### DIFF
--- a/packages/ui/src/components/filter.tsx
+++ b/packages/ui/src/components/filter.tsx
@@ -150,7 +150,9 @@ export function FilterRoot({
       }
 
       case 'Enter': {
-        return itemRefs.current[highlightedIndexRef.current]?.click();
+        const element = itemRefs.current[highlightedIndexRef.current];
+
+        return element?.click();
       }
 
       default:
@@ -341,6 +343,20 @@ type FilterListProps = PropsWithChildren<{
 }>;
 
 export function FilterList({ children, height = 'max-h-60' }: FilterListProps) {
+  const { highlightedIndex, itemRefs } = useContext(FilterContext);
+
+  useEffect(() => {
+    if (highlightedIndex !== -1) {
+      const element = itemRefs.current[highlightedIndex];
+
+      element?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    }
+  }, [highlightedIndex]);
+
   // We clone the children so that we can pass in the `index` prop to each
   // child, taking the responsibility off of the caller to do so.
   const clonedChildren = React.Children.map(children, (child, index) => {


### PR DESCRIPTION
## Description ✏️

This PR fixes a bug which doesn't scroll the filter item into view when using the keyboard.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
