### PR TITLE
feat: allow re-adding ambassador as admin ➕

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.admins.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.admins.tsx
@@ -1,4 +1,10 @@
-import { type LoaderFunctionArgs, Outlet, useLoaderData } from 'react-router';
+import { Plus } from 'react-feather';
+import {
+  Link,
+  type LoaderFunctionArgs,
+  Outlet,
+  useLoaderData,
+} from 'react-router';
 
 import {
   doesAdminHavePermission,
@@ -7,8 +13,9 @@ import {
 } from '@oyster/core/admins';
 import { type AdminRole } from '@oyster/core/admins/types';
 import { AdminTable } from '@oyster/core/admins/ui';
-import { Dashboard } from '@oyster/ui';
+import { Button, Dashboard } from '@oyster/ui';
 
+import { Route } from '@/shared/constants';
 import { ensureUserAuthenticated, user } from '@/shared/session.server';
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -65,10 +72,21 @@ export default function Admins() {
     <>
       <Dashboard.Header>
         <Dashboard.Title>Admins</Dashboard.Title>
+        <AddAdminButton />
       </Dashboard.Header>
 
       <AdminTable admins={admins} />
       <Outlet />
     </>
+  );
+}
+
+function AddAdminButton() {
+  return (
+    <Button.Slot variant="primary">
+      <Link to={Route['/admins/add']}>
+        <Plus size={16} /> Add Admin
+      </Link>
+    </Button.Slot>
   );
 }

--- a/packages/core/src/modules/admins/admins.ts
+++ b/packages/core/src/modules/admins/admins.ts
@@ -117,18 +117,6 @@ export async function addAdmin({
     });
   }
 
-  const existingAdmin = await getAdmin({
-    select: [],
-    where: { email },
-  });
-
-  if (existingAdmin) {
-    return fail({
-      code: 409,
-      error: 'An admin already exists with this email.',
-    });
-  }
-
   const adminId = id();
 
   await db.transaction().execute(async (trx) => {
@@ -152,6 +140,14 @@ export async function addAdmin({
           memberId,
           role,
         };
+      })
+      .onConflict((eb) => {
+        return eb.column('email').doUpdateSet({
+          deletedAt: null,
+          firstName,
+          lastName,
+          role,
+        });
       })
       .execute();
   });


### PR DESCRIPTION
## Description ✏️

This PR allows past ambassadors to be added as admins after they have already been archived.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
