### PR TITLE
fix: migration for cascading deletes in member removal ❗️

### DIFF
--- a/packages/db/src/migrations/20250924044343_fix_removal.ts
+++ b/packages/db/src/migrations/20250924044343_fix_removal.ts
@@ -1,0 +1,41 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  // applications
+
+  await db.schema
+    .alterTable('applications')
+    .dropConstraint('applications_referral_id_fkey')
+    .execute();
+
+  await db.schema
+    .alterTable('applications')
+    .addForeignKeyConstraint(
+      'applications_referral_id_fkey',
+      ['referral_id'],
+      'referrals',
+      ['id']
+    )
+    .onDelete('cascade')
+    .execute();
+
+  // opportunity_reports
+
+  await db.schema
+    .alterTable('opportunity_reports')
+    .dropConstraint('opportunity_reports_reporter_id_fkey')
+    .execute();
+
+  await db.schema
+    .alterTable('opportunity_reports')
+    .addForeignKeyConstraint(
+      'opportunity_reports_reporter_id_fkey',
+      ['reporter_id'],
+      'students',
+      ['id']
+    )
+    .onDelete('cascade')
+    .execute();
+}
+
+export async function down(_: Kysely<any>) {}


### PR DESCRIPTION
## Description ✏️

This PR updates a couple FK constraints to set `ON DELETE CASCADE`.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
