### PR TITLE
feat: add feed notification for peer help/event 🚀

### DIFF
--- a/packages/core/src/modules/events/events.ts
+++ b/packages/core/src/modules/events/events.ts
@@ -13,6 +13,7 @@ import { EventBullJob } from '@/infrastructure/bull.types';
 import { listAirmeetEvents } from '@/modules/events/airmeet';
 import { ActivityType } from '@/modules/gamification/gamification.types';
 import { getMemberByEmail } from '@/modules/members/queries/get-member-by-email';
+import { STUDENT_PROFILE_URL } from '@/shared/env';
 import { NotFoundError } from '@/shared/errors';
 import { getAirmeetEvent, listAirmeetAttendees } from './airmeet';
 import {
@@ -474,6 +475,11 @@ async function syncAirmeetEvent({ eventId }: GetBullJobData<'event.sync'>) {
     });
   }
 
+  const existingEvent = await db
+    .selectFrom('events')
+    .where('id', '=', event.id)
+    .executeTakeFirst();
+
   // If the event has already ended, we can fetch the attendees from Airmeet,
   // otherwise, we won't import any attendees.
   const attendees =
@@ -518,6 +524,14 @@ async function syncAirmeetEvent({ eventId }: GetBullJobData<'event.sync'>) {
       })
     );
   });
+
+  if (!existingEvent && !attendees.length) {
+    job('notification.slack.send', {
+      channel: process.env.SLACK_FEED_CHANNEL_ID!,
+      message: `🚨 A new event, ${event.name}, was posted! <${STUDENT_PROFILE_URL}/events/${event.id}/register|Register now!>`,
+      workspace: 'regular',
+    });
+  }
 
   studentIds.forEach((studentId) => {
     job('event.attended', {

--- a/packages/core/src/modules/events/events.ts
+++ b/packages/core/src/modules/events/events.ts
@@ -528,7 +528,7 @@ async function syncAirmeetEvent({ eventId }: GetBullJobData<'event.sync'>) {
   if (!existingEvent && !attendees.length) {
     job('notification.slack.send', {
       channel: process.env.SLACK_FEED_CHANNEL_ID!,
-      message: `🚨 A new event, ${event.name}, was posted! <${STUDENT_PROFILE_URL}/events/${event.id}/register|Register now!>`,
+      message: `🚨 A new event, _${event.name}_, was posted! <${STUDENT_PROFILE_URL}/events/${event.id}/register|Register now!>`,
       workspace: 'regular',
     });
   }

--- a/packages/core/src/modules/peer-help.ts
+++ b/packages/core/src/modules/peer-help.ts
@@ -432,6 +432,12 @@ export async function requestHelp({
     user: memberId,
   });
 
+  job('notification.slack.send', {
+    channel: process.env.SLACK_FEED_CHANNEL_ID!,
+    message: `🚨 A new <${STUDENT_PROFILE_URL}/peer-help/${helpRequest.id}|help request> was posted!\n\n>${description}`,
+    workspace: 'regular',
+  });
+
   return success({ id: helpRequest.id });
 }
 

--- a/packages/core/src/modules/slack/use-cases/create-slack-channel.ts
+++ b/packages/core/src/modules/slack/use-cases/create-slack-channel.ts
@@ -1,5 +1,6 @@
 import { db } from '@oyster/db';
 
+import { job } from '@/infrastructure/bull';
 import { type GetBullJobData } from '@/infrastructure/bull.types';
 import { joinSlackChannel } from '@/modules/slack/services/slack-channel.service';
 
@@ -20,4 +21,10 @@ export async function createSlackChannel({
     .execute();
 
   await joinSlackChannel(id);
+
+  job('notification.slack.send', {
+    channel: process.env.SLACK_FEED_CHANNEL_ID!,
+    message: `🚨 New channel alert! <#${id}>`,
+    workspace: 'regular',
+  });
 }

--- a/packages/core/src/modules/slack/use-cases/send-emoji-update.ts
+++ b/packages/core/src/modules/slack/use-cases/send-emoji-update.ts
@@ -24,7 +24,7 @@ export async function onSlackEmojiAdded(data: EmojiAddEvent) {
   const message = `\`:${data.name}:\` is now available.<${data.value}|\u200b>`;
 
   return slack.chat.postMessage({
-    channel: process.env.SLACK_FEED_CHANNEL_ID!,
+    channel: process.env.SLACK_EMOJI_CHANNEL_ID!,
     text: message,
   });
 }


### PR DESCRIPTION
## Description ✏️

This PR:
- Sends a `#feed` channel notification when a help request is posted.
- Sends a `#feed` channel notification when a new Airmeet event is created and open for registration.
- Moves the Slack emoji notification to a different channel.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [x] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
