### PR TITLE
fix: send opportunity notification if web scraping fails ❗️

### DIFF
--- a/packages/core/src/modules/opportunities.ts
+++ b/packages/core/src/modules/opportunities.ts
@@ -330,7 +330,11 @@ async function createOpportunity({
   let websiteContent = '';
 
   if (!isProtectedURL) {
-    websiteContent = await getPageContent(link);
+    try {
+      websiteContent = await getPageContent(link);
+    } catch (e) {
+      reportException(e);
+    }
   }
 
   const opportunity = await db
@@ -359,7 +363,7 @@ async function createOpportunity({
   // If the link is NOT a protected URL, we'll scrape the website content
   // using puppeteer, create a new "empty" opportunity, and then refine it with
   // AI using that website content.
-  if (!isProtectedURL) {
+  if (websiteContent) {
     return refineOpportunity({
       content: websiteContent.slice(0, 10_000),
       opportunityId: opportunity.id,


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue where a notification would not be sent to the member who posted an opportunity if the web scraping of that opportunity failed for whatever reason.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
