### PR TITLE
feat: reject applicant if linkedin url already found ❎

### DIFF
--- a/packages/core/src/modules/applications/applications.ts
+++ b/packages/core/src/modules/applications/applications.ts
@@ -456,6 +456,10 @@ const ExpandedRejectionReason: Record<ApplicationRejectionReason, string> = {
 
   is_international: 'We only admit students enrolled in the US or Canada.',
 
+  linkedin_already_used:
+    'Due to the volume of applications we receive, we will not be able to ' +
+    'provide additional feedback on your application.',
+
   not_undergraduate: 'We only admit undergraduate students.',
 
   other:
@@ -625,6 +629,15 @@ async function shouldReject(
 
   if (memberWithSameEmail) {
     return [true, 'email_already_used'];
+  }
+
+  const memberWithSameLinkedIn = await db
+    .selectFrom('students')
+    .where('linkedInUrl', 'ilike', application.linkedInUrl)
+    .executeTakeFirst();
+
+  if (memberWithSameLinkedIn) {
+    return [true, 'linkedin_already_used'];
   }
 
   const applicationAcceptedWithSameEmail = await db

--- a/packages/core/src/modules/applications/applications.types.ts
+++ b/packages/core/src/modules/applications/applications.types.ts
@@ -10,6 +10,7 @@ export const ApplicationRejectionReason = {
   EMAIL_BOUNCED: 'email_bounced',
   INELIGIBLE_MAJOR: 'ineligible_major',
   IS_INTERNATIONAL: 'is_international',
+  LINKEDIN_ALREADY_USED: 'linkedin_already_used',
   NOT_UNDERGRADUATE: 'not_undergraduate',
   OTHER: 'other',
 } as const;

--- a/packages/types/src/domain/student.ts
+++ b/packages/types/src/domain/student.ts
@@ -60,7 +60,7 @@ const StudentSocialLinks = z.object({
     .startsWith('http', 'URL must start with "http://".')
     .url()
     .transform((value) => value.toLowerCase())
-    .transform((value) => normalizeUri(value))
+    .transform((value) => normalizeUri(value, { removeWww: true }))
     .refine((value) => value.includes('linkedin.com/in/'), {
       message: 'URL must be a valid LinkedIn URL.',
     })

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -66,6 +66,7 @@ type NormalizeOptions = Partial<{
   removeHash: boolean;
   removeSearch: boolean;
   removeTrailingSlash: boolean;
+  removeWww: boolean;
 }>;
 
 /**
@@ -90,6 +91,7 @@ export function normalizeUri<T extends string | null | undefined>(
     removeHash: true,
     removeSearch: true,
     removeTrailingSlash: true,
+    removeWww: false,
   };
 
   options = {
@@ -98,6 +100,10 @@ export function normalizeUri<T extends string | null | undefined>(
   };
 
   const uri = new URL(input);
+
+  if (options.removeWww) {
+    uri.hostname = uri.hostname.replace('www.', '');
+  }
 
   if (options.forceHttps) {
     uri.protocol = 'https:';


### PR DESCRIPTION
## Description ✏️

This PR:
- Automatically rejects an applicant if they are using a `linked_in_url` that is already found in the `members` table.
- Updates the Zod schema for `linkedInUrl` such that it removes the `www.` from the value. This is so that we can get a better gauge for uniqueness.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
