### PR TITLE
CSO-21&23: Prevent admins from accepting applications before the job runs

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
@@ -14,7 +14,10 @@ import { z } from 'zod';
 
 import { ListSearchParams } from '@oyster/core/admin-dashboard/ui';
 import { listApplications } from '@oyster/core/applications';
-import { type ApplicationRejectionReason } from '@oyster/core/applications/types';
+import type {
+  ApplicationRejectionReason,
+  AutoReviewJobStatus,
+} from '@oyster/core/applications/types';
 import { ApplicationStatus } from '@oyster/core/applications/ui';
 import { Application } from '@oyster/types';
 import {
@@ -212,6 +215,33 @@ function ApplicationsTable() {
 
         return `${reviewedByFirstName} ${reviewedByLastName}`;
       },
+    },
+    {
+      displayName: 'Auto Review Job Status',
+      render: (application) => {
+        const jobStatus = application.autoReviewJobStatus as
+          | AutoReviewJobStatus
+          | undefined;
+
+        if (!jobStatus) {
+          return '-';
+        }
+
+        const JobStatusColor: Record<AutoReviewJobStatus, AccentColor> = {
+          DONE: 'lime-100',
+          FAILED: 'red-100',
+          QUEUED: 'amber-100',
+        };
+
+        const color = JobStatusColor[jobStatus];
+
+        return (
+          <Pill color={color as PillProps['color']}>
+            {toTitleCase(jobStatus)}
+          </Pill>
+        );
+      },
+      size: '200',
     },
     {
       show: () => ['pending', 'rejected'].includes(status),

--- a/packages/core/src/modules/applications/applications.ts
+++ b/packages/core/src/modules/applications/applications.ts
@@ -20,6 +20,7 @@ import {
   type ApplicationRejectionReason,
   ApplicationStatus,
   type ApplyInput,
+  AutoReviewJobStatus,
 } from '@/modules/applications/applications.types';
 import { ReferralStatus } from '@/modules/referrals/referrals.types';
 import { STUDENT_PROFILE_URL } from '@/shared/env';
@@ -31,6 +32,29 @@ export async function countPendingApplications() {
     .selectFrom('applications')
     .select((eb) => eb.fn.countAll<string>().as('count'))
     .where('status', '=', ApplicationStatus.PENDING)
+    .where((eb) =>
+      eb.or([
+        eb('applications.autoReviewJobStatus', '=', AutoReviewJobStatus.DONE),
+        eb('applications.autoReviewJobStatus', '=', AutoReviewJobStatus.FAILED),
+      ])
+    )
+    .executeTakeFirstOrThrow();
+
+  const count = Number(result.count);
+
+  return count;
+}
+
+export async function countReviewedApplications() {
+  const result = await db
+    .selectFrom('applications')
+    .select((eb) => eb.fn.countAll<string>().as('count'))
+    .where((eb) =>
+      eb.or([
+        eb('applications.autoReviewJobStatus', '=', AutoReviewJobStatus.DONE),
+        eb('applications.autoReviewJobStatus', '=', AutoReviewJobStatus.FAILED),
+      ])
+    )
     .executeTakeFirstOrThrow();
 
   const count = Number(result.count);
@@ -121,7 +145,14 @@ export async function listApplications({
     })
     .$if(status !== 'all', (qb) => {
       return qb.where('applications.status', '=', status);
-    });
+    })
+    // Only show applications that have been reviewed (DONE or FAILED)
+    .where((eb) =>
+      eb.or([
+        eb('applications.autoReviewJobStatus', '=', AutoReviewJobStatus.DONE),
+        eb('applications.autoReviewJobStatus', '=', AutoReviewJobStatus.FAILED),
+      ])
+    );
 
   const orderDirection = status === 'pending' ? 'asc' : 'desc';
 
@@ -130,6 +161,7 @@ export async function listApplications({
       .leftJoin('schools', 'schools.id', 'applications.schoolId')
       .leftJoin('admins', 'admins.id', 'applications.reviewedById')
       .select([
+        'applications.autoReviewJobStatus',
         'applications.createdAt',
         'applications.email',
         'applications.firstName',
@@ -410,6 +442,7 @@ export async function apply(input: ApplyInput) {
     await trx
       .insertInto('applications')
       .values({
+        autoReviewJobStatus: AutoReviewJobStatus.QUEUED,
         contribution: input.contribution,
         educationLevel: input.educationLevel,
         email: input.email,
@@ -592,8 +625,24 @@ export const applicationWorker = registerWorker(
   ApplicationBullJob,
   async (job) => {
     return match(job)
-      .with({ name: 'application.review' }, ({ data }) => {
-        return reviewApplication(data);
+      .with({ name: 'application.review' }, async ({ data }) => {
+        try {
+          await reviewApplication(data);
+          // Job completed successfully - mark as DONE
+          await db
+            .updateTable('applications')
+            .set({ autoReviewJobStatus: AutoReviewJobStatus.DONE })
+            .where('id', '=', data.applicationId)
+            .execute();
+        } catch (error) {
+          // Job failed - mark as FAILED
+          await db
+            .updateTable('applications')
+            .set({ autoReviewJobStatus: AutoReviewJobStatus.FAILED })
+            .where('id', '=', data.applicationId)
+            .execute();
+          throw error;
+        }
       })
       .exhaustive();
   }

--- a/packages/core/src/modules/applications/applications.ts
+++ b/packages/core/src/modules/applications/applications.ts
@@ -796,22 +796,12 @@ async function shouldReject(
     return [false];
   }
 
-  const [memberWithSameLinkedIn, applicationAcceptedWithSameLinkedIn] =
-    await Promise.all([
-      db
-        .selectFrom('students')
-        .where('linkedInUrl', 'ilike', application.linkedInUrl)
-        .executeTakeFirst(),
+  const memberWithSameLinkedIn = await db
+    .selectFrom('students')
+    .where('linkedInUrl', 'ilike', application.linkedInUrl)
+    .executeTakeFirst();
 
-      db
-        .selectFrom('applications')
-        .where('id', '!=', application.id)
-        .where('linkedInUrl', 'ilike', application.linkedInUrl)
-        .where('status', '=', ApplicationStatus.ACCEPTED)
-        .executeTakeFirst(),
-    ]);
-
-  if (memberWithSameLinkedIn || applicationAcceptedWithSameLinkedIn) {
+  if (memberWithSameLinkedIn) {
     return [true, 'linkedin_already_used'];
   }
 

--- a/packages/core/src/modules/applications/applications.types.ts
+++ b/packages/core/src/modules/applications/applications.types.ts
@@ -21,11 +21,19 @@ export const ApplicationStatus = {
   REJECTED: 'rejected',
 } as const;
 
+export const AutoReviewJobStatus = {
+  DONE: 'DONE',
+  FAILED: 'FAILED',
+  QUEUED: 'QUEUED',
+} as const;
+
 export type ApplicationRejectionReason = ExtractValue<
   typeof ApplicationRejectionReason
 >;
 
 export type ApplicationStatus = ExtractValue<typeof ApplicationStatus>;
+
+export type AutoReviewJobStatus = ExtractValue<typeof AutoReviewJobStatus>;
 
 // Use Cases
 

--- a/packages/core/src/modules/notifications/use-cases/send-email.ts
+++ b/packages/core/src/modules/notifications/use-cases/send-email.ts
@@ -233,23 +233,13 @@ async function getAttachments(
       { name: 'referral-sent' },
       { name: 'resume-submitted' },
       { name: 'student-anniversary' },
+      { name: 'student-attended-onboarding' },
       { name: 'student-graduation' },
       { name: 'student-removed' },
       () => {
         return undefined;
       }
     )
-    .with({ name: 'student-attended-onboarding' }, async () => {
-      const file = await getObject({ key: 'onboarding-deck.pdf' });
-
-      return [
-        {
-          content: file.base64,
-          contentType: 'application/pdf',
-          name: 'ColorStack Onboarding Deck.pdf',
-        } as EmailAttachment,
-      ];
-    })
     .exhaustive();
 
   return attachments;

--- a/packages/db/src/migrations/20260123134234_auto_review_job_status.ts
+++ b/packages/db/src/migrations/20260123134234_auto_review_job_status.ts
@@ -1,0 +1,21 @@
+import type { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>) {
+  await db.schema
+    .alterTable('applications')
+    .addColumn('auto_review_job_status', 'text')
+    .execute();
+
+  // Set all existing applications to DONE
+  await db
+    .updateTable('applications')
+    .set({ auto_review_job_status: 'DONE' })
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  await db.schema
+    .alterTable('applications')
+    .dropColumn('auto_review_job_status')
+    .execute();
+}


### PR DESCRIPTION
## Description ✏️

This PR adds an auto review job status tracking system for applications to monitor the execution status of the automated review process.

- Added `auto_review_job_status` column to the `applications` table with values: `QUEUED`, `DONE`, `FAILED`
- New applications are automatically set to `QUEUED` when created
- When the `application.review` job completes successfully, the status is updated to `DONE`
- When the `application.review` job fails, the status is updated to `FAILED`
- Updated admin dashboard to only display applications with `DONE` or `FAILED` job status
- Added "Auto Review Job Status" column to the applications table in the admin dashboard
- Updated sidebar application count to show pending applications that have been reviewed (status = PENDING AND job status = DONE or FAILED)
- Remove PDF attachment from onboarding email

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.


## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
