### PR TITLE
fix: dropdown portal bug ❗️

### DIFF
--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -5,7 +5,6 @@ import { match } from 'ts-pattern';
 
 import { Dropdown, DropdownContext } from './dropdown';
 import { IconButton } from './icon-button';
-import { Portal } from './portal';
 import { Text } from './text';
 import { usePosition } from '../hooks/use-position';
 import { cx } from '../utils/cx';
@@ -252,14 +251,12 @@ Table.Dropdown = function TableDropdown({ children }: PropsWithChildren) {
   const { x, y } = usePosition(ref);
 
   return (
-    <Portal>
-      <Dropdown
-        className="fixed -ml-2 mt-[unset] -translate-x-full"
-        style={{ left: x, top: y }}
-      >
-        {children}
-      </Dropdown>
-    </Portal>
+    <Dropdown
+      className="fixed -ml-2 mt-[unset] -translate-x-full"
+      style={{ left: x, top: y }}
+    >
+      {children}
+    </Dropdown>
   );
 };
 


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue when using the `Table.Dropdown` component, which fails to open a modal due to the `Portal` that we're using. This was introduced in #773.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
