### PR TITLE
feat: support color for resource tags 🏷️

### DIFF
--- a/apps/member-profile/app/routes/_profile.opportunities.tsx
+++ b/apps/member-profile/app/routes/_profile.opportunities.tsx
@@ -182,11 +182,7 @@ async function listAllTags() {
       ({ fn }) => fn.countAll<string>().as('count'),
     ])
     .where('opportunities.expiresAt', '>', new Date())
-    .groupBy([
-      'opportunityTags.color',
-      'opportunityTags.id',
-      'opportunityTags.name',
-    ])
+    .groupBy('opportunityTags.id')
     .orderBy('count', 'desc')
     .execute();
 

--- a/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.$id_.edit.tsx
@@ -20,6 +20,7 @@ import {
 import { type ResourceType, UpdateResourceInput } from '@oyster/core/resources';
 import { getResource, updateResource } from '@oyster/core/resources/server';
 import {
+  type AccentColor,
   Button,
   Divider,
   ErrorMessage,
@@ -156,6 +157,7 @@ export default function EditResourceModal() {
           <ResourceTagsField
             defaultValue={(resource.tags || []).map((tag) => {
               return {
+                color: tag.color as AccentColor,
                 label: tag.name,
                 value: tag.id,
               };

--- a/apps/member-profile/app/routes/_profile.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.tsx
@@ -24,6 +24,7 @@ import { getPresignedURL } from '@oyster/core/s3';
 import { db } from '@oyster/db';
 import { ISO8601Date } from '@oyster/types';
 import {
+  type AccentColor,
   Button,
   Dashboard,
   ExistingSearchParams,
@@ -207,11 +208,12 @@ async function listAllTags() {
       'resourceTagAssociations.tagId'
     )
     .select([
+      'resourceTags.color',
       'resourceTags.id',
       'resourceTags.name',
       ({ fn }) => fn.countAll<string>().as('count'),
     ])
-    .groupBy(['resourceTags.id', 'resourceTags.name'])
+    .groupBy('resourceTags.id')
     .orderBy('count', 'desc')
     .execute();
 
@@ -227,7 +229,7 @@ async function listAppliedTags(searchParams: URLSearchParams) {
 
   const tags = await db
     .selectFrom('resourceTags')
-    .select(['resourceTags.id', 'resourceTags.name'])
+    .select(['resourceTags.color', 'resourceTags.id', 'resourceTags.name'])
     .where((eb) => {
       return eb.or([
         eb('resourceTags.id', 'in', tagsFromSearch),
@@ -293,7 +295,7 @@ function TagFilter() {
       name="tag"
       selectedValues={appliedTags.map((tag) => {
         return {
-          color: 'pink-100',
+          color: tag.color as AccentColor,
           label: tag.name,
           value: tag.id,
         };
@@ -330,7 +332,7 @@ function TagList() {
 
         return (
           <FilterItem
-            color="pink-100"
+            color={tag.color as AccentColor}
             key={tag.id}
             label={label}
             value={tag.id}

--- a/apps/member-profile/app/routes/_profile.resources.tsx
+++ b/apps/member-profile/app/routes/_profile.resources.tsx
@@ -196,14 +196,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
 async function listAllTags() {
   const tags = await db
     .selectFrom('resources')
-    .innerJoin('resourceTags', 'resourceTags.resourceId', 'resources.id')
-    .innerJoin('tags', 'tags.id', 'resourceTags.tagId')
+    .innerJoin(
+      'resourceTagAssociations',
+      'resourceTagAssociations.resourceId',
+      'resources.id'
+    )
+    .innerJoin(
+      'resourceTags',
+      'resourceTags.id',
+      'resourceTagAssociations.tagId'
+    )
     .select([
-      'tags.id',
-      'tags.name',
+      'resourceTags.id',
+      'resourceTags.name',
       ({ fn }) => fn.countAll<string>().as('count'),
     ])
-    .groupBy(['tags.id', 'tags.name'])
+    .groupBy(['resourceTags.id', 'resourceTags.name'])
     .orderBy('count', 'desc')
     .execute();
 
@@ -218,12 +226,12 @@ async function listAppliedTags(searchParams: URLSearchParams) {
   }
 
   const tags = await db
-    .selectFrom('tags')
-    .select(['tags.id', 'tags.name'])
+    .selectFrom('resourceTags')
+    .select(['resourceTags.id', 'resourceTags.name'])
     .where((eb) => {
       return eb.or([
-        eb('tags.id', 'in', tagsFromSearch),
-        eb('tags.name', 'in', tagsFromSearch),
+        eb('resourceTags.id', 'in', tagsFromSearch),
+        eb('resourceTags.name', 'in', tagsFromSearch),
       ]);
     })
     .execute();

--- a/apps/member-profile/app/routes/api.tags.add.ts
+++ b/apps/member-profile/app/routes/api.tags.add.ts
@@ -16,10 +16,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return json({}, { status: 400 });
   }
 
-  await createTag({
-    id: data.id,
-    name: data.name,
-  });
+  await createTag(data);
 
   track({
     event: 'Resource Tag Added',

--- a/apps/member-profile/app/routes/api.tags.search.ts
+++ b/apps/member-profile/app/routes/api.tags.search.ts
@@ -11,7 +11,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const tags = await listTags({
     pagination: { limit: 25, page: 1 },
-    select: ['id', 'name'],
+    select: ['color', 'id', 'name'],
     where: { search },
   });
 

--- a/apps/member-profile/app/shared/components/resource-form.tsx
+++ b/apps/member-profile/app/shared/components/resource-form.tsx
@@ -6,8 +6,10 @@ import React, {
   useState,
 } from 'react';
 
+import { getRandomAccentColor } from '@oyster/core/member-profile/ui';
 import { ResourceType } from '@oyster/core/resources';
 import {
+  type AccentColor,
   Checkbox,
   ComboboxPopover,
   Field,
@@ -186,11 +188,12 @@ export function ResourceTagsField({
   error,
   name,
 }: FieldProps<MultiComboboxProps['defaultValues']>) {
+  const [color, setColor] = useState<AccentColor>(getRandomAccentColor());
+  const [tagId, setTagId] = useState<string>(id());
+  const [search, setSearch] = useState<string>('');
+
   const createFetcher = useFetcher<unknown>();
   const listFetcher = useFetcher<SearchTagsResult>();
-
-  const [newTagId, setNewTagId] = useState<string>(id());
-  const [search, setSearch] = useState<string>('');
 
   useEffect(() => {
     listFetcher.load('/api/tags/search');
@@ -199,7 +202,8 @@ export function ResourceTagsField({
   const tags = listFetcher.data?.tags || [];
 
   function reset() {
-    setNewTagId(id());
+    setColor(getRandomAccentColor());
+    setTagId(id());
   }
 
   return (
@@ -244,22 +248,30 @@ export function ResourceTagsField({
                     {filteredTags.map((tag) => {
                       return (
                         <MultiComboboxItem
+                          color={tag.color as AccentColor}
                           key={tag.id}
                           label={tag.name}
                           onSelect={reset}
                           value={tag.id}
                         >
-                          <Pill color="pink-100">{tag.name}</Pill>
+                          <Pill color={tag.color as AccentColor}>
+                            {tag.name}
+                          </Pill>
                         </MultiComboboxItem>
                       );
                     })}
 
                     {!!search.length && (
                       <MultiComboboxItem
+                        color={color}
                         label={search}
                         onSelect={(e) => {
                           createFetcher.submit(
-                            { id: e.currentTarget.value, name: search },
+                            {
+                              color,
+                              id: e.currentTarget.value,
+                              name: search,
+                            },
                             {
                               action: '/api/tags/add',
                               method: 'post',
@@ -268,9 +280,9 @@ export function ResourceTagsField({
 
                           reset();
                         }}
-                        value={newTagId}
+                        value={tagId}
                       >
-                        Create <Pill color="pink-100">{search}</Pill>
+                        Create <Pill color={color}>{search}</Pill>
                       </MultiComboboxItem>
                     )}
                   </ul>

--- a/apps/member-profile/app/shared/components/resource.tsx
+++ b/apps/member-profile/app/shared/components/resource.tsx
@@ -10,6 +10,7 @@ import { match } from 'ts-pattern';
 
 import { ResourceType } from '@oyster/core/resources';
 import {
+  type AccentColor,
   cx,
   getIconButtonCn,
   getTextCn,
@@ -41,7 +42,7 @@ type ResourceProps = {
   posterLastName: string;
   posterProfilePicture: string | null;
   shareableUri: string;
-  tags: { id: string; name: string }[];
+  tags: { color: AccentColor; id: string; name: string }[];
   title: string;
   type: ResourceType;
   upvoted: boolean;
@@ -244,7 +245,7 @@ function ResourceTagList({ tags }: Pick<ResourceProps, 'tags'>) {
 
         return (
           <Pill
-            color="pink-100"
+            color={tag.color}
             key={tag.id}
             to={{ search: searchParams.toString() }}
           >

--- a/packages/core/src/modules/resources/queries/list-resources.ts
+++ b/packages/core/src/modules/resources/queries/list-resources.ts
@@ -70,8 +70,8 @@ export async function listResources<
       return qb.where((eb) => {
         return eb.exists((eb) => {
           return eb
-            .selectFrom('resourceTags')
-            .whereRef('resourceTags.resourceId', '=', 'resources.id')
+            .selectFrom('resourceTagAssociations')
+            .whereRef('resourceTagAssociations.resourceId', '=', 'resources.id')
             .groupBy('resources.id')
             .having(
               ({ ref }) => sql`array_agg(${ref('tagId')})`,

--- a/packages/core/src/modules/resources/queries/list-tags.ts
+++ b/packages/core/src/modules/resources/queries/list-tags.ts
@@ -10,16 +10,14 @@ type ListTagsOptions<Selection> = {
   where: { ids?: string[]; search?: string };
 };
 
-export async function listTags<Selection extends SelectExpression<DB, 'tags'>>({
-  pagination,
-  select,
-  where,
-}: ListTagsOptions<Selection>) {
+export async function listTags<
+  Selection extends SelectExpression<DB, 'resourceTags'>,
+>({ pagination, select, where }: ListTagsOptions<Selection>) {
   return db
-    .selectFrom('tags')
+    .selectFrom('resourceTags')
     .select(select)
     .$if(!!where.ids, (qb) => {
-      return qb.where('tags.id', 'in', where.ids!);
+      return qb.where('resourceTags.id', 'in', where.ids!);
     })
     .$if(!!where.search, (qb) => {
       return qb.where('name', 'ilike', `%${where.search}%`);

--- a/packages/core/src/modules/resources/resources.types.ts
+++ b/packages/core/src/modules/resources/resources.types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { type ExtractValue } from '@oyster/types';
 
 import { ListSearchParams } from '@/shared/types';
+import { ACCENT_COLORS } from '@/shared/utils/color';
 import { FileLike } from '@/shared/utils/zod';
 
 // Types
@@ -41,6 +42,8 @@ const Resource = z.object({
 });
 
 const Tag = z.object({
+  // @ts-expect-error - not sure why b/c AccentColor extends `string`!
+  color: z.enum(ACCENT_COLORS),
   createdAt: z.coerce.date(),
   id: z.string().min(1),
   name: z.string().trim().min(1),
@@ -81,6 +84,7 @@ export const AddResourceInput = Resource.pick({
 });
 
 export const CreateTagInput = Tag.pick({
+  color: true,
   id: true,
   name: true,
 });

--- a/packages/core/src/modules/resources/shared/index.ts
+++ b/packages/core/src/modules/resources/shared/index.ts
@@ -36,18 +36,22 @@ export function buildAttachmentsField(eb: ExpressionBuilder<DB, 'resources'>) {
  */
 export function buildTagsField(eb: ExpressionBuilder<DB, 'resources'>) {
   return eb
-    .selectFrom('resourceTags')
-    .leftJoin('tags', 'tags.id', 'resourceTags.tagId')
-    .whereRef('resourceTags.resourceId', '=', 'resources.id')
+    .selectFrom('resourceTagAssociations')
+    .leftJoin(
+      'resourceTags',
+      'resourceTags.id',
+      'resourceTagAssociations.tagId'
+    )
+    .whereRef('resourceTagAssociations.resourceId', '=', 'resources.id')
     .select(({ fn, ref }) => {
       const object = jsonBuildObject({
-        id: ref('tags.id'),
-        name: ref('tags.name'),
+        id: ref('resourceTags.id'),
+        name: ref('resourceTags.name'),
       });
 
       return fn
-        .jsonAgg(sql`${object} order by ${ref('tags.name')} asc`)
-        .filterWhere('tags.id', 'is not', null)
+        .jsonAgg(sql`${object} order by ${ref('resourceTags.name')} asc`)
+        .filterWhere('resourceTags.id', 'is not', null)
         .$castTo<{ id: string; name: string }[]>()
         .as('tags');
     })

--- a/packages/core/src/modules/resources/shared/index.ts
+++ b/packages/core/src/modules/resources/shared/index.ts
@@ -3,6 +3,8 @@ import { jsonBuildObject } from 'kysely/helpers/postgres';
 
 import { type DB } from '@oyster/db';
 
+import { type AccentColor } from '@/shared/utils/color';
+
 /**
  * When querying from the "resources" table, we often need to include the
  * attachments associated with those resources, which happens in the same SQL
@@ -45,6 +47,7 @@ export function buildTagsField(eb: ExpressionBuilder<DB, 'resources'>) {
     .whereRef('resourceTagAssociations.resourceId', '=', 'resources.id')
     .select(({ fn, ref }) => {
       const object = jsonBuildObject({
+        color: ref('resourceTags.color'),
         id: ref('resourceTags.id'),
         name: ref('resourceTags.name'),
       });
@@ -52,7 +55,7 @@ export function buildTagsField(eb: ExpressionBuilder<DB, 'resources'>) {
       return fn
         .jsonAgg(sql`${object} order by ${ref('resourceTags.name')} asc`)
         .filterWhere('resourceTags.id', 'is not', null)
-        .$castTo<{ id: string; name: string }[]>()
+        .$castTo<{ color: AccentColor; id: string; name: string }[]>()
         .as('tags');
     })
     .as('tags');

--- a/packages/core/src/modules/resources/use-cases/add-resource.ts
+++ b/packages/core/src/modules/resources/use-cases/add-resource.ts
@@ -48,7 +48,7 @@ export async function addResource(
 
     for (const tag of input.tags) {
       await trx
-        .insertInto('resourceTags')
+        .insertInto('resourceTagAssociations')
         .values({
           resourceId: resource.id,
           tagId: tag,

--- a/packages/core/src/modules/resources/use-cases/create-tag.ts
+++ b/packages/core/src/modules/resources/use-cases/create-tag.ts
@@ -7,7 +7,7 @@ export async function createTag(input: CreateTagInput) {
     const tag = await trx
       .insertInto('resourceTags')
       .values({
-        color,
+        color: input.color,
         createdAt: new Date(),
         id: input.id,
         name: input.name,

--- a/packages/core/src/modules/resources/use-cases/create-tag.ts
+++ b/packages/core/src/modules/resources/use-cases/create-tag.ts
@@ -5,7 +5,7 @@ import { type CreateTagInput } from '@/modules/resources/resources.types';
 export async function createTag(input: CreateTagInput) {
   const result = await db.transaction().execute(async (trx) => {
     const tag = await trx
-      .insertInto('tags')
+      .insertInto('resourceTags')
       .values({
         id: input.id,
         name: input.name,

--- a/packages/core/src/modules/resources/use-cases/create-tag.ts
+++ b/packages/core/src/modules/resources/use-cases/create-tag.ts
@@ -7,6 +7,8 @@ export async function createTag(input: CreateTagInput) {
     const tag = await trx
       .insertInto('resourceTags')
       .values({
+        color,
+        createdAt: new Date(),
         id: input.id,
         name: input.name,
       })

--- a/packages/core/src/modules/resources/use-cases/update-resource.ts
+++ b/packages/core/src/modules/resources/use-cases/update-resource.ts
@@ -43,12 +43,12 @@ export async function updateResource(
       .executeTakeFirstOrThrow();
 
     await trx
-      .deleteFrom('resourceTags')
+      .deleteFrom('resourceTagAssociations')
       .where('resourceId', '=', resourceId)
       .execute();
 
     await trx
-      .insertInto('resourceTags')
+      .insertInto('resourceTagAssociations')
       .values(
         input.tags.map((tag) => {
           return {

--- a/packages/db/src/migrations/20250514204059_resource_tags.ts
+++ b/packages/db/src/migrations/20250514204059_resource_tags.ts
@@ -1,0 +1,19 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('resource_tags')
+    .renameTo('resource_tag_associations')
+    .execute();
+
+  await db.schema.alterTable('tags').renameTo('resource_tags').execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema.alterTable('resource_tags').renameTo('tags').execute();
+
+  await db.schema
+    .alterTable('resource_tag_associations')
+    .renameTo('resource_tags')
+    .execute();
+}

--- a/packages/db/src/migrations/20250514204059_resource_tags.ts
+++ b/packages/db/src/migrations/20250514204059_resource_tags.ts
@@ -1,5 +1,21 @@
 import { type Kysely } from 'kysely';
 
+const ACCENT_COLORS = [
+  'amber-100',
+  'blue-100',
+  'cyan-100',
+  'green-100',
+  'lime-100',
+  'orange-100',
+  'pink-100',
+  'purple-100',
+  'red-100',
+];
+
+function getRandomAccentColor() {
+  return ACCENT_COLORS[Math.floor(Math.random() * ACCENT_COLORS.length)];
+}
+
 export async function up(db: Kysely<any>) {
   await db.schema
     .alterTable('resource_tags')
@@ -7,9 +23,35 @@ export async function up(db: Kysely<any>) {
     .execute();
 
   await db.schema.alterTable('tags').renameTo('resource_tags').execute();
+
+  await db.schema
+    .alterTable('resource_tags')
+    .addColumn('color', 'text')
+    .execute();
+
+  const tags = await db.selectFrom('resource_tags').select('id').execute();
+
+  await db.transaction().execute(async (trx) => {
+    for (const tag of tags) {
+      await trx
+        .updateTable('resource_tags')
+        .set({ color: getRandomAccentColor() })
+        .where('id', '=', tag.id)
+        .execute();
+    }
+  });
+
+  await db.schema
+    .alterTable('resource_tags')
+    .alterColumn('color', (column) => {
+      return column.setNotNull();
+    })
+    .execute();
 }
 
 export async function down(db: Kysely<any>) {
+  await db.schema.alterTable('resource_tags').dropColumn('color').execute();
+
   await db.schema.alterTable('resource_tags').renameTo('tags').execute();
 
   await db.schema

--- a/packages/db/src/migrations/20250514204059_resource_tags.ts
+++ b/packages/db/src/migrations/20250514204059_resource_tags.ts
@@ -31,15 +31,13 @@ export async function up(db: Kysely<any>) {
 
   const tags = await db.selectFrom('resource_tags').select('id').execute();
 
-  await db.transaction().execute(async (trx) => {
-    for (const tag of tags) {
-      await trx
-        .updateTable('resource_tags')
-        .set({ color: getRandomAccentColor() })
-        .where('id', '=', tag.id)
-        .execute();
-    }
-  });
+  for (const tag of tags) {
+    await db
+      .updateTable('resource_tags')
+      .set({ color: getRandomAccentColor() })
+      .where('id', '=', tag.id)
+      .execute();
+  }
 
   await db.schema
     .alterTable('resource_tags')

--- a/packages/db/src/scripts/seed.ts
+++ b/packages/db/src/scripts/seed.ts
@@ -536,11 +536,11 @@ async function seed(trx: Transaction<DB>) {
   await trx
     .insertInto('resourceTags')
     .values([
-      { id: academicTagId, name: 'Academic' },
-      { id: careerAdviceTagId, name: 'Career Advice' },
-      { id: interviewPrepTagId, name: 'Interview Prep' },
-      { id: learningTagId, name: 'Learning' },
-      { id: videoTagId, name: 'Video' },
+      { color: 'pink-100', id: academicTagId, name: 'Academic' },
+      { color: 'orange-100', id: careerAdviceTagId, name: 'Career Advice' },
+      { color: 'blue-100', id: interviewPrepTagId, name: 'Interview Prep' },
+      { color: 'lime-100', id: learningTagId, name: 'Learning' },
+      { color: 'purple-100', id: videoTagId, name: 'Video' },
     ])
     .execute();
 

--- a/packages/db/src/scripts/seed.ts
+++ b/packages/db/src/scripts/seed.ts
@@ -534,7 +534,7 @@ async function seed(trx: Transaction<DB>) {
   const videoTagId = id();
 
   await trx
-    .insertInto('tags')
+    .insertInto('resourceTags')
     .values([
       { id: academicTagId, name: 'Academic' },
       { id: careerAdviceTagId, name: 'Career Advice' },
@@ -545,7 +545,7 @@ async function seed(trx: Transaction<DB>) {
     .execute();
 
   await trx
-    .insertInto('resourceTags')
+    .insertInto('resourceTagAssociations')
     .values([
       { resourceId: resourceId1, tagId: interviewPrepTagId },
       { resourceId: resourceId1, tagId: learningTagId },


### PR DESCRIPTION
## Description ✏️

This PR:
- Renames the `resource_tags` table to `resource_tag_associations`.
- Renames the `tags` table to `resource_tags`.
- Supports a `color` field on `resource_tags` table.
- Retroactively stores a `color` field on each resource tag.
- Updates all components and queries related to showing the color.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
