### PR TITLE
fix-updates Anthropic model from retired snapshot to claude-sonnet-4-6 ☝🏾

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -97,3 +97,4 @@
 - Praise-creator
 - AdamOwolabi
 - Isaiah648
+- jnanda97

--- a/packages/core/src/infrastructure/ai.ts
+++ b/packages/core/src/infrastructure/ai.ts
@@ -151,9 +151,9 @@ type GetChatCompletionInput = {
   /**
    * The model to use for the completion.
    *
-   * @default 'claude-sonnet-4-20250514'
+   * @default 'claude-sonnet-4-6'
    */
-  model?: 'claude-sonnet-4-20250514';
+  model?: 'claude-sonnet-4-6';
 
   /**
    * The system prompt to use for the completion. This can be used to provide
@@ -190,7 +190,7 @@ const AnthropicResponse = z.object({
 export async function getChatCompletion({
   maxTokens,
   messages,
-  model = 'claude-sonnet-4-20250514',
+  model = 'claude-sonnet-4-6',
   system: _system,
   temperature = 0.5,
 }: GetChatCompletionInput): Promise<Result<string>> {


### PR DESCRIPTION
## Description ✏️
  getChatCompletion in packages/core/src/infrastructure/ai.ts was hardcoding claude-sonnet-4-5-20250514, a
   dated model snapshot that Anthropic retired on June 15, 2026. This was causing the resume review tool to fail.

  Because the error handling handles only special cases 429 (rate limit) and 529 (overloaded), the failure fell
  into the generic branch and surfaced as "failed to fetch chat completion" — making it look like a random
  outage rather than a retired model.
   
Closes this [issue](https://github.com/colorstackorg/oyster/issues/891) that first identified this bug.

Describe what this PR does.
 - This PR swaps the model string to claude-sonnet-4-6 (Anthropic's recommended successor) in three spots: the
  JSDoc default, the TypeScript type, and the default parameter.


## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
