### PR TITLE
fix: scroll issue w/ tables + fixed position of dropdown ❗️

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-portal": "^1.1.4",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",

--- a/packages/ui/src/components/dropdown.tsx
+++ b/packages/ui/src/components/dropdown.tsx
@@ -1,4 +1,5 @@
 import React, {
+  createRef,
   type PropsWithChildren,
   useContext,
   useRef,
@@ -11,6 +12,7 @@ import { cx } from '../utils/cx';
 export const DropdownContext = React.createContext({
   _initialized: false,
   open: false,
+  ref: createRef<HTMLElement>(),
   setOpen: (_: boolean) => {},
 });
 
@@ -22,7 +24,7 @@ export function useIsDropdownParent() {
 
 type DropdownProps = Pick<
   React.HTMLProps<HTMLElement>,
-  'children' | 'className'
+  'children' | 'className' | 'style'
 > & {
   align?: 'left' | 'right';
 };
@@ -31,6 +33,7 @@ export const Dropdown = ({
   align = 'right',
   children,
   className,
+  ...rest
 }: DropdownProps) => {
   const { open } = useContext(DropdownContext);
 
@@ -45,6 +48,7 @@ export const Dropdown = ({
         align === 'left' ? 'left-0' : 'right-0',
         className
       )}
+      {...rest}
     >
       {children}
     </div>
@@ -85,7 +89,14 @@ Dropdown.Root = function DropdownRoot({ children }: PropsWithChildren) {
   });
 
   return (
-    <DropdownContext.Provider value={{ _initialized: true, open, setOpen }}>
+    <DropdownContext.Provider
+      value={{
+        _initialized: true,
+        ref,
+        open,
+        setOpen,
+      }}
+    >
       <div className="relative" ref={ref}>
         {children}
       </div>

--- a/packages/ui/src/components/portal.tsx
+++ b/packages/ui/src/components/portal.tsx
@@ -1,0 +1,5 @@
+import { type PortalProps, Root } from '@radix-ui/react-portal';
+
+export function Portal(props: PortalProps) {
+  return <Root {...props} />;
+}

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,11 +1,13 @@
 import { type LinkProps, useNavigate } from '@remix-run/react';
-import React, { type PropsWithChildren } from 'react';
+import React, { type PropsWithChildren, useContext } from 'react';
 import { MoreVertical } from 'react-feather';
 import { match } from 'ts-pattern';
 
-import { Dropdown } from './dropdown';
+import { Dropdown, DropdownContext } from './dropdown';
 import { IconButton } from './icon-button';
+import { Portal } from './portal';
 import { Text } from './text';
+import { usePosition } from '../hooks/use-position';
 import { cx } from '../utils/cx';
 
 type TableData = Record<string, unknown>;
@@ -246,7 +248,19 @@ function getFilteredColumns(columns: TableProps['columns']) {
 // Dropdown
 
 Table.Dropdown = function TableDropdown({ children }: PropsWithChildren) {
-  return <Dropdown className="absolute right-10">{children}</Dropdown>;
+  const { ref } = useContext(DropdownContext);
+  const { x, y } = usePosition(ref);
+
+  return (
+    <Portal>
+      <Dropdown
+        className="fixed -ml-2 mt-[unset] -translate-x-full"
+        style={{ left: x, top: y }}
+      >
+        {children}
+      </Dropdown>
+    </Portal>
+  );
 };
 
 Table.DropdownOpenButton = function TableDropdownOpenButton() {

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -84,7 +84,7 @@ type TableProps<T extends TableData = any> = {
 
 export const Table = ({ columns, data, emptyMessage, rowTo }: TableProps) => {
   return (
-    <div className="rounded-lg border border-gray-200">
+    <div className="overflow-auto rounded-lg border border-gray-200">
       {!data.length ? (
         <div className="box-border flex w-full flex-col items-center justify-center gap-4 p-12">
           <Text>{emptyMessage}</Text>

--- a/packages/ui/src/hooks/use-position.ts
+++ b/packages/ui/src/hooks/use-position.ts
@@ -1,0 +1,44 @@
+import { type RefObject, useEffect, useState } from 'react';
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+/**
+ * Hook to track the position of an element. This takes into account the
+ * element's position relative to the viewport, as well as the scroll position
+ * of the page.
+ *
+ * @param ref - The reference to the element to track.
+ * @returns The position of the element.
+ */
+export function usePosition(ref: RefObject<HTMLElement>): Position {
+  const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const { x, y } = element.getBoundingClientRect();
+
+      setPosition({ x, y });
+    };
+
+    updatePosition();
+
+    window.addEventListener('scroll', updatePosition);
+    window.addEventListener('resize', updatePosition);
+
+    return () => {
+      window.removeEventListener('scroll', updatePosition);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [ref]);
+
+  return position;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,6 +2114,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
   integrity sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==
 
+"@radix-ui/react-compose-refs@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
+  integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
+
 "@radix-ui/react-context@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
@@ -2237,6 +2242,14 @@
     "@radix-ui/react-primitive" "2.0.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-portal@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.4.tgz#ff5401ff63c8a825c46eea96d3aef66074b8c0c8"
+  integrity sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-presence@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
@@ -2260,6 +2273,13 @@
   integrity sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
+
+"@radix-ui/react-primitive@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz#ac8b7854d87b0d7af388d058268d9a7eb64ca8ef"
+  integrity sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.2"
 
 "@radix-ui/react-progress@^1.1.0":
   version "1.1.0"
@@ -2318,6 +2338,13 @@
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+
+"@radix-ui/react-slot@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.2.tgz#daffff7b2bfe99ade63b5168407680b93c00e1c6"
+  integrity sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
 
 "@radix-ui/react-tooltip@^1.0.7":
   version "1.0.7"


### PR DESCRIPTION
## Description ✏️

This PR fixes a bug introduced in #766 where we removed the `overflow-auto` of the table container (in order to use dropdowns w/ absolute position) but now we can't scroll horizontally either. We reintroduce the `overflow-auto` but now used fixed positioning for the dropdown with additional JS logic to track the x/y coordinates of the dropdown container.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
