### PR TITLE
fix: prevent scroll reset in peer help ❗️

### DIFF
--- a/apps/member-profile/app/routes/_profile.peer-help.tsx
+++ b/apps/member-profile/app/routes/_profile.peer-help.tsx
@@ -438,6 +438,7 @@ function HelpRequestItem({
 
         <Link
           className="link"
+          preventScrollReset
           to={{
             pathname: generatePath(Route['/peer-help/:id'], { id }),
             search: searchParams.toString(),
@@ -563,6 +564,7 @@ function EditButton({ id }: Pick<HelpRequest, 'id'>) {
           backgroundColorOnHover="gray-200"
         >
           <Link
+            preventScrollReset
             to={{
               pathname: generatePath(Route['/peer-help/:id/edit'], { id }),
               search: searchParams.toString(),
@@ -594,6 +596,7 @@ function FinishButton({ finished, id }: Pick<HelpRequest, 'finished' | 'id'>) {
   return (
     <Button.Slot size="sm">
       <Link
+        preventScrollReset
         to={{
           pathname: generatePath(Route['/peer-help/:id/finish'], { id }),
           search: searchParams.toString(),


### PR DESCRIPTION
## Description ✏️

This PR fixes a small scroll issue in the Peer Help page.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
