### PR TITLE
Fix/client bundle server leak

### DIFF
--- a/packages/core/src/modules/employment/employment.types.ts
+++ b/packages/core/src/modules/employment/employment.types.ts
@@ -10,7 +10,7 @@ import {
   Student,
 } from '@oyster/types';
 
-import { parseLinkedInCompanySlug } from '@/modules/employment/use-cases/fetch-company-from-linkedin';
+import { parseLinkedInCompanySlug } from '@/modules/employment/employment.utils';
 import { ListSearchParams } from '@/shared/types';
 
 // Enums

--- a/packages/core/src/modules/employment/employment.utils.ts
+++ b/packages/core/src/modules/employment/employment.utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalizes user input into a LinkedIn company slug.
+ *
+ * Accepts either a full LinkedIn company URL or a bare slug, so forms can be
+ * lenient about what they accept.
+ *
+ * This lives apart from the use cases that fetch from LinkedIn because it is
+ * also needed by `employment.types.ts`, which is bundled for the browser. Any
+ * import of a use case from there pulls Redis and the Sentry Node SDK into the
+ * client build.
+ *
+ * @example parseLinkedInCompanySlug('https://www.linkedin.com/company/google') // 'google'
+ * @example parseLinkedInCompanySlug('@google') // 'google'
+ */
+export function parseLinkedInCompanySlug(input: string) {
+  const trimmed = input.trim();
+
+  const match = trimmed.match(/linkedin\.com\/company\/([^/?#]+)/i);
+
+  if (match?.[1]) {
+    return match[1];
+  }
+
+  return trimmed.replace(/^@/, '');
+}

--- a/packages/core/src/modules/employment/use-cases/fetch-company-from-linkedin.ts
+++ b/packages/core/src/modules/employment/use-cases/fetch-company-from-linkedin.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { withCache } from '@/infrastructure/redis';
 import { runActor } from '@/modules/apify';
+import { parseLinkedInCompanySlug } from '@/modules/employment/employment.utils';
 import { ColorStackError } from '@/shared/errors';
 
 const LinkedInLogo = z.object({
@@ -41,18 +42,6 @@ function getBestLogoUrl(logos: z.infer<typeof LinkedInLogo>[] | undefined) {
   return logos.reduce((best, current) => {
     return (current.width ?? 0) > (best.width ?? 0) ? current : best;
   }).url;
-}
-
-export function parseLinkedInCompanySlug(input: string) {
-  const trimmed = input.trim();
-
-  const match = trimmed.match(/linkedin\.com\/company\/([^/?#]+)/i);
-
-  if (match?.[1]) {
-    return match[1];
-  }
-
-  return trimmed.replace(/^@/, '');
 }
 
 export async function fetchCompanyFromLinkedIn(

--- a/packages/core/src/modules/employment/use-cases/fetch-company-from-linkedin.ts
+++ b/packages/core/src/modules/employment/use-cases/fetch-company-from-linkedin.ts
@@ -4,16 +4,44 @@ import { withCache } from '@/infrastructure/redis';
 import { runActor } from '@/modules/apify';
 import { ColorStackError } from '@/shared/errors';
 
-const LinkedInCompany = z.object({
+const LinkedInLogo = z.object({
+  height: z.number().optional(),
+  url: z.string().url(),
+  width: z.number().optional(),
+});
+
+const LinkedInCompanyResponse = z.object({
   description: z.string().nullish(),
   id: z.string(),
   logo: z.string().url().optional(),
+  logos: LinkedInLogo.array().optional(),
   name: z.string(),
   universalName: z.string(),
   website: z.string().url().nullish(),
 });
 
+const LinkedInCompany = LinkedInCompanyResponse.transform((company) => {
+  return {
+    description: company.description,
+    id: company.id,
+    logo: company.logo ?? getBestLogoUrl(company.logos),
+    name: company.name,
+    universalName: company.universalName,
+    website: company.website,
+  };
+});
+
 export type LinkedInCompany = z.infer<typeof LinkedInCompany>;
+
+function getBestLogoUrl(logos: z.infer<typeof LinkedInLogo>[] | undefined) {
+  if (!logos?.length) {
+    return undefined;
+  }
+
+  return logos.reduce((best, current) => {
+    return (current.width ?? 0) > (best.width ?? 0) ? current : best;
+  }).url;
+}
 
 export function parseLinkedInCompanySlug(input: string) {
   const trimmed = input.trim();


### PR DESCRIPTION
## Description ✏️

Adds admin company management tooling and fixes two LinkedIn-related issues discovered during testing.
- Move `parseLinkedInCompanySlug` into `employment.utils.ts` so `employment.types.ts` no longer imports server-only use cases (prevents Redis/Sentry Node SDK from leaking into the client bundle)
- Fall back to the largest logo in Apify's `logos` array when the top-level `logo` field is missing


## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).


