### PR TITLE
feat: track timestamp for linkedin sync 🔀

### DIFF
--- a/packages/core/src/infrastructure/mixpanel.ts
+++ b/packages/core/src/infrastructure/mixpanel.ts
@@ -63,6 +63,12 @@ export type MixpanelEvent = {
     Type: string;
   };
 
+  'LinkedIn Synced': {
+    '# of Education Changes': number;
+    '# of Work Experience Changes': number;
+    'Location Changed': boolean;
+  };
+
   'Logged In': {
     Method: 'Google' | 'OTP' | 'Slack';
   };
@@ -109,7 +115,7 @@ export type MixpanelEvent = {
 };
 
 export type TrackInput<Event extends keyof MixpanelEvent> = {
-  application?: 'Member Profile' | 'Slack';
+  application?: 'API' | 'Member Profile' | 'Slack';
   event: Event;
   properties: MixpanelEvent[Event];
   request?: Request;

--- a/packages/core/src/modules/linkedin.ts
+++ b/packages/core/src/modules/linkedin.ts
@@ -185,6 +185,14 @@ export async function syncLinkedInProfile(memberId: string): Promise<void> {
         .exhaustive();
     });
 
+    promises.push(
+      trx
+        .updateTable('students')
+        .set({ linkedinSyncedAt: new Date() })
+        .where('id', '=', memberId)
+        .execute()
+    );
+
     await Promise.all(promises);
   });
 }

--- a/packages/db/src/migrations/20250611203613_linkedin_sync.ts
+++ b/packages/db/src/migrations/20250611203613_linkedin_sync.ts
@@ -1,0 +1,15 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('students')
+    .addColumn('linkedin_synced_at', 'timestamptz')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('students')
+    .dropColumn('linkedin_synced_at')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR adds a `linkedin_synced_at` column to the `students` table in order to track the timestamp for when a LinkedIn is synced to a member's profile. Also updates this in the `syncLinkedInProfile` method.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
