### PR TITLE
feat: make company employees searchable 🔎

### DIFF
--- a/apps/member-profile/app/routes/_profile.companies.tsx
+++ b/apps/member-profile/app/routes/_profile.companies.tsx
@@ -217,7 +217,7 @@ function CompanyItem({ company }: { company: CompanyInView }) {
 
       <CompanyDescription description={company.description} />
 
-      <div className="flex items-center gap-4">
+      <div className="mt-auto flex items-center gap-4">
         <EmployeeCount employees={company.employees} />
         <OpportunitiesCount opportunities={company.opportunities} />
         <ReviewCount reviews={company.reviews} />

--- a/apps/member-profile/app/routes/_profile.companies_.$id.employees.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.employees.tsx
@@ -121,8 +121,16 @@ function SearchForm() {
 type EmployeeInView = SerializeFrom<typeof loader>['employees'][number];
 
 function EmployeeItem({ employee }: { employee: EmployeeInView }) {
-  const { firstName, id, lastName, location, profilePicture, status, title } =
-    employee;
+  const {
+    duration,
+    firstName,
+    id,
+    lastName,
+    location,
+    profilePicture,
+    status,
+    title,
+  } = employee;
 
   return (
     <li className="line-clamp-1 grid grid-cols-[3rem_1fr] items-start gap-2 rounded-2xl p-2 hover:bg-gray-100">
@@ -154,6 +162,10 @@ function EmployeeItem({ employee }: { employee: EmployeeInView }) {
           ) : (
             <>{title}</>
           )}
+        </Text>
+
+        <Text color="gray-500" variant="sm">
+          {duration}
         </Text>
       </div>
     </li>

--- a/apps/member-profile/app/routes/_profile.companies_.$id.employees.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.employees.tsx
@@ -3,107 +3,126 @@ import {
   type LoaderFunctionArgs,
   type SerializeFrom,
 } from '@remix-run/node';
-import { generatePath, Link, useLoaderData } from '@remix-run/react';
+import {
+  generatePath,
+  Link,
+  useLoaderData,
+  useSearchParams,
+} from '@remix-run/react';
+import { useEffect, useState } from 'react';
 
 import { listCompanyEmployees } from '@oyster/core/employment/server';
-import { cx, getTextCn, ProfilePicture, Text } from '@oyster/ui';
+import {
+  cx,
+  getTextCn,
+  Pill,
+  ProfilePicture,
+  SearchBar,
+  Text,
+  useDelayedValue,
+} from '@oyster/ui';
+import { toTitleCase } from '@oyster/utils';
 
-import { Card } from '@/shared/components/card';
 import { Route } from '@/shared/constants';
 import { ensureUserAuthenticated } from '@/shared/session.server';
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   await ensureUserAuthenticated(request);
 
-  const companyId = params.id as string;
+  const { search } = Object.fromEntries(new URL(request.url).searchParams);
 
-  const _employees = await listCompanyEmployees({
-    where: { companyId },
+  const employees = await listCompanyEmployees({
+    where: {
+      companyId: params.id as string,
+      search,
+    },
   });
 
-  const employees = _employees.map(
-    ({ locationCity, locationState, ...employee }) => {
-      return {
-        ...employee,
-        ...(locationCity &&
-          locationState && {
-            location: `${locationCity}, ${locationState}`,
-          }),
-      };
+  let currentCount = 0;
+  let pastCount = 0;
+
+  employees.forEach(({ status }) => {
+    if (status === 'current') {
+      currentCount++;
+    } else if (status === 'past') {
+      pastCount++;
     }
-  );
-
-  const currentEmployees = employees.filter((employee) => {
-    return employee.status === 'current';
-  });
-
-  const pastEmployees = employees.filter((employee) => {
-    return employee.status === 'past';
   });
 
   return json({
-    currentEmployees,
-    pastEmployees,
+    currentCount,
+    employees,
+    pastCount,
   });
 }
 
 export default function Employees() {
+  const { currentCount, employees, pastCount } = useLoaderData<typeof loader>();
+
   return (
     <>
-      <CurrentEmployees />
-      <PastEmployees />
+      <SearchForm />
+
+      {employees.length ? (
+        <>
+          <ul className="max-h-80 overflow-auto">
+            {employees.map((employee) => {
+              return <EmployeeItem key={employee.id} employee={employee} />;
+            })}
+          </ul>
+
+          <Text variant="xs" color="gray-500" className="ml-auto">
+            Current: {currentCount} | Past: {pastCount}
+          </Text>
+        </>
+      ) : (
+        <Text color="gray-500">No employees found from ColorStack.</Text>
+      )}
     </>
   );
 }
 
-function CurrentEmployees() {
-  const { currentEmployees } = useLoaderData<typeof loader>();
+function SearchForm() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState<string | undefined>(undefined);
+  const delayedSearch = useDelayedValue(search, 250);
+
+  useEffect(() => {
+    if (delayedSearch === undefined) {
+      return;
+    }
+
+    if (delayedSearch === '') {
+      return setSearchParams((params) => {
+        params.delete('search');
+
+        return params;
+      });
+    }
+
+    return setSearchParams((params) => {
+      params.set('search', delayedSearch);
+
+      return params;
+    });
+  }, [delayedSearch]);
 
   return (
-    <Card>
-      <Card.Title>Current Employees ({currentEmployees.length})</Card.Title>
-
-      {currentEmployees.length ? (
-        <ul>
-          {currentEmployees.map((employee) => {
-            return <EmployeeItem key={employee.id} employee={employee} />;
-          })}
-        </ul>
-      ) : (
-        <Text color="gray-500">
-          There are no current employees from ColorStack.
-        </Text>
-      )}
-    </Card>
+    <SearchBar
+      defaultValue={searchParams.get('search') || undefined}
+      name="search"
+      onChange={(e) => setSearch(e.currentTarget.value)}
+      width="full"
+      placeholder="Search by name or title..."
+    />
   );
 }
 
-function PastEmployees() {
-  const { pastEmployees } = useLoaderData<typeof loader>();
-
-  return (
-    <Card>
-      <Card.Title>Past Employees ({pastEmployees.length})</Card.Title>
-
-      {pastEmployees.length ? (
-        <ul>
-          {pastEmployees.map((employee) => {
-            return <EmployeeItem key={employee.id} employee={employee} />;
-          })}
-        </ul>
-      ) : (
-        <Text color="gray-500">
-          There are no past employees from ColorStack.
-        </Text>
-      )}
-    </Card>
-  );
-}
-
-type EmployeeInView = SerializeFrom<typeof loader>['currentEmployees'][number];
+type EmployeeInView = SerializeFrom<typeof loader>['employees'][number];
 
 function EmployeeItem({ employee }: { employee: EmployeeInView }) {
-  const { firstName, id, lastName, location, profilePicture, title } = employee;
+  const { firstName, id, lastName, location, profilePicture, status, title } =
+    employee;
 
   return (
     <li className="line-clamp-1 grid grid-cols-[3rem_1fr] items-start gap-2 rounded-2xl p-2 hover:bg-gray-100">
@@ -114,12 +133,18 @@ function EmployeeItem({ employee }: { employee: EmployeeInView }) {
       />
 
       <div>
-        <Link
-          className={cx(getTextCn({}), 'hover:underline')}
-          to={generatePath(Route['/directory/:id'], { id })}
-        >
-          {firstName} {lastName}
-        </Link>
+        <Text className="flex items-center gap-1">
+          <Link
+            className={cx(getTextCn({}), 'hover:underline')}
+            to={generatePath(Route['/directory/:id'], { id })}
+          >
+            {firstName} {lastName}
+          </Link>
+
+          <Pill color={status === 'current' ? 'lime-100' : 'gray-100'}>
+            {toTitleCase(status)}
+          </Pill>
+        </Text>
 
         <Text color="gray-500" variant="sm">
           {location ? (

--- a/apps/member-profile/app/routes/_profile.companies_.$id.tsx
+++ b/apps/member-profile/app/routes/_profile.companies_.$id.tsx
@@ -4,6 +4,7 @@ import {
   type SerializeFrom,
 } from '@remix-run/node';
 import { generatePath, Link, Outlet, useLoaderData } from '@remix-run/react';
+import { useState } from 'react';
 import { ExternalLink } from 'react-feather';
 
 import { getCompany } from '@oyster/core/employment/server';
@@ -76,7 +77,7 @@ export default function CompanyPage() {
         <AverageRating averageRating={company.averageRating} />
       </header>
 
-      <Text color="gray-500">{company.description}</Text>
+      <CompanyDescription description={company.description} />
       <OpportunitiesAlert />
       <CompanyNavigation />
       <Outlet />
@@ -184,6 +185,37 @@ function AverageRating({
         <span className="text-2xl">{averageRating}</span>/10
       </Text>
     </div>
+  );
+}
+
+function CompanyDescription({
+  description,
+}: Pick<CompanyInView, 'description'>) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!description) {
+    return null;
+  }
+
+  const isLongDescription = description.length > 400;
+  const displayText = isExpanded ? description : description.slice(0, 400);
+
+  return (
+    <Text className="whitespace-pre-wrap" color="gray-500" variant="sm">
+      {displayText}
+      {isLongDescription && !isExpanded && (
+        <>
+          ...{' '}
+          <button
+            className="text-primary underline"
+            onClick={() => setIsExpanded(true)}
+            type="button"
+          >
+            see more
+          </button>
+        </>
+      )}
+    </Text>
   );
 }
 

--- a/packages/core/src/modules/employment/queries/list-company-employees.ts
+++ b/packages/core/src/modules/employment/queries/list-company-employees.ts
@@ -1,4 +1,8 @@
+import { sql } from 'kysely';
+
 import { db } from '@oyster/db';
+
+import { EmploymentType } from '@/modules/employment/employment.types';
 
 type ListCompanyEmployeesOptions = {
   where: {
@@ -10,33 +14,112 @@ export async function listCompanyEmployees({
   where,
 }: ListCompanyEmployeesOptions) {
   const employees = await db
-    .selectFrom('workExperiences')
-    .leftJoin('students as employees', 'employees.id', 'studentId')
+    .with('experiences', (qb) => {
+      // This first past is just getting all the work experiences for the
+      // company and calculating the duration (in days) of each experience.
+      return qb
+        .selectFrom('workExperiences')
+        .leftJoin('students as employees', 'employees.id', 'studentId')
+        .select([
+          'employees.firstName',
+          'employees.id as employeeId',
+          'employees.lastName',
+          'employees.profilePicture',
+          'workExperiences.employmentType',
+          'workExperiences.endDate',
+          'workExperiences.locationCity',
+          'workExperiences.locationType',
+          'workExperiences.locationState',
+          'workExperiences.startDate',
+          'workExperiences.title',
+          (eb) => {
+            return eb
+              .case()
+              .when('endDate', '<', new Date())
+              .then('past' as const)
+              .else('current' as const)
+              .end()
+              .as('status');
+          },
+          ({ fn, ref }) => {
+            const endDate = fn.coalesce(
+              ref('workExperiences.endDate'),
+              sql`current_date`
+            );
+
+            const startDate = fn.coalesce(
+              ref('workExperiences.startDate'),
+              sql`current_date`
+            );
+
+            return sql<number>`${endDate} - ${startDate}`.as('durationInDays');
+          },
+        ])
+        .where('companyId', '=', where.companyId)
+        .where('workExperiences.deletedAt', 'is', null);
+    })
+    .with('latestExperiences', (qb) => {
+      // This second part is getting the _latest_ experience for each employee.
+      return qb
+        .selectFrom('experiences')
+        .selectAll()
+        .orderBy('employeeId')
+        .orderBy('endDate', 'desc')
+        .orderBy('startDate', 'desc')
+        .distinctOn('employeeId');
+    })
+    .with('totalDurations', (qb) => {
+      // This third part is summing up the duration of all experiences for each
+      // employee.
+      return qb
+        .selectFrom('experiences')
+        .select([
+          'employeeId',
+          ({ fn, ref }) => {
+            return fn.sum(ref('durationInDays')).as('totalDurationInDays');
+          },
+        ])
+        .groupBy('employeeId');
+    })
+    // This final part is joining the latest experiences with the total
+    // durations (which we're using to sort the employees) and selecting the
+    // final fields we want to display.
+    .selectFrom('latestExperiences')
+    .innerJoin(
+      'totalDurations',
+      'totalDurations.employeeId',
+      'latestExperiences.employeeId'
+    )
     .select([
-      'employees.firstName',
-      'employees.id',
-      'employees.lastName',
-      'employees.profilePicture',
-      'workExperiences.locationCity',
-      'workExperiences.locationType',
-      'workExperiences.locationState',
-      'workExperiences.title',
-      (eb) => {
-        return eb
-          .case()
-          .when('endDate', '<', new Date())
-          .then('past' as const)
-          .else('current' as const)
-          .end()
-          .as('status');
-      },
+      'totalDurations.employeeId as id',
+      'latestExperiences.firstName',
+      'latestExperiences.lastName',
+      'latestExperiences.locationCity',
+      'latestExperiences.locationState',
+      'latestExperiences.locationType',
+      'latestExperiences.profilePicture',
+      'latestExperiences.status',
+      'latestExperiences.title',
     ])
-    .distinctOn('studentId')
-    .where('companyId', '=', where.companyId)
-    .where('workExperiences.deletedAt', 'is', null)
-    .orderBy('studentId')
-    .orderBy('endDate', 'desc')
-    .orderBy('startDate', 'desc')
+    .orderBy('totalDurations.totalDurationInDays', 'desc')
+    .orderBy((eb) => {
+      return eb
+        .case()
+        .when('employmentType', '=', EmploymentType.FULL_TIME)
+        .then(1)
+        .when('employmentType', '=', EmploymentType.INTERNSHIP)
+        .then(2)
+        .when('employmentType', '=', EmploymentType.CONTRACT)
+        .then(3)
+        .when('employmentType', '=', EmploymentType.PART_TIME)
+        .then(4)
+        .when('employmentType', '=', EmploymentType.APPRENTICESHIP)
+        .then(5)
+        .when('employmentType', '=', EmploymentType.FREELANCE)
+        .then(6)
+        .else(7)
+        .end();
+    })
     .execute();
 
   return employees;

--- a/packages/core/src/modules/employment/ui/work-experience.tsx
+++ b/packages/core/src/modules/employment/ui/work-experience.tsx
@@ -146,7 +146,7 @@ export function WorkExperienceItem({
           {experience.description && (
             <div className="mt-4">
               <Text
-                className="whitespace-pre-wrap"
+                className="whitespace-pre-line"
                 color="gray-500"
                 variant="sm"
               >

--- a/packages/core/src/modules/employment/ui/work-experience.tsx
+++ b/packages/core/src/modules/employment/ui/work-experience.tsx
@@ -75,11 +75,11 @@ export function WorkExperienceItem({
         {experience.companyImageUrl ? (
           <img
             alt={experience.companyName!}
-            className="h-12 w-12 rounded-lg object-contain"
+            className="h-12 w-12 flex-shrink-0 rounded-lg object-contain"
             src={experience.companyImageUrl}
           />
         ) : (
-          <div className="h-12 w-12 rounded-lg bg-gray-100" />
+          <div className="h-12 w-12 flex-shrink-0 rounded-lg bg-gray-100" />
         )}
 
         <div>

--- a/packages/ui/src/components/search-bar.tsx
+++ b/packages/ui/src/components/search-bar.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
 import { Search } from 'react-feather';
 
+import { cx } from '../utils/cx';
+
 export type SearchBarProps = Pick<
   React.HTMLProps<HTMLInputElement>,
   'defaultValue' | 'name' | 'id' | 'placeholder' | 'onChange'
->;
+> & {
+  width: 'full';
+};
 
 export function SearchBar({
   defaultValue,
   placeholder = 'Search...',
+  width,
   ...rest
 }: SearchBarProps) {
   return (
-    <div className="flex items-center gap-2 rounded-full bg-gray-50 p-2 sm:w-[420px]">
+    <div
+      className={cx(
+        'flex items-center gap-2 rounded-full bg-gray-50 p-2',
+        width === 'full' ? 'w-full' : 'sm:w-[420px]'
+      )}
+    >
       <Search className="text-gray-500" size="1.25rem" />
 
       <input

--- a/packages/ui/src/components/search-bar.tsx
+++ b/packages/ui/src/components/search-bar.tsx
@@ -7,7 +7,7 @@ export type SearchBarProps = Pick<
   React.HTMLProps<HTMLInputElement>,
   'defaultValue' | 'name' | 'id' | 'placeholder' | 'onChange'
 > & {
-  width: 'full';
+  width?: 'full';
 };
 
 export function SearchBar({


### PR DESCRIPTION
## Description ✏️

This PR:
- Updates the `listCompanyEmployees` to accept a `search` parameter. It also does some extra calculation in the query which sums up the total time someone has spent at the company, then sorts in descending order based off of that.
- Updates the UI of the company employees page:
  - Shows one big list of employees instead of separating current/past.
  - Shows a `Current` | `Past` pill for the employee.
  - Shows the time spent at the company.
- Fixes other visual bugs.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
