### PR TITLE
feat: split linkedin batches into jobs 🖖

### DIFF
--- a/packages/core/src/infrastructure/bull.ts
+++ b/packages/core/src/infrastructure/bull.ts
@@ -142,8 +142,8 @@ export function registerWorker<Schema extends ZodType>(
   options = {
     autorun: false,
     connection: redis,
-    removeOnComplete: { age: 60 * 60 * 24 * 1, count: 100 },
-    removeOnFail: { age: 60 * 60 * 24 * 7, count: 1000 },
+    removeOnComplete: { age: 60 * 60 * 24 * 1, count: 1000 },
+    removeOnFail: { age: 60 * 60 * 24 * 7, count: 10000 },
     ...options,
   };
 

--- a/packages/core/src/modules/linkedin.ts
+++ b/packages/core/src/modules/linkedin.ts
@@ -5,6 +5,7 @@ import { type DB, db, point } from '@oyster/db';
 import { type Major } from '@oyster/types';
 import { id, run, splitArray } from '@oyster/utils';
 
+import { job } from '@/infrastructure/bull';
 import { track } from '@/infrastructure/mixpanel';
 import { cache } from '@/infrastructure/redis';
 import { runActor } from '@/modules/apify';
@@ -388,11 +389,23 @@ export async function syncLinkedInProfiles(
   const { members, memberMap, educationMap, experienceMap } =
     await loadAllData(options);
 
-  const batches = splitArray(members, 50);
+  const batches = splitArray(members, 25);
 
   console.log(
     `Splitting ${members.length} members into ${batches.length} batches.`
   );
+
+  // If there are more than 100 members to sync, then we'll split this task
+  // into a series of smaller jobs that can be processed in parallel.
+  if (members.length > 100) {
+    batches.forEach((batch) => {
+      job('student.linkedin.sync', {
+        memberIds: batch.map((member) => member.id),
+      });
+    });
+
+    return;
+  }
 
   for (let i = 0; i < batches.length; i++) {
     console.log(`Processing batch ${i + 1} of ${batches.length}.`);

--- a/packages/core/src/modules/linkedin.ts
+++ b/packages/core/src/modules/linkedin.ts
@@ -395,9 +395,9 @@ export async function syncLinkedInProfiles(
     `Splitting ${members.length} members into ${batches.length} batches.`
   );
 
-  // If there are more than 100 members to sync, then we'll split this task
+  // If there are more than 10 batches to sync, then we'll split this task
   // into a series of smaller jobs that can be processed in parallel.
-  if (members.length > 100) {
+  if (batches.length > 10) {
     batches.forEach((batch) => {
       job('student.linkedin.sync', {
         memberIds: batch.map((member) => member.id),


### PR DESCRIPTION
## Description ✏️

This PR:
- Splits LinkedIn batches into separate jobs if there are more than 100 members.
- Updates the default Bull removal logic to keep 10x the number of completed/failed jobs.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
