### PR TITLE
fix: preserve search params when editing schools ❗️

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
@@ -259,6 +259,7 @@ function ApplicationDropdown({ id }: ApplicationInView) {
           {searchParams.status === 'pending' && (
             <Dropdown.Item>
               <Link
+                preventScrollReset
                 to={{
                   pathname: generatePath(Route['/applications/:id/email'], {
                     id,
@@ -273,6 +274,7 @@ function ApplicationDropdown({ id }: ApplicationInView) {
           {searchParams.status === 'rejected' && (
             <Dropdown.Item>
               <Link
+                preventScrollReset
                 to={{
                   pathname: generatePath(Route['/applications/:id/accept'], {
                     id,

--- a/apps/admin-dashboard/app/routes/_dashboard.events.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.events.tsx
@@ -211,23 +211,35 @@ function EventDropdown({ id, type }: EventInView) {
         <Dropdown.List>
           {type === EventType.IRL && (
             <Dropdown.Item>
-              <Link to={generatePath(Route['/events/:id/check-in'], { id })}>
+              <Link
+                preventScrollReset
+                to={generatePath(Route['/events/:id/check-in'], { id })}
+              >
                 <Camera /> Check-In QR Code
               </Link>
             </Dropdown.Item>
           )}
           <Dropdown.Item>
-            <Link to={generatePath(Route['/events/:id/import'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/events/:id/import'], { id })}
+            >
               <Upload /> Import Attendees
             </Link>
           </Dropdown.Item>
           <Dropdown.Item>
-            <Link to={generatePath(Route['/events/:id/add-recording'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/events/:id/add-recording'], { id })}
+            >
               <Upload /> Add Recording
             </Link>
           </Dropdown.Item>
           <Dropdown.Item>
-            <Link to={generatePath(Route['/events/:id/delete'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/events/:id/delete'], { id })}
+            >
               <Trash2 /> Delete Event
             </Link>
           </Dropdown.Item>

--- a/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.feature-flags.tsx
@@ -112,12 +112,18 @@ function FeatureFlagsTableDropdown({ id }: FeatureFlagInView) {
       <Table.Dropdown>
         <Dropdown.List>
           <Dropdown.Item>
-            <Link to={generatePath(Route['/feature-flags/:id/edit'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/feature-flags/:id/edit'], { id })}
+            >
               <Edit /> Edit Flag
             </Link>
           </Dropdown.Item>
           <Dropdown.Item>
-            <Link to={generatePath(Route['/feature-flags/:id/delete'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/feature-flags/:id/delete'], { id })}
+            >
               <Trash /> Delete Flag
             </Link>
           </Dropdown.Item>

--- a/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.gamification.activities.tsx
@@ -127,6 +127,7 @@ function ActivitiesTableDropdown({ id }: ActivityInView) {
         <Dropdown.List>
           <Dropdown.Item>
             <Link
+              preventScrollReset
               to={generatePath(Route['/gamification/activities/:id/edit'], {
                 id,
               })}
@@ -137,6 +138,7 @@ function ActivitiesTableDropdown({ id }: ActivityInView) {
 
           <Dropdown.Item>
             <Link
+              preventScrollReset
               to={generatePath(Route['/gamification/activities/:id/archive'], {
                 id,
               })}

--- a/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.onboarding-sessions.tsx
@@ -214,6 +214,7 @@ function OnboardingSessionsDropdown({ id }: OnboardingSessionInView) {
         <Dropdown.List>
           <Dropdown.Item>
             <Link
+              preventScrollReset
               to={generatePath(
                 Route['/onboarding-sessions/:id/add-attendees'],
                 {

--- a/apps/admin-dashboard/app/routes/_dashboard.resume-books.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.resume-books.tsx
@@ -181,7 +181,10 @@ function ResumeBookDropdown({
       <Table.Dropdown>
         <Dropdown.List>
           <Dropdown.Item>
-            <Link to={generatePath(Route['/resume-books/:id/edit'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/resume-books/:id/edit'], { id })}
+            >
               <Edit /> Edit Resume Book
             </Link>
           </Dropdown.Item>
@@ -199,13 +202,13 @@ function ResumeBookDropdown({
           </Dropdown.Item>
 
           <Dropdown.Item>
-            <Link to={airtableUri} target="_blank">
+            <Link preventScrollReset to={airtableUri} target="_blank">
               <ExternalLink /> Go to Airtable
             </Link>
           </Dropdown.Item>
 
           <Dropdown.Item>
-            <Link to={googleDriveUri} target="_blank">
+            <Link preventScrollReset to={googleDriveUri} target="_blank">
               <ExternalLink /> Go to Google Drive
             </Link>
           </Dropdown.Item>

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.$id.chapter.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.$id.chapter.create.tsx
@@ -48,7 +48,11 @@ export async function action({ params, request }: ActionFunctionArgs) {
     message: 'Created chapter.',
   });
 
-  return redirect(Route['/schools'], {
+  const url = new URL(request.url);
+
+  url.pathname = Route['/schools'];
+
+  return redirect(url.toString(), {
     headers: {
       'Set-Cookie': await commitSession(session),
     },

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.$id.edit.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.$id.edit.tsx
@@ -71,7 +71,11 @@ export async function action({ params, request }: ActionFunctionArgs) {
     message: 'Updated school.',
   });
 
-  return redirect(Route['/schools'], {
+  const url = new URL(request.url);
+
+  url.pathname = Route['/schools'];
+
+  return redirect(url.toString(), {
     headers: {
       'Set-Cookie': await commitSession(session),
     },

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.create.tsx
@@ -49,7 +49,11 @@ export async function action({ request }: ActionFunctionArgs) {
     message: 'Created school.',
   });
 
-  return redirect(Route['/schools'], {
+  const url = new URL(request.url);
+
+  url.pathname = Route['/schools'];
+
+  return redirect(url.toString(), {
     headers: {
       'Set-Cookie': await commitSession(session),
     },

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
@@ -4,7 +4,12 @@ import {
   type LoaderFunctionArgs,
   type SerializeFrom,
 } from '@remix-run/node';
-import { Link, Outlet, useLoaderData } from '@remix-run/react';
+import {
+  useSearchParams as _useSearchParams,
+  Link,
+  Outlet,
+  useLoaderData,
+} from '@remix-run/react';
 import { sql } from 'kysely';
 import { BookOpen, Edit, Menu, Plus } from 'react-feather';
 import { generatePath } from 'react-router';
@@ -219,6 +224,8 @@ function SchoolsPagination() {
 }
 
 function SchoolsTableDropdown({ chapterId, id }: SchoolInView) {
+  const [searchParams] = _useSearchParams();
+
   return (
     <Dropdown.Root>
       <Table.Dropdown>
@@ -226,7 +233,10 @@ function SchoolsTableDropdown({ chapterId, id }: SchoolInView) {
           <Dropdown.Item>
             <Link
               preventScrollReset
-              to={generatePath(Route['/schools/:id/edit'], { id })}
+              to={{
+                pathname: generatePath(Route['/schools/:id/edit'], { id }),
+                search: searchParams.toString(),
+              }}
             >
               <Edit /> Edit School
             </Link>
@@ -236,9 +246,12 @@ function SchoolsTableDropdown({ chapterId, id }: SchoolInView) {
             <Dropdown.Item>
               <Link
                 preventScrollReset
-                to={generatePath(Route['/schools/:id/chapter/create'], {
-                  id,
-                })}
+                to={{
+                  pathname: generatePath(Route['/schools/:id/chapter/create'], {
+                    id,
+                  }),
+                  search: searchParams.toString(),
+                }}
               >
                 <BookOpen /> Create Chapter
               </Link>

--- a/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.schools.tsx
@@ -224,7 +224,10 @@ function SchoolsTableDropdown({ chapterId, id }: SchoolInView) {
       <Table.Dropdown>
         <Dropdown.List>
           <Dropdown.Item>
-            <Link to={generatePath(Route['/schools/:id/edit'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/schools/:id/edit'], { id })}
+            >
               <Edit /> Edit School
             </Link>
           </Dropdown.Item>
@@ -232,6 +235,7 @@ function SchoolsTableDropdown({ chapterId, id }: SchoolInView) {
           {!chapterId && (
             <Dropdown.Item>
               <Link
+                preventScrollReset
                 to={generatePath(Route['/schools/:id/chapter/create'], {
                   id,
                 })}

--- a/apps/admin-dashboard/app/routes/_dashboard.students.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.students.tsx
@@ -210,7 +210,10 @@ function StudentDropdown({
         <Dropdown.List>
           {!activatedAt && (
             <Dropdown.Item>
-              <Link to={generatePath(Route['/students/:id/activate'], { id })}>
+              <Link
+                preventScrollReset
+                to={generatePath(Route['/students/:id/activate'], { id })}
+              >
                 <Zap /> Activate Member
               </Link>
             </Dropdown.Item>
@@ -218,6 +221,7 @@ function StudentDropdown({
 
           <Dropdown.Item>
             <Link
+              preventScrollReset
               to={generatePath(Route['/students/:id/points/grant'], { id })}
             >
               <Star /> Grant Points
@@ -225,33 +229,47 @@ function StudentDropdown({
           </Dropdown.Item>
 
           <Dropdown.Item>
-            <Link to={generatePath(Route['/students/:id/email'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/students/:id/email'], { id })}
+            >
               <Edit /> Update Email
             </Link>
           </Dropdown.Item>
 
           {applicationUri && (
             <Dropdown.Item>
-              <Link target="_blank" to={applicationUri}>
+              <Link preventScrollReset target="_blank" to={applicationUri}>
                 <CornerUpLeft /> View Application
               </Link>
             </Dropdown.Item>
           )}
 
           <Dropdown.Item>
-            <Link target="_blank" to={airtableUri} rel="noopener noreferrer">
+            <Link
+              preventScrollReset
+              target="_blank"
+              to={airtableUri}
+              rel="noopener noreferrer"
+            >
               <ExternalLink /> View Airtable Record
             </Link>
           </Dropdown.Item>
 
           <Dropdown.Item>
-            <Link to={generatePath(Route['/students/:id/gift'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/students/:id/gift'], { id })}
+            >
               <Gift /> Send Goody Gift
             </Link>
           </Dropdown.Item>
 
           <Dropdown.Item>
-            <Link to={generatePath(Route['/students/:id/remove'], { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath(Route['/students/:id/remove'], { id })}
+            >
               <Trash /> Remove Member
             </Link>
           </Dropdown.Item>

--- a/packages/core/src/modules/admins/admins.ui.tsx
+++ b/packages/core/src/modules/admins/admins.ui.tsx
@@ -145,7 +145,10 @@ function AdminDropdown({ id }: AdminInTable) {
       <Table.Dropdown>
         <Dropdown.List>
           <Dropdown.Item>
-            <Link to={generatePath('/admins/:id/remove', { id })}>
+            <Link
+              preventScrollReset
+              to={generatePath('/admins/:id/remove', { id })}
+            >
               <Trash /> Remove Admin
             </Link>
           </Dropdown.Item>


### PR DESCRIPTION
## Description ✏️

This PR fixes a bug when editing schools which didn't preserve search params and preset scroll.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
