### PR TITLE
fix: issue with `postmark.getBounces`, swapping `postmark` lib for native `fetch` ❗️

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -176,7 +176,6 @@
         "nanoid": "^3.0.0",
         "nodemailer": "^6.9.13",
         "pdf-parse": "^1.1.1",
-        "postmark": "^3.0.15",
         "react-router": "^7.0.0",
         "ua-parser-js": "^1.0.36",
         "user-agents": "^1.1.478",
@@ -2131,8 +2130,6 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
-    "postmark": ["postmark@3.11.0", "", { "dependencies": { "axios": "^0.25.0" } }, "sha512-asguBQ9M/8ueQMJ1D45iPF+3+T641q8rAU8m8cQSfhDWePw4TVYql9wszjAwSCE93dUonyrF08D8Kvg6USBoFA=="],
-
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
@@ -2820,8 +2817,6 @@
     "path-scurry/lru-cache": ["lru-cache@11.1.0", "", {}, "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="],
 
     "pdf-parse/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
-
-    "postmark/axios": ["axios@0.25.0", "", { "dependencies": { "follow-redirects": "^1.14.7" } }, "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,6 @@
     "nanoid": "^3.0.0",
     "nodemailer": "^6.9.13",
     "pdf-parse": "^1.1.1",
-    "postmark": "^3.0.15",
     "react-router": "^7.0.0",
     "ua-parser-js": "^1.0.36",
     "user-agents": "^1.1.478",

--- a/packages/core/src/infrastructure/postmark.ts
+++ b/packages/core/src/infrastructure/postmark.ts
@@ -39,6 +39,7 @@ export async function sendEmail(input: SendEmailInput) {
   }
 
   const response = await fetch(`${POSTMARK_API_URL}/email`, {
+    method: 'POST',
     body: JSON.stringify(input),
     headers: {
       Accept: 'application/json',

--- a/packages/core/src/infrastructure/postmark.ts
+++ b/packages/core/src/infrastructure/postmark.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+
+import { reportException } from '@/infrastructure/sentry';
+
+// Environment Variables
+
+const POSTMARK_API_TOKEN = process.env.POSTMARK_API_TOKEN;
+const POSTMARK_API_URL = 'https://api.postmarkapp.com';
+
+// Core
+
+type PostmarkAttachment = {
+  Content: string;
+  ContentType: string;
+  Name: string;
+};
+
+type SendEmailInput = {
+  Attachments?: Array<PostmarkAttachment>;
+  From: string;
+  HtmlBody: string;
+  ReplyTo: string;
+  Subject: string;
+  To: string;
+};
+
+/**
+ * Sends an email using Postmark.
+ *
+ * @param input - The input to send the email with.
+ *
+ * @see https://postmarkapp.com/developer/api/email-api#send-a-single-email
+ */
+export async function sendEmail(input: SendEmailInput) {
+  if (!POSTMARK_API_TOKEN) {
+    console.warn('POSTMARK_API_TOKEN is not set, skipping email send.');
+
+    return;
+  }
+
+  const response = await fetch(`${POSTMARK_API_URL}/email`, {
+    body: JSON.stringify(input),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Postmark-Server-Token': POSTMARK_API_TOKEN,
+    },
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    reportException(
+      new Error(`Failed to send Postmark email to "${input.To}".`),
+      {
+        data,
+        input,
+        status: response.status,
+        statusText: response.statusText,
+      }
+    );
+
+    return;
+  }
+}
+
+/**
+ * Returns `true` if the email has bounced at least once on Postmark.
+ *
+ *
+ * @param email - The email to check.
+ * @returns Whether the email has bounced at least once on Postmark.
+ *
+ * @see https://postmarkapp.com/developer/api/bounce-api#bounces
+ */
+export async function hasEmailBounced(email: string): Promise<boolean> {
+  if (!POSTMARK_API_TOKEN) {
+    console.warn('POSTMARK_API_TOKEN is not set, returning false as fallback.');
+
+    return false;
+  }
+
+  const url = new URL(`${POSTMARK_API_URL}/bounces`);
+
+  url.searchParams.set('count', '1');
+  url.searchParams.set('emailFilter', email);
+  url.searchParams.set('inactive', 'true');
+  url.searchParams.set('offset', '0');
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+      'X-Postmark-Server-Token': POSTMARK_API_TOKEN,
+    },
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    reportException(
+      new Error(`Failed to get bounces for ${email}: ${response.statusText}`),
+      data
+    );
+
+    return false;
+  }
+
+  const parseResult = z.object({ TotalCount: z.number() }).safeParse(data);
+
+  if (!parseResult.success) {
+    reportException(
+      new Error(`Failed to parse bounces for ${email}: ${response.statusText}`),
+      data
+    );
+
+    return false;
+  }
+
+  return parseResult.data.TotalCount >= 1;
+}

--- a/packages/core/src/modules/applications/applications.ts
+++ b/packages/core/src/modules/applications/applications.ts
@@ -11,12 +11,12 @@ import {
   ApplicationBullJob,
   type GetBullJobData,
 } from '@/infrastructure/bull.types';
+import { hasEmailBounced } from '@/infrastructure/postmark';
 import {
   type ApplicationRejectionReason,
   ApplicationStatus,
   type ApplyInput,
 } from '@/modules/applications/applications.types';
-import { getPostmarkInstance } from '@/modules/notifications/shared/email.utils';
 import { ReferralStatus } from '@/modules/referrals/referrals.types';
 import { STUDENT_PROFILE_URL } from '@/shared/env';
 
@@ -638,15 +638,9 @@ async function shouldReject(
     return [true, 'email_already_used'];
   }
 
-  const postmark = getPostmarkInstance();
+  const bounced = await hasEmailBounced(application.email);
 
-  const bounces = await postmark.getBounces({
-    count: 1,
-    emailFilter: application.email,
-    inactive: true,
-  });
-
-  if (bounces.TotalCount >= 1) {
+  if (bounced) {
     return [true, 'email_bounced'];
   }
 

--- a/packages/core/src/modules/notifications/shared/email.utils.ts
+++ b/packages/core/src/modules/notifications/shared/email.utils.ts
@@ -1,5 +1,4 @@
 import nodemailer from 'nodemailer';
-import { ServerClient } from 'postmark';
 
 export function getNodemailerTransporter() {
   const SMTP_HOST = process.env.SMTP_HOST;
@@ -22,18 +21,4 @@ export function getNodemailerTransporter() {
   });
 
   return transporter;
-}
-
-export function getPostmarkInstance() {
-  const POSTMARK_API_TOKEN = process.env.POSTMARK_API_TOKEN;
-
-  if (!POSTMARK_API_TOKEN) {
-    throw new Error(
-      '"POSTMARK_API_TOKEN" is not set, sending emails is disabled.'
-    );
-  }
-
-  const postmark = new ServerClient(POSTMARK_API_TOKEN);
-
-  return postmark;
 }

--- a/packages/core/src/modules/notifications/use-cases/send-email.ts
+++ b/packages/core/src/modules/notifications/use-cases/send-email.ts
@@ -17,12 +17,10 @@ import {
   StudentRemovedEmail,
 } from '@oyster/email-templates';
 
+import { sendEmail as sendPostmarkEmail } from '@/infrastructure/postmark';
 import { getObject } from '@/infrastructure/s3';
 import { ENVIRONMENT } from '@/shared/env';
-import {
-  getNodemailerTransporter,
-  getPostmarkInstance,
-} from '../shared/email.utils';
+import { getNodemailerTransporter } from '../shared/email.utils';
 
 // Constants
 
@@ -63,8 +61,6 @@ export async function sendEmail(input: EmailTemplate) {
 }
 
 async function sendEmailWithPostmark(input: EmailTemplate) {
-  const postmark = getPostmarkInstance();
-
   const from = match(input.name)
     .with('application-accepted', () => FROM_JEHRON)
     .with('application-created', () => FROM_NOTIFICATIONS)
@@ -82,11 +78,10 @@ async function sendEmailWithPostmark(input: EmailTemplate) {
 
   const attachments = await getAttachments(input);
 
-  await postmark.sendEmail({
+  await sendPostmarkEmail({
     Attachments: attachments?.map((attachment) => {
       return {
         Content: attachment.content,
-        ContentID: null,
         ContentType: attachment.contentType,
         Name: attachment.name,
       };


### PR DESCRIPTION
## Description ✏️

This PR fixes a bug with `postmark.getBounces` which now requires the `offset` search param to be set.

In doing so, we also just remove the `postmark` library dependency and implement the API integration using native `fetch`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
