### PR TITLE
fix: bump minimum node version to `22.17.0` to support vite 7 ❗️

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 22.17.0
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.17.0
           cache: 'yarn'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "engines": {
     "npm": ">=7.0.0",
-    "node": ">=20.0.0"
+    "node": ">=22.17.0"
   },
   "packageManager": "yarn@1.22.10"
 }


### PR DESCRIPTION
## Description ✏️

This PR makes the minimum node version `22.17.0` in order to support installing vite 7.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
