### PR TITLE
refactor: remove readonly styling for input 🔄

### DIFF
--- a/apps/member-profile/app/routes/_profile.tsx
+++ b/apps/member-profile/app/routes/_profile.tsx
@@ -147,7 +147,6 @@ export default function ProfileLayout() {
             <Dashboard.NavigationLink
               icon={<Users />}
               label="Peer Help"
-              isNew
               pathname={Route['/peer-help']}
               prefetch="intent"
             />

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -171,16 +171,10 @@ function formatPhoneNumber(input: string): string {
 
 // Helpers
 
-type InputCnOptions = {
-  readOnly?: boolean;
-};
-
-export function getInputCn(options: InputCnOptions = { readOnly: true }) {
+export function getInputCn() {
   return cx(
     'w-full rounded-lg border border-gray-300 p-2',
     'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500',
-    options.readOnly &&
-      'read-only:cursor-not-allowed read-only:bg-gray-50 read-only:text-gray-500',
     'focus:border-primary'
   );
 }

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -34,7 +34,7 @@ export function Select({
   return (
     <select
       className={cx(
-        getInputCn({ readOnly: false }),
+        getInputCn(),
 
         // If the width is set to 'fit', we'll add some padding to the right
         // to allow room for the arrow icon to fit in the "background-image".


### PR DESCRIPTION
## Description ✏️

This PR reverts the changes to `getInputCn` with regards to readonly styling.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
