### PR TITLE
fix: use `pathe` for kysely file migration provider ❗️

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,6 +32,7 @@
     "commander": "^12.0.0",
     "dedent": "^0.7.0",
     "kysely-codegen": "^0.10.1",
+    "pathe": "^2.0.3",
     "prisma": "^5.16.2",
     "prompt-sync": "^4.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9906,6 +9906,11 @@ pathe@^1.1.1, pathe@^1.1.2:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"


### PR DESCRIPTION
## Description ✏️

Closes #770.

This PR fixes the flakiness around Windows machines and the Kysely `FileMigrationProvider`. It seems to be working in most cases but not all. We use the most recent Kysely [recommended solution](https://github.com/kysely-org/kysely/issues/768#issuecomment-2118886520) to use the [`pathe`](https://www.npmjs.com/package/pathe) package, which normalizes all operations to use a `/` instead of `\`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
