### PR TITLE
fix: Redis / Slack Worker Concurrency (Application Queue & Slack-to-O…

### DIFF
--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -8,3 +8,27 @@ Sentry.init({
   environment: ENV.ENVIRONMENT,
   tracesSampleRate: 0.25,
 });
+
+// This process runs both the HTTP server and every Bull worker, and neither of
+// these used to be reported at all -- errors from background work just vanished,
+// which is how the workers were able to stop consuming for weeks while the API
+// kept looking perfectly healthy.
+
+// Report but don't exit. There are deliberate fire-and-forget promises in the
+// codebase, and a rejected analytics call shouldn't take the API down. The case
+// we actually care about -- a worker's run loop dying -- is handled explicitly
+// in `startBullWorkers`, which does exit.
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled rejection!', reason);
+
+  Sentry.captureException(reason);
+});
+
+// An uncaught exception leaves the process in genuinely unknown state, so here
+// we do bail and let the platform restart us.
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught exception! Exiting...', error);
+
+  Sentry.captureException(error);
+  Sentry.flush(2000).finally(() => process.exit(1));
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -96,7 +96,7 @@ function startBullWorkers(): void {
 
   for (const worker of workers) {
     worker.run().catch((e) => {
-      console.error(`The "${worker.name}" worker died! Exiting...`, e);
+      console.error(`The "${worker.name}" worker died!`, e);
 
       Sentry.captureException(e, { tags: { queue: worker.name } });
     });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -99,7 +99,6 @@ function startBullWorkers(): void {
       console.error(`The "${worker.name}" worker died! Exiting...`, e);
 
       Sentry.captureException(e, { tags: { queue: worker.name } });
-      Sentry.flush(2000).finally(() => process.exit(1));
     });
   }
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -66,23 +66,42 @@ async function bootstrap() {
  *
  * Each worker is responsible for processing jobs in its respective queue,
  * allowing for distributed and asynchronous task execution.
+ *
+ * `run()` returns a promise that rejects if the worker's run loop dies. We
+ * deliberately crash the process instead of swallowing that, because a worker
+ * that quietly stops consuming looks completely healthy from the outside -- the
+ * HTTP server keeps serving and keeps enqueueing, while its queue grows without
+ * bound. Better to fail loudly and let the platform restart us.
  */
 function startBullWorkers(): void {
-  airtableWorker.run();
-  applicationWorker.run();
-  eventWorker.run();
-  feedWorker.run();
-  gamificationWorker.run();
-  mailchimpWorker.run();
-  memberWorker.run();
-  memberEmailWorker.run();
-  notificationWorker.run();
-  offerWorker.run();
-  onboardingSessionWorker.run();
-  oneTimeCodeWorker.run();
-  opportunityWorker.run();
-  peerHelpWorker.run();
-  profileWorker.run();
-  resumeReviewWorker.run();
-  slackWorker.run();
+  const workers = [
+    airtableWorker,
+    applicationWorker,
+    eventWorker,
+    feedWorker,
+    gamificationWorker,
+    mailchimpWorker,
+    memberWorker,
+    memberEmailWorker,
+    notificationWorker,
+    offerWorker,
+    onboardingSessionWorker,
+    oneTimeCodeWorker,
+    opportunityWorker,
+    peerHelpWorker,
+    profileWorker,
+    resumeReviewWorker,
+    slackWorker,
+  ];
+
+  for (const worker of workers) {
+    worker.run().catch((e) => {
+      console.error(`The "${worker.name}" worker died! Exiting...`, e);
+
+      Sentry.captureException(e, { tags: { queue: worker.name } });
+      Sentry.flush(2000).finally(() => process.exit(1));
+    });
+  }
+
+  console.log(`Started ${workers.length} Bull workers! 🐂`);
 }

--- a/packages/core/src/infrastructure/bull.ts
+++ b/packages/core/src/infrastructure/bull.ts
@@ -22,6 +22,13 @@ const REDIS_URL = process.env.REDIS_URL as string;
 // will be created lazily.
 const _queues: Record<string, Queue> = {};
 
+/**
+ * The maximum amount of time (in ms) a single job may run before we consider it
+ * hung and fail it.
+ *
+ */
+const DEFAULT_JOB_TIMEOUT = 1000 * 60 * 10;
+
 // Core
 
 /**
@@ -125,23 +132,31 @@ export async function listQueueNames() {
  * @param name - The name of the queue to process.
  * @param schema - Zod schema for validating the job data.
  * @param processor - The function to process each job.
- * @param options - Optional configuration for the worker.
+ * @param options - Optional configuration for the worker. Supports an extra
+ *   `jobTimeout` (in ms) on top of the standard Bull worker options.
  * @returns A `Worker` instance.
  */
 export function registerWorker<Schema extends ZodType>(
   name: BullQueue,
   schema: Schema,
   processor: (job: z.infer<Schema>) => Promise<unknown>,
-  options: WorkerOptions = {}
+  { jobTimeout = DEFAULT_JOB_TIMEOUT, ...options }: RegisterWorkerOptions = {}
 ) {
   const redis = new Redis(REDIS_URL, {
     family: 0,
     maxRetriesPerRequest: null,
   });
 
-  options = {
+  const workerOptions: WorkerOptions = {
     autorun: false,
     connection: redis,
+
+    // Some jobs in these queues wait on LLM completions, which can easily run
+    // past Bull's 30s default and get reclaimed mid-flight by the stalled
+    // checker. Give them room to renew their lock before that happens.
+    lockDuration: 60 * 1000,
+    maxStalledCount: 2,
+
     removeOnComplete: { age: 60 * 60 * 24 * 1, count: 1000 },
     removeOnFail: { age: 60 * 60 * 24 * 30, count: 10000 },
     ...options,
@@ -161,9 +176,13 @@ export function registerWorker<Schema extends ZodType>(
 
       const job = result.data;
 
-      return processor(job);
+      return withTimeout(
+        processor(job),
+        jobTimeout,
+        `${input.name} (${input.id})`
+      );
     },
-    options
+    workerOptions
   );
 
   worker.on('failed', (job, error) => {
@@ -175,5 +194,53 @@ export function registerWorker<Schema extends ZodType>(
     });
   });
 
+  // A worker whose run loop dies takes its whole queue down with it, silently.
+  // Surface it instead of letting the process carry on half-alive.
+  worker.on('error', (error) => {
+    reportException(error, { queueName: name });
+  });
+
   return worker;
+}
+
+// Types
+
+type RegisterWorkerOptions = WorkerOptions & {
+  /**
+   * How long (in ms) a single job may run before it's failed as hung.
+   *
+   * @default DEFAULT_JOB_TIMEOUT
+   */
+  jobTimeout?: number;
+};
+
+// Utils
+
+/**
+ * Rejects if the given promise hasn't settled within `ms`.
+ *
+ * This can't cancel the underlying work -- a hung promise keeps running in the
+ * background. What it does do is release the worker's concurrency slot, so one
+ * stuck job can't take the entire queue down with it.
+ *
+ * @param promise - The promise to race against the timer.
+ * @param ms - How long to wait before rejecting.
+ * @param label - Human-readable job label, used in the error message.
+ */
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const timer = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`Job "${label}" timed out after ${ms}ms.`));
+    }, ms);
+  });
+
+  return Promise.race([promise, timer]).finally(() => {
+    clearTimeout(timeout);
+  }) as Promise<T>;
 }

--- a/packages/core/src/modules/slack/events/slack-reaction-added.ts
+++ b/packages/core/src/modules/slack/events/slack-reaction-added.ts
@@ -3,8 +3,8 @@ import { db } from '@oyster/db';
 import { job } from '@/infrastructure/bull';
 import { type GetBullJobData } from '@/infrastructure/bull.types';
 import { ErrorWithContext } from '@/shared/errors';
-import { retryWithBackoff } from '@/shared/utils/core';
 import { getSlackMessage } from '../services/slack-message.service';
+import { addSlackMessage } from '../use-cases/add-slack-message';
 
 export async function onSlackReactionAdded(
   data: GetBullJobData<'slack.reaction.added'>
@@ -43,55 +43,36 @@ export async function onSlackReactionAdded(
 async function ensureMessageExists(
   data: GetBullJobData<'slack.reaction.added'>
 ) {
-  let waiting = false;
+  const existingMessage = await db
+    .selectFrom('slackMessages')
+    .select(['id'])
+    .where('channelId', '=', data.channelId)
+    .where('id', '=', data.messageId)
+    .executeTakeFirst();
 
-  await retryWithBackoff(
-    async () => {
-      const existingMessage = await db
-        .selectFrom('slackMessages')
-        .select(['id'])
-        .where('channelId', '=', data.channelId)
-        .where('id', '=', data.messageId)
-        .executeTakeFirst();
+  if (existingMessage) {
+    return;
+  }
 
-      if (existingMessage) {
-        return existingMessage;
-      }
+  console.warn('No message found, querying the Slack API...');
 
-      if (waiting) {
-        return false;
-      }
+  const message = await getSlackMessage({
+    channelId: data.channelId,
+    messageId: data.messageId,
+  });
 
-      console.warn('No message found, querying the Slack API...');
+  if (!message) {
+    throw new ErrorWithContext('No message found via Slack API.').withContext({
+      channelId: data.channelId,
+      messageId: data.messageId,
+    });
+  }
 
-      const message = await getSlackMessage({
-        channelId: data.channelId,
-        messageId: data.messageId,
-      });
-
-      if (!message) {
-        throw new ErrorWithContext(
-          'No message found via Slack API.'
-        ).withContext({
-          channelId: data.channelId,
-          messageId: data.messageId,
-        });
-      }
-
-      job('slack.message.add', {
-        channelId: message.channelId,
-        createdAt: message.createdAt,
-        id: message.id,
-        studentId: message.studentId,
-        text: message.text,
-        threadId: message.threadId,
-        userId: message.userId,
-      });
-
-      waiting = true;
-
-      return false;
-    },
-    { maxRetries: 10, retryInterval: 5000 }
-  );
+  // Add the message inline rather than enqueueing `slack.message.add` and
+  // polling for it. That job would land at the back of the very queue this job
+  // is occupying, so it can't run until we return -- we'd burn the full retry
+  // window and fail, every time. Worse, the deeper the backlog the longer the
+  // wait, so falling behind made every reaction job slower and guaranteed the
+  // queue could never catch back up.
+  await addSlackMessage(message);
 }

--- a/packages/core/src/modules/slack/slack.worker.ts
+++ b/packages/core/src/modules/slack/slack.worker.ts
@@ -137,5 +137,6 @@ export const slackWorker = registerWorker(
         return result.data;
       })
       .exhaustive();
-  }
+  },
+  { concurrency: 5 }
 );

--- a/packages/core/src/modules/slack/use-cases/add-slack-message.ts
+++ b/packages/core/src/modules/slack/use-cases/add-slack-message.ts
@@ -3,9 +3,9 @@ import { db } from '@oyster/db';
 import { job } from '@/infrastructure/bull';
 import { type GetBullJobData } from '@/infrastructure/bull.types';
 import { redis } from '@/infrastructure/redis';
+import { reportException } from '@/infrastructure/sentry';
 import { slack } from '@/modules/slack/instances';
 import { ErrorWithContext } from '@/shared/errors';
-import { retryWithBackoff } from '@/shared/utils/core';
 import { getSlackMessage } from '../services/slack-message.service';
 
 // Environment Variables
@@ -55,11 +55,13 @@ export async function addSlackMessage(data: AddSlackMessageInput) {
     threadId: data.threadId || data.id,
   });
 
-  // We don't need to await this since it's not a critical path.
+  // We don't need to await this since it's not a critical path -- but it does
+  // hit the DB and the Slack API, so it has to catch its own rejections.
+  // Otherwise it escapes as an unhandled rejection, which is now fatal.
   notifyBusySlackThreadIfNecessary({
     channelId: data.channelId,
     threadId: data.threadId,
-  });
+  }).catch((e) => reportException(e));
 
   // We'll do some additional checks for top-level threads...
   if (!data.threadId) {
@@ -123,60 +125,36 @@ async function ensureThreadExistsIfNecessary(data: AddSlackMessageInput) {
     return;
   }
 
-  let waiting = false;
+  const existingThread = await db
+    .selectFrom('slackMessages')
+    .where('id', '=', data.threadId)
+    .where('channelId', '=', data.channelId)
+    .executeTakeFirst();
 
-  await retryWithBackoff(
-    async () => {
-      const existingThread = await db
-        .selectFrom('slackMessages')
-        .where('id', '=', data.threadId!)
-        .where('channelId', '=', data.channelId)
-        .executeTakeFirst();
+  if (existingThread) {
+    return;
+  }
 
-      if (existingThread) {
-        return existingThread;
-      }
+  console.warn('No thread found, querying the Slack API...');
 
-      if (waiting) {
-        return false;
-      }
+  const slackThread = await getSlackMessage({
+    channelId: data.channelId,
+    messageId: data.threadId,
+  });
 
-      console.warn('No thread found, querying the Slack API...');
+  if (!slackThread) {
+    throw new ErrorWithContext('No thread found via Slack API.').withContext({
+      channelId: data.channelId,
+      messageId: data.id,
+      threadId: data.threadId,
+    });
+  }
 
-      const slackThread = await getSlackMessage({
-        channelId: data.channelId,
-        messageId: data.threadId!,
-      });
-
-      if (!slackThread) {
-        throw new ErrorWithContext(
-          'No thread found via Slack API.'
-        ).withContext({
-          channelId: data.channelId,
-          messageId: data.id,
-          threadId: data.threadId,
-        });
-      }
-
-      job('slack.message.add', {
-        channelId: slackThread.channelId,
-        createdAt: slackThread.createdAt,
-        id: slackThread.id,
-        studentId: slackThread.studentId,
-        text: slackThread.text,
-        threadId: slackThread.threadId,
-        userId: slackThread.userId,
-      });
-
-      waiting = true;
-
-      return false;
-    },
-    {
-      maxRetries: 10,
-      retryInterval: 5000,
-    }
-  );
+  // Add the parent inline rather than enqueueing `slack.message.add` and
+  // polling for it -- that job would land behind us in the same queue and
+  // couldn't run until we return. This terminates because Slack's `thread_ts`
+  // always points at the thread root, and a root has no `threadId` of its own.
+  await addSlackMessage(slackThread);
 }
 
 /**


### PR DESCRIPTION
## Description ✏️

Closes #xxx

Our Bull workers stopped consuming jobs in early July and nothing told us. By 2026-07-30 there were **~83,000 jobs stuck in `waiting` across 9 queues**, including 22 days of unprocessed `one_time_code` jobs (login codes) and 19 days of `notification` jobs.

This PR fixes the reasons a stalled worker could go unnoticed and unrecovered. 



## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).


