### PR TITLE
fix: preserve white space for help request description ❗️

### DIFF
--- a/apps/member-profile/app/routes/_profile.peer-help.tsx
+++ b/apps/member-profile/app/routes/_profile.peer-help.tsx
@@ -452,7 +452,7 @@ function HelpRequestItem({
 
       <Tooltip>
         <TooltipTrigger cursor="default">
-          <HelpRequestDescription className="line-clamp-2">
+          <HelpRequestDescription lineClamp="2">
             {description}
           </HelpRequestDescription>
         </TooltipTrigger>

--- a/apps/member-profile/app/shared/components/peer-help.tsx
+++ b/apps/member-profile/app/shared/components/peer-help.tsx
@@ -19,16 +19,20 @@ import {
 // Information
 
 type HelpRequestDescriptionProps = PropsWithChildren<{
-  className?: string;
+  lineClamp?: '2';
 }>;
 
 export function HelpRequestDescription({
   children,
-  className,
+  lineClamp,
 }: HelpRequestDescriptionProps) {
   return (
     <Text
-      className={cx('border-l border-gray-300 pl-2', className)}
+      className={cx(
+        'border-l border-gray-300 pl-2',
+        lineClamp === '2' && 'line-clamp-2',
+        !lineClamp && 'whitespace-pre-wrap'
+      )}
       color="gray-500"
       variant="sm"
     >


### PR DESCRIPTION
## Description ✏️

This PR fixes a small issue where the white space of a help request description was not being preserved.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
