### PR TITLE
Feature/search slack channels

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -83,3 +83,5 @@
 - dotcomnerd
 - joolaoye
 - djblanco-code
+- aymerick116
+

--- a/packages/core/src/modules/slack/queries/list-slack-channels.ts
+++ b/packages/core/src/modules/slack/queries/list-slack-channels.ts
@@ -1,0 +1,10 @@
+import { db } from '@oyster/db';
+
+export async function listSlackChannels(search?: string) {
+  return await db
+    .selectFrom('slackChannels')
+    .selectAll()
+    .$if(!!search, (qb) => qb.where('name', 'ilike', `%${search}%`))
+    .orderBy('name', 'asc')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

Closes #743 

Describe what this PR does.

Adds a new query function to retrieve Slack channels from the database. Supports optional filtering by name with case-insensitive search.

- Implements listSlackChannels query to fetch all Slack channels.
- Supports search parameter for filtering by partial channel name.
- Uses ilike for case-insensitive matching.
- Results are ordered alphabetically by channel name.

## Type of Change 🐞

- [x ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable). 
- [ ] I have added/updated any relevant documentation (if applicable).

⚠️ Note: This is a non-breaking addition. I wasn’t able to verify the output locally due to an empty database, but the query itself should work as intended. If someone with a populated DB could give it a quick test, that would be appreciated!

