### PR TITLE
fix: allow null `education_id` on `resume_book_submissions` ❗️

### DIFF
--- a/packages/db/src/migrations/20250624195818_resume_book_submission_education.ts
+++ b/packages/db/src/migrations/20250624195818_resume_book_submission_education.ts
@@ -1,0 +1,52 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('resume_book_submissions')
+    .alterColumn('education_id', (column) => {
+      return column.dropNotNull();
+    })
+    .execute();
+
+  await db.schema
+    .alterTable('resume_book_submissions')
+    .dropConstraint('resume_book_submissions_education_id_fkey')
+    .ifExists()
+    .execute();
+
+  await db.schema
+    .alterTable('resume_book_submissions')
+    .addForeignKeyConstraint(
+      'resume_book_submissions_education_id_fkey',
+      ['education_id'],
+      'educations',
+      ['id']
+    )
+    .onDelete('set null')
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('resume_book_submissions')
+    .dropConstraint('resume_book_submissions_education_id_fkey')
+    .ifExists()
+    .execute();
+
+  await db.schema
+    .alterTable('resume_book_submissions')
+    .addForeignKeyConstraint(
+      'resume_book_submissions_education_id_fkey',
+      ['education_id'],
+      'educations',
+      ['id']
+    )
+    .execute();
+
+  await db.schema
+    .alterTable('resume_book_submissions')
+    .alterColumn('education_id', (column) => {
+      return column.setNotNull();
+    })
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR ships a couple fixes which allow the final 5,000 members' education/work histories to be migrated.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
