### PR TITLE
feat: allow education dates to be nullable 📆

### DIFF
--- a/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
+++ b/apps/member-profile/app/routes/_profile.profile.education.$id.edit.tsx
@@ -202,12 +202,12 @@ export default function EditEducationPage() {
             name={keys.otherMajor}
           />
           <EducationForm.StartDateField
-            defaultValue={education.startDate.slice(0, 7)}
+            defaultValue={education.startDate?.slice(0, 7)}
             error={errors.startDate}
             name={keys.startDate}
           />
           <EducationForm.EndDateField
-            defaultValue={education.endDate.slice(0, 7)}
+            defaultValue={education.endDate?.slice(0, 7)}
             error={errors.endDate}
             name={keys.endDate}
           />

--- a/apps/member-profile/app/routes/onboarding.education.tsx
+++ b/apps/member-profile/app/routes/onboarding.education.tsx
@@ -162,12 +162,12 @@ function FieldsetFromEducation() {
         name="otherMajor"
       />
       <EducationForm.StartDateField
-        defaultValue={education.startDate.slice(0, 7) || undefined}
+        defaultValue={education.startDate?.slice(0, 7)}
         error={errors.startDate}
         name="startDate"
       />
       <EducationForm.EndDateField
-        defaultValue={education.endDate.slice(0, 7)}
+        defaultValue={education.endDate?.slice(0, 7)}
         error={errors.endDate}
         name="endDate"
       />

--- a/apps/member-profile/app/shared/components/education-experience.tsx
+++ b/apps/member-profile/app/shared/components/education-experience.tsx
@@ -8,7 +8,7 @@ import { Route } from '@/shared/constants';
 
 type EducationExperienceItemProps = {
   education: {
-    date: string;
+    date?: string;
     degreeType: string;
     id: string;
     location: string | null;
@@ -66,7 +66,7 @@ export function EducationExperienceItem({
             {education.degreeType}, {education.major}
           </Text>
 
-          <Text color="gray-500">{education.date}</Text>
+          {!!education.date && <Text color="gray-500">{education.date}</Text>}
         </div>
       </div>
     </Experience>

--- a/apps/member-profile/app/shared/queries/index.ts
+++ b/apps/member-profile/app/shared/queries/index.ts
@@ -49,11 +49,17 @@ export async function getEducationExperiences(id: string) {
       location = `${experience.addressCity}, ${experience.addressState}`;
     }
 
-    const startMonth = dayjs.utc(experience.startDate).format('MMMM YYYY');
-    const endMonth = dayjs.utc(experience.endDate).format('MMMM YYYY');
+    let date = undefined;
+
+    if (experience.startDate && experience.endDate) {
+      const startMonth = dayjs.utc(experience.startDate).format('MMMM YYYY');
+      const endMonth = dayjs.utc(experience.endDate).format('MMMM YYYY');
+
+      date = `${startMonth} - ${endMonth}`;
+    }
 
     return {
-      date: `${startMonth} - ${endMonth}`,
+      date,
       degreeType: FORMATTED_DEGREEE_TYPE[experience.degreeType as DegreeType],
       id: experience.id,
       location,

--- a/packages/core/src/modules/education/use-cases/check-most-recent-education.ts
+++ b/packages/core/src/modules/education/use-cases/check-most-recent-education.ts
@@ -37,8 +37,13 @@ export async function checkMostRecentEducation(studentId: string) {
     return;
   }
 
-  const graduationMonth = education.endDate.getMonth() + 1;
-  const graduationYear = education.endDate.getFullYear();
+  let graduationMonth = undefined;
+  let graduationYear = undefined;
+
+  if (education.endDate) {
+    graduationMonth = education.endDate.getMonth() + 1;
+    graduationYear = education.endDate.getFullYear();
+  }
 
   await db
     .updateTable('students')
@@ -46,7 +51,7 @@ export async function checkMostRecentEducation(studentId: string) {
       educationLevel:
         EducationLevelFromDegreeType[education.degreeType as DegreeType],
       graduationMonth,
-      graduationYear: graduationYear.toString(),
+      graduationYear: graduationYear?.toString(),
       major: education.major,
       otherMajor: education.otherMajor,
       otherSchool: education.otherSchool,
@@ -74,8 +79,8 @@ export async function checkMostRecentEducation(studentId: string) {
     airtableRecordId: member.airtableId as string,
     airtableTableId: AIRTABLE_MEMBERS_TABLE_ID!,
     data: {
-      'Expected Graduation Month': graduationMonth.toString(),
-      'Expected Graduation Year': graduationYear.toString(),
+      'Expected Graduation Month': graduationMonth?.toString(),
+      'Expected Graduation Year': graduationYear?.toString(),
       School: member.school as string,
     },
   });

--- a/packages/core/src/modules/employment/queries/list-work-experiences.ts
+++ b/packages/core/src/modules/employment/queries/list-work-experiences.ts
@@ -47,8 +47,8 @@ export async function listWorkExperiences(
         });
     })
     .where('workExperiences.studentId', '=', memberId)
-    .orderBy('workExperiences.startDate', 'desc')
     .orderBy('workExperiences.endDate', 'desc')
+    .orderBy('workExperiences.startDate', 'desc')
     .execute();
 
   const experiences = rows.map(({ endDate, startDate, ...row }) => {

--- a/packages/core/src/modules/resume-books/resume-books.ts
+++ b/packages/core/src/modules/resume-books/resume-books.ts
@@ -515,7 +515,7 @@ export async function submitResume({
 
     db
       .selectFrom('students as members')
-      .select(['email'])
+      .select(['email', 'graduationYear'])
       .where('id', '=', memberId)
       .executeTakeFirstOrThrow(),
 
@@ -579,9 +579,13 @@ export async function submitResume({
       })
     : null;
 
+  // If the education end date is not present, we'll use the graduation
+  // year from the member record.
+  const graduationYear =
+    education.endDate?.getFullYear() || member.graduationYear;
+
   // In order to keep the resume file names consistent for the partners,
   // we'll use the same naming convention based on the submitter.
-  const graduationYear = education.endDate.getFullYear();
   const fileName = `${lastName}_${firstName}_${graduationYear}.pdf`;
 
   // We need to do a little massaging/formatting of the data before we sent it
@@ -606,7 +610,9 @@ export async function submitResume({
     'First Name': firstName,
 
     'Graduation Season': run(() => {
-      return education.endDate.getMonth() <= 6 ? 'Spring' : 'Fall';
+      return education.endDate && education.endDate.getMonth() >= 6
+        ? 'Fall'
+        : 'Spring';
     }),
 
     // We need to convert to a string because Airtable expects strings for

--- a/packages/db/src/migrations/20250528184104_education_date_optional.ts
+++ b/packages/db/src/migrations/20250528184104_education_date_optional.ts
@@ -1,0 +1,25 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('educations')
+    .alterColumn('end_date', (column) => {
+      return column.dropNotNull();
+    })
+    .alterColumn('start_date', (column) => {
+      return column.dropNotNull();
+    })
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('educations')
+    .alterColumn('end_date', (column) => {
+      return column.setNotNull();
+    })
+    .alterColumn('start_date', (column) => {
+      return column.setNotNull();
+    })
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR alters the `educations` table to allow the `end_date` and `start_date` to be nullable. This change is a precursor to the LinkedIn integration sync where we automatically pull education history from a LinkedIn profile. LinkedIn allows someone to not put the start/end date of their education, and thus we want to do the same.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
