### PR TITLE
fix: scroll bug related to the filter component ❗️

### DIFF
--- a/packages/ui/src/components/filter.tsx
+++ b/packages/ui/src/components/filter.tsx
@@ -81,7 +81,9 @@ export function FilterRoot({
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   useOnClickOutside(rootRef, () => {
-    close();
+    if (open) {
+      close();
+    }
   });
 
   function close() {


### PR DESCRIPTION
## Description ✏️

This PR fixes a bug in which the scroll resets when clicking on an item within a scrolled view where the `FilterRoot` component is mounted in the same page. The issue was the `useClickOutside` hook that ran within the `FilterRoot` component.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
