### PR TITLE
fix: linkedin sync broken due to apify schema changes

### DIFF
--- a/packages/core/src/modules/employment/use-cases/save-company-if-necessary.ts
+++ b/packages/core/src/modules/employment/use-cases/save-company-if-necessary.ts
@@ -65,12 +65,14 @@ export async function saveCompanyIfNecessary(
     async () => {
       return runActor({
         actorId: 'harvestapi~linkedin-company',
-        body: { companies: [companyNameOrLinkedInId] },
+        body: {
+          companies: [
+            `https://www.linkedin.com/company/${companyNameOrLinkedInId}`,
+          ],
+        },
       });
     }
   );
-
-  console.log(companyNameOrLinkedInId, apifyResult);
 
   const parseResult = z.array(Company).safeParse(apifyResult);
 

--- a/packages/core/src/modules/employment/use-cases/save-company-if-necessary.ts
+++ b/packages/core/src/modules/employment/use-cases/save-company-if-necessary.ts
@@ -70,6 +70,8 @@ export async function saveCompanyIfNecessary(
     }
   );
 
+  console.log(companyNameOrLinkedInId, apifyResult);
+
   const parseResult = z.array(Company).safeParse(apifyResult);
 
   if (!parseResult.success) {

--- a/packages/core/src/modules/linkedin.ts
+++ b/packages/core/src/modules/linkedin.ts
@@ -713,8 +713,6 @@ async function scrapeProfiles(profilesToScrape: string[]) {
     body: { urls: profilesToScrape },
   });
 
-  // console.log(apifyResult);
-
   // We just need the bare minimum in order to cache the profiles, we're not
   // trying to parse the entire profile here. This ensures that we're not
   // too restrictive and forcing ourselves to re-scrape profiles that we

--- a/packages/core/src/modules/linkedin.ts
+++ b/packages/core/src/modules/linkedin.ts
@@ -324,19 +324,18 @@ const LinkedInLocation = z.object({
 });
 
 const LinkedInProfile = z.object({
-  element: z.object({
-    education: z.array(LinkedInEducation),
-    experience: z.array(LinkedInExperience),
-    headline: z.string().nullish(),
-    location: LinkedInLocation,
-    openToWork: z.boolean().nullish(),
-    photo: z.string().url().nullish(),
-  }),
+  education: z.array(LinkedInEducation),
+  error: z.undefined(),
+  experience: z.array(LinkedInExperience),
+  headline: z.string().nullish(),
+  location: LinkedInLocation,
+  openToWork: z.boolean().nullish(),
+  photo: z.string().url().nullish(),
   originalQuery: z.object({ url: z.string() }),
 });
 
 const LinkedInFailure = z.object({
-  element: z.null(),
+  error: z.array(z.any()),
   originalQuery: z.object({ url: z.string() }),
 });
 
@@ -345,11 +344,11 @@ const LinkedInResult = z.union([LinkedInProfile, LinkedInFailure]);
 // Types
 
 type LinkedInEducation = NonNullable<
-  z.infer<typeof LinkedInProfile>['element']['education'][number]
+  z.infer<typeof LinkedInProfile>['education'][number]
 >;
 
 type LinkedInExperience = NonNullable<
-  z.infer<typeof LinkedInProfile>['element']['experience'][number]
+  z.infer<typeof LinkedInProfile>['experience'][number]
 >;
 
 type LinkedInProfile = z.infer<typeof LinkedInProfile>;
@@ -430,7 +429,7 @@ export async function syncLinkedInProfiles(
 
         // This is the case where there are multiple members with the same
         // LinkedIn URL, something that should be fixed.
-        if (!profile.element || !member) {
+        if (profile.error || !member) {
           await finishSync(memberId);
 
           console.log(`Profile not found for ${memberId}, moving on.`);
@@ -714,6 +713,8 @@ async function scrapeProfiles(profilesToScrape: string[]) {
     body: { urls: profilesToScrape },
   });
 
+  // console.log(apifyResult);
+
   // We just need the bare minimum in order to cache the profiles, we're not
   // trying to parse the entire profile here. This ensures that we're not
   // too restrictive and forcing ourselves to re-scrape profiles that we
@@ -746,7 +747,7 @@ async function scrapeProfiles(profilesToScrape: string[]) {
   await db.transaction().execute(async (trx) => {
     await Promise.all(
       newResults.map(async (result) => {
-        if (result.element) {
+        if (!result.error) {
           return successfulResults.push(result);
         }
 
@@ -803,7 +804,7 @@ async function processProfile({
         }
       });
 
-      const checkEducationPromises = profile.element.education.map(
+      const checkEducationPromises = profile.education.map(
         async (education) => {
           if (!education) {
             return;
@@ -826,7 +827,7 @@ async function processProfile({
         }
       );
 
-      const checkExperiencesPromises = profile.element.experience.map(
+      const checkExperiencesPromises = profile.experience.map(
         async (experience) => {
           if (!experience) {
             return;
@@ -896,7 +897,7 @@ type CheckMemberInput = {
 
 async function checkMember({ member, profile, trx }: CheckMemberInput) {
   const updatedLocation = await run(async () => {
-    const locationFromLinkedIn = profile.element.location.parsed?.text;
+    const locationFromLinkedIn = profile.location.parsed?.text;
 
     if (!locationFromLinkedIn) {
       return null;
@@ -914,10 +915,10 @@ async function checkMember({ member, profile, trx }: CheckMemberInput) {
     return getMostRelevantLocation(locationFromLinkedIn, 'geocode');
   });
 
-  if (!!profile.element.photo && !profile.element.openToWork) {
+  if (!!profile.photo && !profile.openToWork) {
     await uploadProfilePicture({
       memberId: member.id,
-      pictureUrl: profile.element.photo,
+      pictureUrl: profile.photo,
     });
   }
 
@@ -925,7 +926,7 @@ async function checkMember({ member, profile, trx }: CheckMemberInput) {
     .updateTable('students')
     .set({
       ...(!member.headline && {
-        headline: profile.element.headline,
+        headline: profile.headline,
       }),
       ...(!!updatedLocation && {
         currentLocation: updatedLocation.formattedAddress,
@@ -1265,6 +1266,7 @@ async function createWorkExperience({
   memberId,
   trx,
 }: CreateWorkExperienceInput) {
+  // console.log(linkedInExperience);
   const [companyId, location] = await Promise.all([
     saveCompanyIfNecessary(trx, linkedInExperience.companyId),
     getMostRelevantLocation(linkedInExperience.location, 'geocode'),
@@ -1309,6 +1311,7 @@ async function updateWorkExperience({
   linkedInExperience,
   trx,
 }: UpdateWorkExperienceInput) {
+  // console.log(existingExperience, linkedInExperience);
   const set: Updateable<DB['workExperiences']> = {};
 
   if (existingExperience.linkedinId !== linkedInExperience.companyId) {

--- a/packages/core/src/modules/linkedin.ts
+++ b/packages/core/src/modules/linkedin.ts
@@ -1264,7 +1264,6 @@ async function createWorkExperience({
   memberId,
   trx,
 }: CreateWorkExperienceInput) {
-  // console.log(linkedInExperience);
   const [companyId, location] = await Promise.all([
     saveCompanyIfNecessary(trx, linkedInExperience.companyId),
     getMostRelevantLocation(linkedInExperience.location, 'geocode'),
@@ -1309,7 +1308,6 @@ async function updateWorkExperience({
   linkedInExperience,
   trx,
 }: UpdateWorkExperienceInput) {
-  // console.log(existingExperience, linkedInExperience);
   const set: Updateable<DB['workExperiences']> = {};
 
   if (existingExperience.linkedinId !== linkedInExperience.companyId) {


### PR DESCRIPTION
## Description ✏️

This PR fixes an issue with the LinkedIn sync that is due to schema changes that happened with the Apify actor. Not sure why they changed it or if we can pin it somehow but this is a quick fix.

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns LinkedIn sync with Apify’s updated response shape and fixes company scraping input.
> 
> - Updates `LinkedInProfile`/`LinkedInFailure` schemas: remove `element` nesting; add top-level `education`/`experience`/`photo`/`headline`/`location`; `Failure` now includes `error` array
> - Adjusts sync logic to treat results without `error` as success and to read fields from the new top-level paths (education, experience, location, headline, photo)
> - Replaces checks like `!profile.element` with `profile.error` and updates all downstream uses (`processProfile`, `checkMember`, etc.)
> - Changes company scraping to pass full LinkedIn company URL in `runActor` body (`companies: ["https://www.linkedin.com/company/${id}"]`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96944411679ef0a3ac90bd68e188c66cda120c89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->