### PR TITLE
fix: set domain for linkedin oauth redirection 🔒

### DIFF
--- a/apps/api/src/handlers/oauth.ts
+++ b/apps/api/src/handlers/oauth.ts
@@ -10,6 +10,7 @@ import {
   saveGoogleDriveCredentials,
 } from '@oyster/core/api';
 import { track } from '@oyster/core/mixpanel';
+import { getRootDomainFromHostname } from '@oyster/utils';
 
 import { BunResponse } from '../shared/bun-response';
 
@@ -82,7 +83,7 @@ const LinkedInOAuthSearchParams = createOAuthSearchParamsSchema(
 );
 
 export async function handleLinkedInOauth(req: BunRequest) {
-  const { searchParams } = new URL(req.url);
+  const { hostname, searchParams } = new URL(req.url);
   const result = LinkedInOAuthSearchParams.safeParse(searchParams);
 
   if (!result.success) {
@@ -110,9 +111,11 @@ export async function handleLinkedInOauth(req: BunRequest) {
     JSON.stringify({ email, firstName, lastName })
   );
 
+  const domain = getRootDomainFromHostname(hostname);
+
   response.headers.set(
     'Set-Cookie',
-    `oauth_info=${info}; Path=/; Max-Age=86400; Secure; SameSite=Lax; HttpOnly`
+    `oauth_info=${info}; Domain=${domain}; Path=/; Max-Age=86400; Secure; SameSite=Lax; HttpOnly`
   );
 
   if (redirectTo.pathname === '/apply') {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -26,6 +26,22 @@ export function getCookie(cookie: string, name: string) {
   return match[2];
 }
 
+/**
+ * Returns the root domain from a hostname.
+ *
+ * @param hostname - The hostname to get the root domain from.
+ *
+ * @example
+ * ```ts
+ * getRootDomainFromHostname('api.colorstack.io'); // => 'colorstack.io'
+ * getRootDomainFromHostname('colorstack.io'); // => 'colorstack.io'
+ * getRootDomainFromHostname('localhost:3000'); // => 'localhost'
+ * ```
+ */
+export function getRootDomainFromHostname(hostname: string) {
+  return hostname.split('.').slice(-2).join('.');
+}
+
 const nanoid = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 12);
 
 /**


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue with the cookie that gets set after LinkedIn authentication...need to set the `Domain` attribute which we calculate from the URL `hostname`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
