### PR TITLE
CSO-25: Update Sponsor Selector logic to display companies without work …

### DIFF
--- a/apps/admin-dashboard/app/routes/api.companies.search.tsx
+++ b/apps/admin-dashboard/app/routes/api.companies.search.tsx
@@ -13,9 +13,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const search = url.searchParams.get('search') || '';
 
   const { companies } = await listCompanies({
+    includeCompaniesWithoutEmployeesOrOpportunities: true,
     orderBy: 'most_employees',
     pagination: {
-      limit: 100,
+      limit: 50,
       page: 1,
     },
     select: ['companies.id', 'companies.name'],

--- a/packages/core/src/modules/employment/queries/list-companies.ts
+++ b/packages/core/src/modules/employment/queries/list-companies.ts
@@ -10,6 +10,7 @@ import {
 import { type PaginationSearchParams } from '@/shared/types';
 
 type ListCompaniesOptions<Selection> = {
+  includeCompaniesWithoutEmployeesOrOpportunities?: boolean;
   orderBy: ListCompaniesOrderBy;
   pagination: PaginationSearchParams;
   select: Selection[];
@@ -18,7 +19,13 @@ type ListCompaniesOptions<Selection> = {
 
 export async function listCompanies<
   Selection extends SelectExpression<DB, 'companies'>,
->({ orderBy, pagination, select, where }: ListCompaniesOptions<Selection>) {
+>({
+  includeCompaniesWithoutEmployeesOrOpportunities = false,
+  orderBy,
+  pagination,
+  select,
+  where,
+}: ListCompaniesOptions<Selection>) {
   const query = db
     .selectFrom('companies')
     .leftJoin('opportunities', (join) => {
@@ -33,13 +40,15 @@ export async function listCompanies<
       'workExperiences.id'
     )
     .where('workExperiences.deletedAt', 'is', null)
-    .where((eb) => {
-      // We only want to return companies that have at least one employee (past
-      // or present) or opportunity.
-      return eb.or([
-        eb('opportunities.companyId', 'is not', null),
-        eb('workExperiences.companyId', 'is not', null),
-      ]);
+    .$if(!includeCompaniesWithoutEmployeesOrOpportunities, (qb) => {
+      // We only want to return companies that have at least one employee
+      // (past or present) or opportunity.
+      return qb.where((eb) => {
+        return eb.or([
+          eb('opportunities.companyId', 'is not', null),
+          eb('workExperiences.companyId', 'is not', null),
+        ]);
+      });
     })
     .$if(!!where.search, (qb) => {
       const { search } = where;


### PR DESCRIPTION
## Description ✏️

Closes #xxx

Update the Sponsor Selector logic to allow companies to appear even when they do not have any associated work experience records.

Currently, companies are only displayed if they have either:
- An active opportunity, or
- A non-deleted work experience record associated with them.

This causes companies that exist in the database but do not have qualifying associated records to be excluded from the Sponsor Selector. For example, **Sentry** exists in the database but was not displayed because it had no associated work experience records.

The client confirmed that **Sentry** and **eSentry** are separate companies and requested that the Sponsor Selector logic be updated so valid companies can appear regardless of whether they have work experience records.

## Type of Change 🐞

- [x] Fix - A non-breaking change which fixes a bug.
- [ ] Feature - A non-breaking change which adds functionality.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).

## Acceptance Criteria

- Companies should appear in the Sponsor Selector even if they do not have associated work experience records.
